### PR TITLE
LIBHYDRA-53. Display related and member objects' titles as links.

### DIFF
--- a/app/assets/stylesheets/blacklight.scss
+++ b/app/assets/stylesheets/blacklight.scss
@@ -3,3 +3,9 @@
 @import 'bootstrap';
 
 @import 'blacklight/blacklight';
+
+.multivalued-field-value {
+    list-style-type: none;
+    padding-left: 0;
+    margin: 0;
+}

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -108,14 +108,14 @@ class CatalogController < ApplicationController
     config.add_show_field 'display_title', label: 'Title'
     config.add_show_field 'author', label: 'Author'
     config.add_show_field 'type', label: 'Type'
-    config.add_show_field 'rdf_type', label: 'RDF Type'
+    config.add_show_field 'rdf_type', label: 'RDF Type', helper_method: :rdf_type_list
     config.add_show_field 'id', label: 'Fedora URL'
     config.add_show_field 'date', label: 'Date'
-    config.add_show_field 'pcdm_collection', label: 'Collection'
-    config.add_show_field 'pcdm_member_of', label: 'Member Of'
-    config.add_show_field 'pcdm_members', label: 'Members'
-    config.add_show_field 'pcdm_related_object_of', label: 'Related To'
-    config.add_show_field 'pcdm_related_objects', label: 'Related Objects'
+    config.add_show_field 'pcdm_collection', label: 'Collection', helper_method: :collection_from_subquery
+    config.add_show_field 'pcdm_member_of', label: 'Member Of', helper_method: :parent_from_subquery
+    config.add_show_field 'pcdm_members', label: 'Members', helper_method: :members_from_subquery
+    config.add_show_field 'pcdm_related_object_of', label: 'Related To', helper_method: :related_object_of_from_subquery
+    config.add_show_field 'pcdm_related_objects', label: 'Related Objects', helper_method: :related_objects_from_subquery
     config.add_show_field 'pcdm_file_of', label: 'File Of'
     config.add_show_field 'pcdm_files', label: 'Files'
     config.add_show_field 'object_type', label: 'Object Type'

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -27,4 +27,32 @@ module ApplicationHelper
   def iiif_base_url()
     return IIIF_MANIFEST_PREFIX
   end
+
+  def from_subquery(subquery_field, args)
+    args[:document][args[:field]] = args[:document][subquery_field]['docs']
+  end
+
+  def collection_from_subquery(args)
+    from_subquery 'pcdm_collection_info', args
+  end
+
+  def parent_from_subquery(args)
+    from_subquery 'pcdm_member_of_info', args
+  end
+
+  def members_from_subquery(args)
+    from_subquery 'pcdm_members_info', args
+  end
+
+  def related_objects_from_subquery(args)
+    from_subquery 'pcdm_related_objects_info', args
+  end
+
+  def related_object_of_from_subquery(args)
+    from_subquery 'pcdm_related_object_of_info', args
+  end
+
+  def rdf_type_list(args)
+    args[:document][args[:field]]
+  end
 end

--- a/app/views/catalog/_show_default.html.erb
+++ b/app/views/catalog/_show_default.html.erb
@@ -3,9 +3,27 @@
 <dl class="dl-horizontal  dl-invert">
   <% document_show_fields(document).each do |field_name, field| -%>
     <% if should_render_show_field? document, field %>
-      <dt class="blacklight-<%= field_name.parameterize %>"><%= render_document_show_field_label document, field: field_name %></dt>
+      <dt class="blacklight-<%= field_name.parameterize %>">
+      <%= render_document_show_field_label document, field: field_name %>
+      </dt>
       <% if field_name=='id' %>
         <dd class="blacklight-<%= field_name.parameterize %>"><%= link_to doc_presenter.field_value(field_name), doc_presenter.field_value(field_name), target: "_blank" %></dd>
+      <% elsif ['pcdm_members', 'pcdm_related_objects', 'pcdm_related_object_of', 'pcdm_member_of', 'pcdm_collection'].include?(field_name) %>
+        <dd class="blacklight-<%= field_name.parameterize %>">
+          <ul class="multivalued-field-value">
+            <% doc_presenter.field_value(field_name).each do |v| %>
+              <li><%= link_to v['title'][0], solr_document_path(v['id']) %></li>
+            <% end %>
+          </ul>
+        </dd>
+      <% elsif field_name == 'rdf_type' %>
+        <dd class="blacklight-<%= field_name.parameterize %>">
+          <ul class="multivalued-field-value">
+            <% doc_presenter.field_value(field_name).each do |v| %>
+              <li><%= v %></li>
+            <% end %>
+          </ul>
+        </dd>
       <% else %>
         <dd class="blacklight-<%= field_name.parameterize %>"><%= doc_presenter.field_value field_name %></dd>
       <% end %>


### PR DESCRIPTION
Instead of displaying the fcrepo URIs for related and member objects, display the titles of those objects and link to their catalog page in Archelon.

https://issues.umd.edu/browse/LIBHYDRA-53