### PR TITLE
LIBHYDRA-65. Prepend "fcrepo:" to the PCDM manifest path.

### DIFF
--- a/app/views/mirador/_show.html.erb
+++ b/app/views/mirador/_show.html.erb
@@ -22,7 +22,7 @@
   <div style="width: 600px; height: 400px; position: relative;">
     <%= javascript_tag do %>
       window.iiifURLPrefix = '<%= iiif_base_url %>';
-      window.manifestPcdmID = '<%= encoded_id(document) %>';
+      window.manifestPcdmID = 'fcrepo:<%= encoded_id(document) %>';
     <% end %>
     <div id="mirador-viewer">
       <div id="placeholder">Loading Mirador Viewer...</div>


### PR DESCRIPTION
See also https://issues.umd.edu/browse/LIBFCREPO-174 for the update in pcdm-manifests to accept a prefixed identifier.

https://issues.umd.edu/browse/LIBHYDRA-65