### PR TITLE
LIBHYDRA-64. Added "View in Fedora" link to sidebar.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -109,7 +109,6 @@ class CatalogController < ApplicationController
     config.add_show_field 'author', label: 'Author'
     config.add_show_field 'type', label: 'Type'
     config.add_show_field 'rdf_type', label: 'RDF Type', helper_method: :rdf_type_list
-    config.add_show_field 'id', label: 'Fedora URL'
     config.add_show_field 'date', label: 'Date'
     config.add_show_field 'pcdm_collection', label: 'Collection', helper_method: :collection_from_subquery
     config.add_show_field 'pcdm_member_of', label: 'Member Of', helper_method: :parent_from_subquery

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -20,8 +20,7 @@ module ApplicationHelper
 
   def encoded_id(document)
     id = document._source[:id]
-    id.slice!(FEDORA_BASE_URL)
-    return ERB::Util.url_encode(id)
+    return ERB::Util.url_encode(id.slice(FEDORA_BASE_URL.size, id.size))
   end
 
   def iiif_base_url()

--- a/app/views/catalog/_show_sidebar.html.erb
+++ b/app/views/catalog/_show_sidebar.html.erb
@@ -1,0 +1,19 @@
+<div class="panel panel-default">
+  <div class="panel-heading">Links</div>
+  <div class="panel-body">
+    <ul class="nav">
+      <li><%= link_to 'View in Fedora', @document.id, target: '_blank' %></li>
+    </ul>
+  </div>
+</div>
+
+<%= render :partial => 'show_tools' %>
+
+<% unless @document.more_like_this.empty? %>
+  <div class="card">
+    <div class="card-header">More Like This</div>
+    <div class="card-block">
+      <%= render :collection => @document.more_like_this, :partial => 'show_more_like_this', :as => :document %>
+    </div>
+  </div>
+<% end %>


### PR DESCRIPTION
* Removed "Fedora URL" from the fields shown in the document body.
* Changed the encoded_id helper to non-destructively strip the FEDORA_BASE_URL prefix from the document id.
* Added a custom _show_sidebar partial (copied from Blacklight and modified to add the "View in Fedora" link)

https://issues.umd.edu/browse/LIBHYDRA-64