### PR TITLE
LIBHYDRA-67. Added "Download" link for binaries.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -58,4 +58,10 @@ module ApplicationHelper
   def fcrepo_url
     FEDORA_BASE_URL.sub(/fcrepo\/rest\/?/, "")
   end
+
+  def view_in_fedora_link(document)
+    url = document[:id]
+    url += '/fcr:metadata' if document[:rdf_type].include? 'fedora:Binary'
+    link_to 'View in Fedora', url, target: '_blank'
+  end
 end

--- a/app/views/catalog/_show_sidebar.html.erb
+++ b/app/views/catalog/_show_sidebar.html.erb
@@ -2,7 +2,10 @@
   <div class="panel-heading">Links</div>
   <div class="panel-body">
     <ul class="nav">
-      <li><%= link_to 'View in Fedora', @document.id, target: '_blank' %></li>
+      <li><%= view_in_fedora_link(@document) %></li>
+      <% if @document[:rdf_type].include? 'fedora:Binary' %>
+        <li><%= link_to 'Download', @document.id, target: '_blank' %></li>
+      <% end %>
     </ul>
   </div>
 </div>


### PR DESCRIPTION
Also changed "View in Fedora" link to point to the fcr:metadata for the resource.

https://issues.umd.edu/browse/LIBHYDRA-67