### PR TITLE
LIBFCREPO-250. Display members grouped by their component type.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -63,6 +63,10 @@ module ApplicationHelper
     args[:document][args[:field]]
   end
 
+  def unique_component_types(pcdm_members_info)
+    pcdm_members_info.map {|member| member['component']}.uniq
+  end
+
   def fcrepo_url
     FEDORA_BASE_URL.sub(/fcrepo\/rest\/?/, "")
   end

--- a/app/views/catalog/_show_default.html.erb
+++ b/app/views/catalog/_show_default.html.erb
@@ -8,21 +8,36 @@
       </dt>
       <% if field_name=='id' %>
         <dd class="blacklight-<%= field_name.parameterize %>"><%= link_to doc_presenter.field_value(field_name), doc_presenter.field_value(field_name), target: "_blank" %></dd>
-      <% elsif ['pcdm_members', 'pcdm_files', 'pcdm_related_objects', 'pcdm_related_object_of', 'pcdm_member_of', 'pcdm_file_of', 'pcdm_collection'].include?(field_name) %>
+      <% elsif field_name == 'pcdm_members' %>
         <dd class="blacklight-<%= field_name.parameterize %>">
+        <% unique_component_types(doc_presenter.field_value(field_name)).each do |component| %>
+          <% subset = doc_presenter.field_value(field_name).select{|member| member['component'] == component} %>
+          <strong>
+            <%= component.pluralize subset.size %>
+            <span class="badge"><%= subset.size %></span>
+          </strong>
           <ul class="multivalued-field-value">
-            <% doc_presenter.field_value(field_name).each do |v| %>
+            <% subset.sort{|a,b| a['title'] <=> b['title']}.each do |v| %>
               <li><%= link_to v['title'][0], solr_document_path(v['id']) %></li>
             <% end %>
           </ul>
+        <% end %>
+        </dd>
+      <% elsif ['pcdm_files', 'pcdm_related_objects', 'pcdm_related_object_of', 'pcdm_member_of', 'pcdm_file_of', 'pcdm_collection'].include?(field_name) %>
+        <dd class="blacklight-<%= field_name.parameterize %>">
+        <ul class="multivalued-field-value">
+          <% doc_presenter.field_value(field_name).each do |v| %>
+            <li><%= link_to v['title'][0], solr_document_path(v['id']) %></li>
+          <% end %>
+        </ul>
         </dd>
       <% elsif field_name == 'rdf_type' %>
         <dd class="blacklight-<%= field_name.parameterize %>">
-          <ul class="multivalued-field-value">
-            <% doc_presenter.field_value(field_name).each do |v| %>
-              <li><%= v %></li>
-            <% end %>
-          </ul>
+        <ul class="multivalued-field-value">
+          <% doc_presenter.field_value(field_name).each do |v| %>
+            <li><%= v %></li>
+          <% end %>
+        </ul>
         </dd>
       <% else %>
         <dd class="blacklight-<%= field_name.parameterize %>"><%= doc_presenter.field_value field_name %></dd>


### PR DESCRIPTION
In addition, sort by their title and display a badge with the number of each type next to the component type header.

https://issues.umd.edu/browse/LIBFCREPO-250