### PR TITLE
LIBHYDRA-99. Added a mirador_viewer_url helper method.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,9 @@ gem 'rubycas-client', git: 'https://github.com/rubycas/rubycas-client.git', bran
 # dotenv - For storing production configuration parameters
 gem 'dotenv-rails', '~> 2.1.1'
 
+# RFC-complient URI and URI template handling
+gem 'addressable', '~> 2.5'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,8 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
+    addressable (2.5.1)
+      public_suffix (~> 2.0, >= 2.0.2)
     ansi (1.5.0)
     arel (6.0.3)
     ast (2.3.0)
@@ -124,6 +126,7 @@ GEM
       ast (~> 2.2)
     pkg-config (1.1.7)
     powerpack (0.1.1)
+    public_suffix (2.0.5)
     rack (1.6.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -219,6 +222,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  addressable (~> 2.5)
   blacklight (~> 6.0)
   byebug
   coffee-rails (~> 4.1.0)
@@ -244,4 +248,4 @@ DEPENDENCIES
   web-console (~> 2.0)
 
 BUNDLED WITH
-   1.12.5
+   1.13.6

--- a/app/views/mirador/_show.html.erb
+++ b/app/views/mirador/_show.html.erb
@@ -1,6 +1,5 @@
 <% if mirador_displayable?(document) %>
-  <% query_param = @current_query ? "&q=#{@current_query}" : '' %>
   <div class="intrinsic-container ratio-4x3">
-    <iframe src="<%= iiif_base_url %>viewer/1.1.0/mirador.html?manifest=fcrepo:<%= encoded_id(document) %>&amp;iiifURLPrefix=<%= iiif_base_url %>manifests/<%= query_param %>" allowfullscreen></iframe>
+    <iframe src="<%= mirador_viewer_url(document, @current_query) %>" allowfullscreen></iframe>
   </div>
 <% end %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -42,4 +42,7 @@ Rails.application.configure do
   # FCREPO & IIIF URLs
   config.fcrepo_base_url = ENV['FCREPO_BASE_URL'] || 'https://fcrepolocal/fcrepo/rest/'
   config.iiif_base_url = ENV['IIIF_BASE_URL'] || 'https://iiiflocal/'
+
+  # Mirador version
+  config.mirador_static_version = ENV['MIRADOR_STATIC_VERSION'] || '1.1.0'
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -80,4 +80,7 @@ Rails.application.configure do
   # FCREPO & IIIF URLs
   config.fcrepo_base_url = ENV['FCREPO_BASE_URL']
   config.iiif_base_url = ENV['IIIF_BASE_URL']
+
+  # Mirador version
+  config.mirador_static_version = ENV['MIRADOR_STATIC_VERSION']
 end

--- a/config/environments/vagrant.rb
+++ b/config/environments/vagrant.rb
@@ -42,4 +42,7 @@ Rails.application.configure do
   # FCREPO & IIIF URLs
   config.fcrepo_base_url = ENV['FCREPO_BASE_URL'] || 'https://fcrepolocal/fcrepo/rest/'
   config.iiif_base_url = ENV['IIIF_BASE_URL'] || 'https://iiiflocal/'
+
+  # Mirador version
+  config.mirador_static_version = ENV['MIRADOR_STATIC_VERSION'] || '1.1.0'
 end

--- a/env_example
+++ b/env_example
@@ -16,3 +16,7 @@ FCREPO_BASE_URL = 'https://fcrepolocal/fcrepo/rest/'
 # --- config/environments/*.rb
 # base URL of the IIIF server (which serves the manifests, images, and viewer)
 IIIF_BASE_URL = 'https://iiiflocal/'
+
+# --- config/environments/*.rb
+# version of the Mirador Static Viewer
+MIRADOR_STATIC_VERSION = '1.1.0'


### PR DESCRIPTION
Uses the Addressable::Template URI template gem to construct the mirador static viewer URL for the given document and query. Mirador static version is set through an environment variable instead of being hardcoded into the view.

https://issues.umd.edu/browse/LIBHYDRA-99