### PR TITLE
LIBHYDRA-103. Move image viewer above metadata.

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -12,6 +12,11 @@
     margin: 0;
 }
 
+.image-viewer {
+    margin-top: 1em;
+    margin-bottom: 1em;
+}
+
 // based on https://benmarshall.me/responsive-iframes/
 .intrinsic-container {
   position: relative;

--- a/app/views/catalog/_show_default.html.erb
+++ b/app/views/catalog/_show_default.html.erb
@@ -1,6 +1,7 @@
+<%= render "mirador/show", document: document unless document['component'] == 'article' %>
 <% doc_presenter = show_presenter(document) %>
 <%# default partial to display solr document fields in catalog show view -%>
-<dl class="dl-horizontal  dl-invert">
+<dl class="dl-horizontal dl-invert" id="metadata">
   <% document_show_fields(document).each do |field_name, field| %>
     <% if should_render_show_field? document, field %>
       <dt class="blacklight-<%= field_name.parameterize %>">
@@ -44,5 +45,4 @@
       <% end %>
     <% end -%>
   <% end -%>
-  <%= render "mirador/show", document: document unless document['component'] == 'article' %>
 </dl>

--- a/app/views/mirador/_show.html.erb
+++ b/app/views/mirador/_show.html.erb
@@ -1,5 +1,6 @@
 <% if mirador_displayable?(document) %>
-  <div class="intrinsic-container ratio-4x3">
+  <div class="skip-link"><a href="#metadata" data-turbolinks="false">Go to Metadata</a></div>
+  <div class="image-viewer intrinsic-container ratio-4x3">
     <iframe src="<%= mirador_viewer_url(document, @current_query) %>" allowfullscreen></iframe>
   </div>
 <% end %>


### PR DESCRIPTION
Includes a "skip link" to the metadata. This link required a data-turbolinks="false" attribute to stop TurboLinks from doing another GET request for the in-page link. See also https://github.com/turbolinks/turbolinks/issues/75.

https://issues.umd.edu/browse/LIBHYDRA-103