### PR TITLE
LIBHYDRA-111 Enable Download URL routes to contain a period

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,7 +27,7 @@ Rails.application.routes.draw do
 
   resources :download_urls, only: [:index, :show]
   get path: '/download_urls/generate/:document_url', controller: 'download_urls',
-      action: 'generate_download_url', as: 'generate_download_url'
+      action: 'generate_download_url', as: 'generate_download_url', constraints: { document_url: /.*/ }
   post path: '/download_urls/create', controller: 'download_urls',
        action: 'create_download_url', as: 'create_download_url'
   get path: '/download_urls/show/:token', controller: 'download_urls',


### PR DESCRIPTION
By default, Rails does not allow dynamic segments in a URL to contain a
period (.) as it is typically used to specify the expected format of
the response.

The Download URL controller contains a route that may contain a URL,
which has periods in the hostname portion. The "generate_download_url"
route was updated to allow periods.

https://issues.umd.edu/browse/LIBHYDRA-111