### PR TITLE
LIBHYDRA-106. Increase highlighted snippet size.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -105,7 +105,7 @@ class CatalogController < ApplicationController
     config.add_index_field 'object_type', label: 'Object Type'
     config.add_index_field 'component', label: 'Component'
     config.add_index_field 'author', label: 'Author'
-    config.add_index_field 'extracted_text', label: 'OCR', highlight: true, helper_method: :strip_word_coordinates
+    config.add_index_field 'extracted_text', label: 'OCR', highlight: true, helper_method: :format_extracted_text, solr_params: { 'hl.fragsize' => 500 }
     config.add_index_field 'created_by', label: 'Created By'
     config.add_index_field 'created', label: 'Created'
     config.add_index_field 'last_modified', label: 'Last Modified'

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -94,12 +94,15 @@ module ApplicationHelper
     link_to 'Generate Download URL', generate_download_url_path(document_url: url)
   end
 
-  def strip_word_coordinates(args)
-    coord_pattern = /\|\d+,\d+,\d+,\d+/
+  def format_extracted_text(args)
     if args[:value].is_a? Array
-      args[:value].map { |v| v.gsub(coord_pattern, '') }.join('... ').html_safe
+      args[:value].map { |v| format_extracted_text(value: v) }.join('... ').html_safe
     else
-      args[:value].gsub(coord_pattern, '')
+      # to strip out the embedded word corrdinates
+      coord_pattern = /\|\d+,\d+,\d+,\d+/
+      # to remove {SOFT HYPHEN}{NEWLINE}
+      hyphen_pattern = /\u{AD}\n/
+      args[:value].gsub(coord_pattern, '').gsub(hyphen_pattern, '')
     end
   end
 


### PR DESCRIPTION
Also strip out "{SOFT HYPHEN}{NEWLINE}" sequences when displaying the snippets, so we don't get ugly word breaks in the middle of words on the result page.

https://issues.umd.edu/browse/LIBHYDRA-106