### PR TITLE
LIBHYDRA-116. Group textblock hits by page.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -117,4 +117,13 @@ module ApplicationHelper
       q: query
     ).to_s
   end
+
+  def count_additional_hits(document)
+    source = document[:extracted_text_source]
+    if source && @response[:expanded][source]
+      @response[:expanded][source][:numFound]
+    else
+      nil
+    end
+  end
 end

--- a/app/views/catalog/_index_default.html.erb
+++ b/app/views/catalog/_index_default.html.erb
@@ -1,0 +1,17 @@
+<%# partial to display solr document fields in catalog index view -%>
+<% doc_presenter = index_presenter(document) %> 
+<% additional_hits = count_additional_hits(document) || 0 %>
+<dl class="document-metadata dl-horizontal dl-invert">
+
+  <% index_fields(document).each do |field_name, field| -%>
+    <% if should_render_index_field? document, field %>
+      <dt class="blacklight-<%= field_name.parameterize %>"><%= render_index_field_label document, field: field_name %></dt>
+      <dd class="blacklight-<%= field_name.parameterize %>">
+        <%= doc_presenter.field_value field_name %>
+        <% if field_name == 'extracted_text' && additional_hits > 0 %>
+          <div><i>Plus <%= pluralize(additional_hits, 'additional match') %></i></div>
+        <% end -%>
+      </dd>
+    <% end -%>
+  <% end -%>
+</dl>


### PR DESCRIPTION
Use the collapse/expand filter in Solr to group text block hits by page. Display only one hit and highlighted fragment per page, plus a note of the number of additional hits (if any). Due to the way the collapse filter works, currently only the top hit within the group has a highlighted fragment available. Getting the other highlighted fragments would require an additional Solr query per page.

https://issues.umd.edu/browse/LIBHYDRA-116