### PR TITLE
LIBHYDRA-113. SSL configuration for downloads.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -105,7 +105,9 @@ class CatalogController < ApplicationController
     config.add_index_field 'object_type', label: 'Object Type'
     config.add_index_field 'component', label: 'Component'
     config.add_index_field 'author', label: 'Author'
+    # rubocop:disable Metrics/LineLength
     config.add_index_field 'extracted_text', label: 'OCR', highlight: true, helper_method: :format_extracted_text, solr_params: { 'hl.fragsize' => 500 }
+    # rubocop:enable Metrics/LineLength
     config.add_index_field 'created_by', label: 'Created By'
     config.add_index_field 'created', label: 'Created'
     config.add_index_field 'last_modified', label: 'Last Modified'

--- a/app/views/retrieve/retrieve.html.erb
+++ b/app/views/retrieve/retrieve.html.erb
@@ -1,6 +1,6 @@
 <% provide :app_name, 'File Retrieval' %>
 <meta http-equiv="REFRESH" content="3; URL=/retrieve/do/<%= @token %>">
-<h2>File Download</h1>
+<h2>File Download</h2>
 
 <p>Thank you for using the University Libraries File Retrieval service.</p>
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,5 +22,8 @@ module FcrepoSearch
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
+
+    # Default to doing SSL certificate verification
+    config.fcrepo_ssl_verify_mode = OpenSSL::SSL::VERIFY_PEER
   end
 end

--- a/config/environments/vagrant.rb
+++ b/config/environments/vagrant.rb
@@ -45,4 +45,7 @@ Rails.application.configure do
 
   # Mirador version
   config.mirador_static_version = ENV['MIRADOR_STATIC_VERSION'] || '1.1.0'
+
+  # skip SSL cert verification, since fcrepolocal uses a self-signed cert
+  config.fcrepo_ssl_verify_mode = OpenSSL::SSL::VERIFY_NONE
 end


### PR DESCRIPTION
Default to doing SSL peer verification of certificates, but disable it for the Vagrant environment, since fcrepolocal uses a self-signed certificate. Also corrected a mismatched tag in the retrieve view.

https://issues.umd.edu/browse/LIBHYDRA-113