### PR TITLE
LIBHYDRA-124 Point to ca_file in SSL context

### DIFF
--- a/app/controllers/retrieve_controller.rb
+++ b/app/controllers/retrieve_controller.rb
@@ -19,6 +19,11 @@ class RetrieveController < ApplicationController
     fedora_url = download_url.url
     ctx = OpenSSL::SSL::SSLContext.new
     ctx.verify_mode = Rails.configuration.fcrepo_ssl_verify_mode
+
+    if ctx.verify_mode == OpenSSL::SSL::VERIFY_PEER
+      ctx.ca_file = Rails.configuration.ssl_ca_file
+    end
+
     http = HTTP.get(fedora_url, ssl_context: ctx)
     data = http.body
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,5 +25,6 @@ module FcrepoSearch
 
     # Default to doing SSL certificate verification
     config.fcrepo_ssl_verify_mode = OpenSSL::SSL::VERIFY_PEER
+    config.ssl_ca_file = ENV["SSL_CERT_FILE"] || '/etc/ssl/certs/ca-bundle.crt'
   end
 end


### PR DESCRIPTION
This adds a configuration to point to the SSL ca file, which was not
being found by OpenSSL::SSL::SSLContext. This can be set using a ENV['SSL_CERT_FILE']
variable or it looks at '/etc/ssl/certs/ca-bundle.crt' by default

https://issues.umd.edu/browse/LIBHYDRA-124