### PR TITLE
LIBHYDRA-85 Rescue if Blacklight cannot connect

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -4,6 +4,11 @@ class CatalogController < ApplicationController
   include Blacklight::Catalog
   before_action :make_current_query_accessible, only: %i[show index] # rubocop:disable Rails/LexicallyScopedActionFilter
 
+  rescue_from Blacklight::Exceptions::ECONNREFUSED do |_e|
+    flash[:error] = I18n.t(:solr_is_down)
+    redirect_to(about_url)
+  end
+
   configure_blacklight do |config| # rubocop:disable Metrics/BlockLength
     ## Class for sending and receiving requests from a search index
     # config.repository_class = Blacklight::Solr::Repository

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,7 +21,7 @@
 
 en:
   hello: "Hello world"
-  solr_is_down: "Unable to connect to the solr index." 
+  solr_is_down: "Unable to connect to Solr index. Search functionality is unavailable at this time."
   activerecord:
     models:
       download_url: Download URL

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,6 +21,7 @@
 
 en:
   hello: "Hello world"
+  solr_is_down: "Unable to connect to the solr index." 
   activerecord:
     models:
       download_url: Download URL

--- a/test/controllers/catalog_controller_test.rb
+++ b/test/controllers/catalog_controller_test.rb
@@ -1,0 +1,13 @@
+require 'test_helper'
+
+class CatalogControllerTest < ActionController::TestCase
+  test 'should give warning and redirect if solr is down' do
+    raise_e = -> { raise Blacklight::Exceptions::ECONNREFUSED }
+    @controller.stub(:index, raise_e) do
+      get :index
+      assert_redirected_to(about_url)
+      refute flash.empty?
+      assert_equal flash[:error], I18n.t(:solr_is_down)
+    end
+  end
+end

--- a/test/controllers/catalog_controller_test.rb
+++ b/test/controllers/catalog_controller_test.rb
@@ -10,4 +10,14 @@ class CatalogControllerTest < ActionController::TestCase
       assert_equal flash[:error], I18n.t(:solr_is_down)
     end
   end
+
+  test 'should give warning and redirect if solr cannot connect' do
+    raise_e = -> { raise Blacklight::Exceptions::InvalidRequest }
+    @controller.stub(:index, raise_e) do
+      get :index
+      assert_redirected_to(about_url)
+      refute flash.empty?
+      assert_equal flash[:error], I18n.t(:solr_is_down)
+    end
+  end
 end


### PR DESCRIPTION
This rescues and redirects if blacklight cannot connect to solr. The
catalog controller will redirect to the about page. User pages will also
still work.