### PR TITLE
LIBHYDRA-137. Shorten the manifest ID passed to Mirador.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -106,13 +106,18 @@ module ApplicationHelper
     end
   end
 
+  # remove the pairtree from the path
+  def compress_path(path)
+    path.gsub('/', ':').gsub(/:(..):(..):(..):(..):\1\2\3\4/, '::\1\2\3\4')
+  end
+
   def mirador_viewer_url(document, query)
     template = Addressable::Template.new(
-      "#{IIIF_BASE_URL}viewer{/version}/mirador.html?manifest=fcrepo:{id}{&iiifURLPrefix,q}"
+      "#{IIIF_BASE_URL}viewer{/version}/mirador.html?manifest=fcrepo:{+id}{&iiifURLPrefix,q}"
     )
     template.expand(
       version: MIRADOR_STATIC_VERSION,
-      id: repo_path(document[:id]),
+      id: compress_path(repo_path(document[:id])),
       iiifURLPrefix: "#{IIIF_BASE_URL}manifests/",
       q: query
     ).to_s


### PR DESCRIPTION
The PCDM manifests app now uses shortened URIs in the manifests, so when Mirador tries to set the current canvas based on comparing URLs, it never matches to the full URL and was showing page 1 always.

https://issues.umd.edu/browse/LIBHYDRA-137