### PR TITLE
LIBHYDRA-158. Add a user history page.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -92,3 +92,5 @@ group :test do
 end
 
 gem 'rsolr', '~> 1.0'
+
+gem "sparql-client", "~> 3.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,6 +67,7 @@ GEM
       execjs
     coffee-script-source (1.10.0)
     concurrent-ruby (1.1.4)
+    connection_pool (2.2.2)
     crass (1.0.4)
     debug_inspector (0.0.2)
     deprecation (1.0.0)
@@ -87,6 +88,8 @@ GEM
     ffi (1.10.0)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
+    hamster (3.0.0)
+      concurrent-ruby (~> 1.0)
     hashie (3.6.0)
     http (2.2.2)
       addressable (~> 2.3)
@@ -111,6 +114,7 @@ GEM
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
     libv8 (3.16.14.19)
+    link_header (0.0.8)
     loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -128,6 +132,8 @@ GEM
       ruby-progressbar
     multi_json (1.12.1)
     multipart-post (2.0.0)
+    net-http-persistent (3.0.1)
+      connection_pool (~> 2.2)
     net-ldap (0.16.1)
     nokogiri (1.9.1)
       mini_portile2 (~> 2.4.0)
@@ -184,6 +190,9 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
+    rdf (3.0.12)
+      hamster (~> 3.0)
+      link_header (~> 0.0, >= 0.0.8)
     rdoc (4.2.2)
       json (~> 1.4)
     ref (2.0.0)
@@ -228,6 +237,9 @@ GEM
       faraday
       ruby-progressbar
       rubyzip
+    sparql-client (3.0.1)
+      net-http-persistent (>= 2.9, < 4)
+      rdf (~> 3.0)
     spring (1.7.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
@@ -296,6 +308,7 @@ DEPENDENCIES
   simplecov
   simplecov-rcov
   solr_wrapper (>= 0.3)
+  sparql-client (~> 3.0)
   spring
   sqlite3
   therubyracer

--- a/app/views/cas_users/index.html.erb
+++ b/app/views/cas_users/index.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <h1>Users</h1>
 
 <table class="table">
@@ -9,16 +7,16 @@
       <th>Name</th>
       <th>Type</th>
       <th colspan="3"></th>
+      <th colspan="2"></th>
     </tr>
   </thead>
 
   <tbody>
     <% @cas_users.each do |cas_user| %>
       <tr>
-        <td><%= cas_user.cas_directory_id %></td>
+        <td><%= link_to cas_user.cas_directory_id, cas_user %></td>
         <td><%= cas_user.name %></td>
         <td><%= cas_user.user_type %></td>
-        <td><%= link_to 'Show', cas_user %></td>
         <td><%= link_to 'Destroy', cas_user, method: :delete, data: { confirm: 'Please remove Archelon Grouper roles of the user to ensure access is restricted. Confirm delete?' } %></td>
       </tr>
     <% end %>

--- a/app/views/cas_users/show.html.erb
+++ b/app/views/cas_users/show.html.erb
@@ -1,4 +1,6 @@
-<p id="notice"><%= notice %></p>
+<% content_for :page_title, "User Profile: #{@cas_user.cas_directory_id}" %>
+
+<h1><%= content_for :page_title %></h1>
 
 <p>
   <strong>Directory ID:</strong>
@@ -11,7 +13,6 @@
 </p>
 
 <% if current_cas_user.admin? %>
-
 <p>
   <strong>Type:</strong>
   <%= @cas_user.user_type %>
@@ -20,4 +21,7 @@
 
 <div class="actions">
   <%= link_to 'List Users', cas_users_path, class: 'btn btn-default' %>
+  <%= link_to 'User History', { controller: 'cas_users', action: 'show_history' }, class: 'btn btn-success' %>
 </div>
+
+

--- a/app/views/cas_users/show_history.html.erb
+++ b/app/views/cas_users/show_history.html.erb
@@ -1,0 +1,39 @@
+<% content_for :page_title, "User History: #{@cas_user.cas_directory_id}" %>
+
+<h1><%= content_for :page_title %></h1>
+
+<%= form_tag '', method: 'get' do %>
+  Find events from the past
+  <%= number_field_tag :days, @days, size: 4, min: 1 %>
+  days.
+  <%= submit_tag 'Go', class: 'btn btn-notice' %>
+<% end %>
+<table class="table">
+  <thead>
+  <tr>
+    <th>Timestamp</th>
+    <th>Event Type</th>
+    <th>Resource</th>
+  </tr>
+  </thead>
+  <tbody>
+  <% if @events.empty? %>
+    <tr>
+      <td colspan="3">No events found for this user in the past <%= @days %> days</td>
+    </tr>
+  <% else %>
+    <% @events.each do |event| %>
+      <tr>
+        <td><%= event[:timestamp] %></td>
+        <td><%= link_to event[:type_description], event[:type].to_s %></td>
+        <td><%= link_to event[:resource], "/catalog/#{CGI.escape(event[:resource])}" %></td>
+      </tr>
+    <% end %>
+  <% end%>
+  </tbody>
+</table>
+
+<div class="actions">
+  <%= link_to 'List Users', cas_users_path, class: 'btn btn-default' %>
+  <%= link_to 'User Profile', @cas_user, class: 'btn btn-success' %>
+</div>

--- a/app/views/cas_users/show_history.html.erb
+++ b/app/views/cas_users/show_history.html.erb
@@ -6,7 +6,7 @@
   Find events from the past
   <%= number_field_tag :days, @days, size: 4, min: 1 %>
   days.
-  <%= submit_tag 'Go', class: 'btn btn-notice' %>
+  <%= submit_tag 'Go', class: 'btn btn-primary' %>
 <% end %>
 <table class="table">
   <thead>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -45,4 +45,6 @@ Rails.application.configure do
 
   # Mirador version
   config.mirador_static_version = ENV['MIRADOR_STATIC_VERSION'] || '1.1.0'
+
+  config.audit_sparql_endpoint = ENV['AUDIT_SPARQL_ENDPOINT_URL']
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -83,4 +83,6 @@ Rails.application.configure do
 
   # Mirador version
   config.mirador_static_version = ENV['MIRADOR_STATIC_VERSION']
+
+  config.audit_sparql_endpoint = ENV['AUDIT_SPARQL_ENDPOINT_URL']
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
   get 'static_pages/about'
 
   resources :cas_users
+  get '/cas_users/:id/history' => 'cas_users#show_history'
 
   mount Blacklight::Engine => '/'
   root to: 'catalog#index'

--- a/env_example
+++ b/env_example
@@ -29,3 +29,6 @@ RETRIEVE_BASE_URL=http://127.0.0.1:3000/retrieve/
 # LDAP Authentication Credentials
 LDAP_BIND_DN=
 LDAP_BIND_PASSWORD=
+
+# SPAQRL endpoint for querying the repository's audit history
+AUDIT_SPARQL_ENDPOINT_URL=


### PR DESCRIPTION
Displays the audit records where the user is named as an agent. Defaults to displaying 90 days back, can be set to a different value via a form and query params.

https://issues.umd.edu/browse/LIBHYDRA-158