### PR TITLE
LIBHYDRA-165. Use a customized Faraday HTTP connection with RSolr.

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -45,8 +45,12 @@ module Blacklight::Solr
     protected
       # set the SSL CA certs path for Solr connections
       def build_connection
-        conn = Faraday.new ssl: { ca_path: Rails.configuration.ssl_ca_file }
-        RSolr.connect conn, connection_config
+        if Rails.configuration.ssl_ca_file
+          conn = Faraday.new ssl: { ca_path: Rails.configuration.ssl_ca_file }
+          RSolr.connect conn, connection_config
+        else
+          RSolr.connect connection_config
+        end
       end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,6 +33,9 @@ module FcrepoSearch
     elsif File.file? '/etc/ssl/certs/ca-certificates.crt'
       # Debian/Ubuntu path
       config.ssl_ca_file = '/etc/ssl/certs/ca-certificates.crt'
+    elsif File.file? '/etc/openssl/cert.pem'
+      # Mac OS X path
+      config.ssl_ca_file = '/etc/openssl/cert.pem'
     end
 
     # CAS URL

--- a/config/application.rb
+++ b/config/application.rb
@@ -45,7 +45,7 @@ module Blacklight::Solr
     protected
       # set the SSL CA certs path for Solr connections
       def build_connection
-        if Rails.configuration.ssl_ca_file
+        if Rails.configuration.respond_to? :ssl_ca_file
           conn = Faraday.new ssl: { ca_path: Rails.configuration.ssl_ca_file }
           RSolr.connect conn, connection_config
         else

--- a/config/application.rb
+++ b/config/application.rb
@@ -39,3 +39,14 @@ module FcrepoSearch
     config.cas_url = "https://login.umd.edu/cas"
   end
 end
+
+module Blacklight::Solr
+  class Repository < Blacklight::AbstractRepository
+    protected
+      # set the SSL CA certs path for Solr connections
+      def build_connection
+        conn = Faraday.new ssl: { ca_path: Rails.configuration.ssl_ca_file }
+        RSolr.connect conn, connection_config
+      end
+  end
+end


### PR DESCRIPTION
Add support for using a custom ssl ca_path.

https://issues.umd.edu/browse/LIBHYDRA-165