### PR TITLE
LIBHYDRA-185. Enable tests to run on Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,7 +52,9 @@ pipeline {
            |
            |Check console output at $BUILD_URL to view the results.
            |
-           |There are ${ANALYSIS_ISSUES_COUNT} static analysis issues in this build.'''.stripMargin()
+           |There are ${ANALYSIS_ISSUES_COUNT} static analysis issues in this build.
+           |
+           |There were ${TEST_COUNTS,var="skip"} skipped tests.'''.stripMargin()
   }
 
   stages {
@@ -125,6 +127,9 @@ pipeline {
             TESTS_TO_RUN="test:system $TESTS_TO_RUN"
           fi
 
+          # Configure MiniTest to use JUnit-style reporter
+          export MINITEST_REPORTER=JUnitReporter
+
           echo "Running 'bundle exec rails $TESTS_TO_RUN'"
           bundle exec rails $TESTS_TO_RUN
 
@@ -142,6 +147,10 @@ pipeline {
           // Collect Rubocop reports
           recordIssues(tools: [ruboCop(reportEncoding: 'UTF-8')], unstableTotalAll: 1)
 
+          // Collect JUnit test reports
+          junit '**/test/reports/*.xml'
+
+          // Collecte coverage reports
           publishHTML (target: [
             allowMissing: true,
             alwaysLinkToLastBuild: false,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -125,9 +125,8 @@ pipeline {
             TESTS_TO_RUN="test:system $TESTS_TO_RUN"
           fi
 
-          # Skip tests, because of tests need a Solr Vagrant box
-          # echo "Running 'bundle exec rails $TESTS_TO_RUN'"
-          # bundle exec rails $TESTS_TO_RUN
+          echo "Running 'bundle exec rails $TESTS_TO_RUN'"
+          bundle exec rails $TESTS_TO_RUN
 
           # Run RuboCop
           # Send output to standard out for "Record compiler warnings and static analysis results"

--- a/test/controllers/download_urls_controller_test.rb
+++ b/test/controllers/download_urls_controller_test.rb
@@ -103,20 +103,26 @@ class DownloadUrlsControllerTest < ActionController::TestCase
   end
 
   test 'should show download_url' do
-    skip if ENV['RETRIEVE_BASE_URL'].nil?
+    # Set a default RETRIEVE_BASE_URL if none is set, so that Jenkins can
+    # run the test.
+    ENV['RETRIEVE_BASE_URL'] = 'http://example.com/' if ENV['RETRIEVE_BASE_URL'].nil?
     get :show, params: { id: @download_url }
     assert_response :success
   end
 
   test 'generate_download_url should raise 404 RoutingError if document cannot be found' do
-    skip 'Requires Solr'
+    error = ActionController::RoutingError.new('Stub', [])
+    allow(@controller).to receive(:find_solr_document).and_raise(error)
+
     assert_raises(ActionController::RoutingError) do
       get :generate_download_url, params: { document_url: 'document does not exist' }
     end
   end
 
   test 'create_download_url should raise 404 RoutingError if document cannot be found' do
-    skip 'Requires Solr'
+    error = ActionController::RoutingError.new('Stub', [])
+    allow(@controller).to receive(:find_solr_document).and_raise(error)
+
     assert_raises(ActionController::RoutingError) do
       get :create_download_url, params: { document_url: 'document does not exist' }
     end

--- a/test/controllers/download_urls_controller_test.rb
+++ b/test/controllers/download_urls_controller_test.rb
@@ -103,23 +103,28 @@ class DownloadUrlsControllerTest < ActionController::TestCase
   end
 
   test 'should show download_url' do
+    skip if ENV['RETRIEVE_BASE_URL'].nil?
     get :show, params: { id: @download_url }
     assert_response :success
   end
 
   test 'generate_download_url should raise 404 RoutingError if document cannot be found' do
+    skip 'Requires Solr'
     assert_raises(ActionController::RoutingError) do
       get :generate_download_url, params: { document_url: 'document does not exist' }
     end
   end
 
   test 'create_download_url should raise 404 RoutingError if document cannot be found' do
+    skip 'Requires Solr'
     assert_raises(ActionController::RoutingError) do
       get :create_download_url, params: { document_url: 'document does not exist' }
     end
   end
 
   test 'show_download_url should assign the retrieve url' do
+    # Assign a dummy RETRIEVE_BASE_URL so test can run without a .env file
+    ENV['RETRIEVE_BASE_URL'] = 'https://example.com/'
     get :show_download_url, params: { token: @download_url.token }
     retrieve_base_url = ENV['RETRIEVE_BASE_URL']
     assert_not assigns(:download_url).nil?

--- a/test/controllers/download_urls_controller_test.rb
+++ b/test/controllers/download_urls_controller_test.rb
@@ -111,20 +111,18 @@ class DownloadUrlsControllerTest < ActionController::TestCase
   end
 
   test 'generate_download_url should raise 404 RoutingError if document cannot be found' do
-    error = ActionController::RoutingError.new('Stub', [])
-    allow(@controller).to receive(:find_solr_document).and_raise(error)
-
-    assert_raises(ActionController::RoutingError) do
-      get :generate_download_url, params: { document_url: 'document does not exist' }
+    @controller.stub(:find_solr_document, nil) do
+      assert_raises(ActionController::RoutingError) do
+        get :generate_download_url, params: { document_url: 'document does not exist' }
+      end
     end
   end
 
   test 'create_download_url should raise 404 RoutingError if document cannot be found' do
-    error = ActionController::RoutingError.new('Stub', [])
-    allow(@controller).to receive(:find_solr_document).and_raise(error)
-
-    assert_raises(ActionController::RoutingError) do
-      get :create_download_url, params: { document_url: 'document does not exist' }
+    @controller.stub(:find_solr_document, nil) do
+      assert_raises(ActionController::RoutingError) do
+        get :create_download_url, params: { document_url: 'document does not exist' }
+      end
     end
   end
 

--- a/test/integration/cas_authorization_test.rb
+++ b/test/integration/cas_authorization_test.rb
@@ -4,11 +4,26 @@ require 'test_helper'
 # Integration test for CAS authorization functionality
 class CasAuthorizationTest < ActionDispatch::IntegrationTest
   def setup
-    skip 'Requires LDAP setup'
+  end
+
+  # Stubs an empty Solr response, for use when actually retrieving a
+  # web page in the test.
+  def stub_solr_response
+    solr_response = double(Blacklight::Solr::Response)
+    expect(solr_response).to receive(:aggregations).at_least(:once).and_return({})
+    expect_any_instance_of(CatalogController).to receive(:search_results).and_return([solr_response, []])
+  end
+
+  # LDAP call will return the given CAS user ldap_attrs map
+  def stub_ldap_response(ldap_attrs)
+    expect(CasUser).to receive(:ldap_attributes).and_return(ldap_attrs)
   end
 
   test 'existing cas_user can access application' do
-    cas_login('test_user')
+    stub_solr_response
+    # Using mock_cas_login_for_integration_tests, because this is an
+    # existing test fixtures user
+    mock_cas_login_for_integration_tests('test_user')
 
     get root_path
     assert_response :success
@@ -16,37 +31,29 @@ class CasAuthorizationTest < ActionDispatch::IntegrationTest
   end
 
   test 'new cas_user with User Grouper group can access application' do
-    ldap_attrs = {
-      name: 'New CAS User',
-      groups: [GROUPER_USER_GROUP]
-    }
-    CasUser.stub :ldap_attributes, ldap_attrs do
-      cas_login('new_cas_user1')
-    end
+    stub_solr_response
+    stub_ldap_response(name: 'New CAS User', groups: [GROUPER_USER_GROUP])
+
+    cas_login('new_cas_user1')
+
     get root_path
     assert_response :success
     assert_template 'catalog/index'
   end
 
   test 'new cas_user can with User Grouper group has assigned "user" type' do
-    ldap_attrs = {
-      name: 'New CAS User',
-      groups: [GROUPER_USER_GROUP]
-    }
-    CasUser.stub :ldap_attributes, ldap_attrs do
-      cas_login('new_cas_user2')
-    end
+    stub_ldap_response(name: 'New CAS User', groups: [GROUPER_USER_GROUP])
+
+    cas_login('new_cas_user2')
+
     assert CasUser.find_by(cas_directory_id: 'new_cas_user2').user?
   end
 
   test 'new cas_user can with Admin Grouper group can access application' do
-    ldap_attrs = {
-      name: 'New Admin CAS User',
-      groups: [GROUPER_ADMIN_GROUP]
-    }
-    CasUser.stub :ldap_attributes, ldap_attrs do
-      cas_login('new_admin_cas_user1')
-    end
+    stub_solr_response
+    stub_ldap_response(name: 'New Admin CAS User', groups: [GROUPER_ADMIN_GROUP])
+
+    cas_login('new_admin_cas_user1')
 
     get root_path
     assert_response :success
@@ -54,78 +61,65 @@ class CasAuthorizationTest < ActionDispatch::IntegrationTest
   end
 
   test 'new cas_user can with Admin Grouper group has "admin" type' do
-    ldap_attrs = {
-      name: 'New Admin CAS User',
-      groups: [GROUPER_ADMIN_GROUP]
-    }
-    CasUser.stub :ldap_attributes, ldap_attrs do
-      cas_login('new_admin_cas_user2')
-    end
+    stub_ldap_response(name: 'New Admin CAS User', groups: [GROUPER_ADMIN_GROUP])
+
+    cas_login('new_admin_cas_user2')
+
     assert CasUser.find_by(cas_directory_id: 'new_admin_cas_user2').admin?
   end
 
   test 'new cas_user without Grouper groups cannot access application' do
-    ldap_attrs = {
-      name: 'Unauthorized User',
-      groups: ['SOME_OTHER_GROUP']
-    }
-    CasUser.stub :ldap_attributes, ldap_attrs do
-      cas_login('new_unauth_user1')
-    end
+    stub_ldap_response(name: 'Unauthorized User', groups: ['SOME_OTHER_GROUP'])
+
+    cas_login('new_unauth_user1')
 
     get root_path
     assert_response(:forbidden)
   end
 
   test 'new cas_user without Grouper groups has "unauthorized" type' do
-    ldap_attrs = {
-      name: 'Unauthorized User',
-      groups: ['SOME_OTHER_GROUP']
-    }
-    CasUser.stub :ldap_attributes, ldap_attrs do
-      cas_login('new_unauth_user2')
-    end
+    stub_ldap_response(name: 'Unauthorized User', groups: ['SOME_OTHER_GROUP'])
+
+    cas_login('new_unauth_user2')
 
     assert CasUser.find_by(cas_directory_id: 'new_unauth_user2').unauthorized?
   end
 
   test 'existing admin cas_user type is updated based on Grouper group changes during login' do
-    ldap_attrs = {
-      name: 'Prior Admin',
-      groups: [GROUPER_USER_GROUP]
-    }
     assert CasUser.find_by(cas_directory_id: 'prior_admin').admin?
-    CasUser.stub :ldap_attributes, ldap_attrs do
-      cas_login('prior_admin')
-    end
+
+    stub_ldap_response(name: 'Prior Admin', groups: [GROUPER_USER_GROUP])
+
+    cas_login('prior_admin')
+
     assert CasUser.find_by(cas_directory_id: 'prior_admin').user?
   end
 
   test 'existing cas_user type is updated based on Grouper group changes during login' do
-    ldap_attrs = {
-      name: 'Prior User1',
-      groups: [GROUPER_ADMIN_GROUP]
-    }
     assert CasUser.find_by(cas_directory_id: 'prior_user1').user?
-    CasUser.stub :ldap_attributes, ldap_attrs do
-      cas_login('prior_user1')
-    end
+
+    stub_ldap_response(name: 'Prior User1', groups: [GROUPER_ADMIN_GROUP])
+
+    cas_login('prior_user1')
+
     assert CasUser.find_by(cas_directory_id: 'prior_user1').admin?
   end
 
   test 'existing authorized cas_user should be unauthorized if no longer belong to Archelon Grouper groups' do
-    ldap_attrs = {
-      name: 'Prior User2',
-      groups: ['SOME_OTHER_GROUP']
-    }
     assert CasUser.find_by(cas_directory_id: 'prior_user2').user?
-    CasUser.stub :ldap_attributes, ldap_attrs do
-      cas_login('prior_user2')
-    end
+
+    stub_ldap_response(name: 'Prior User2', groups: ['SOME_OTHER_GROUP'])
+
+    cas_login('prior_user2')
+
     assert CasUser.find_by(cas_directory_id: 'prior_user2').unauthorized?
   end
 
   test 'non-existent cas_user cannot access application' do
+    # In this test, the non-existent CAS user is created by the "cas_login"
+    # call, which will check for LDAP attritbutes, so stub LDAP call.
+    stub_ldap_response(name: 'No Such User', groups: [])
+
     cas_login('no_such_user')
 
     get root_path
@@ -133,7 +127,5 @@ class CasAuthorizationTest < ActionDispatch::IntegrationTest
   end
 
   def teardown
-    # Restore normal "test_user"
-    cas_login(DEFAULT_TEST_USER)
   end
 end

--- a/test/integration/cas_authorization_test.rb
+++ b/test/integration/cas_authorization_test.rb
@@ -3,6 +3,10 @@
 require 'test_helper'
 # Integration test for CAS authorization functionality
 class CasAuthorizationTest < ActionDispatch::IntegrationTest
+  def setup
+    skip 'Requires LDAP setup'
+  end
+
   test 'existing cas_user can access application' do
     cas_login('test_user')
 

--- a/test/integration/download_urls_index_test.rb
+++ b/test/integration/download_urls_index_test.rb
@@ -5,6 +5,7 @@ require 'test_helper'
 # Integration test for the DownloadUrl index page
 class DownloadUrlsIndexTest < ActionDispatch::IntegrationTest
   def setup
+    skip 'Requires LDAP setup'
     @sort_columns = %w[created_at]
     cas_login('test_user')
   end

--- a/test/integration/download_urls_index_test.rb
+++ b/test/integration/download_urls_index_test.rb
@@ -5,9 +5,8 @@ require 'test_helper'
 # Integration test for the DownloadUrl index page
 class DownloadUrlsIndexTest < ActionDispatch::IntegrationTest
   def setup
-    skip 'Requires LDAP setup'
     @sort_columns = %w[created_at]
-    cas_login('test_user')
+    mock_cas_login_for_integration_tests('test_user')
   end
 
   test 'index including pagination and sorting' do

--- a/test/integration/user_impersonation_test.rb
+++ b/test/integration/user_impersonation_test.rb
@@ -4,12 +4,11 @@ require 'test_helper'
 # Integration test for CAS authorization functionality
 class UserImpersonationTest < ActionDispatch::IntegrationTest
   def setup
-    skip 'Requires LDAP setup'
   end
 
   test 'admin user can impersonate non-admin user' do
     admin_user = cas_users(:test_admin)
-    cas_login(admin_user.cas_directory_id)
+    mock_cas_login_for_integration_tests(admin_user.cas_directory_id)
     non_admin_user = cas_users(:test_user)
 
     get admin_user_login_as_path(user_id: non_admin_user.id)
@@ -18,7 +17,7 @@ class UserImpersonationTest < ActionDispatch::IntegrationTest
 
   test 'admin user should remain on current page when impersonation is stopped' do
     admin_user = cas_users(:test_admin)
-    cas_login(admin_user.cas_directory_id)
+    mock_cas_login_for_integration_tests(admin_user.cas_directory_id)
     non_admin_user = cas_users(:test_user)
 
     get admin_user_login_as_path(user_id: non_admin_user.id)
@@ -31,7 +30,7 @@ class UserImpersonationTest < ActionDispatch::IntegrationTest
 
   test 'admin user cannot impersonate admin user' do
     admin_user = cas_users(:test_admin)
-    cas_login(admin_user.cas_directory_id)
+    mock_cas_login_for_integration_tests(admin_user.cas_directory_id)
     admin_user2 = cas_users(:test_admin2)
 
     get admin_user_login_as_path(user_id: admin_user2.id)
@@ -40,7 +39,7 @@ class UserImpersonationTest < ActionDispatch::IntegrationTest
 
   test 'regular user cannot impersonate' do
     non_admin_user = cas_users(:test_user)
-    cas_login(non_admin_user.cas_directory_id)
+    mock_cas_login_for_integration_tests(non_admin_user.cas_directory_id)
     admin_user = cas_users(:test_admin)
 
     get admin_user_login_as_path(user_id: admin_user.id)

--- a/test/integration/user_impersonation_test.rb
+++ b/test/integration/user_impersonation_test.rb
@@ -3,6 +3,10 @@
 require 'test_helper'
 # Integration test for CAS authorization functionality
 class UserImpersonationTest < ActionDispatch::IntegrationTest
+  def setup
+    skip 'Requires LDAP setup'
+  end
+
   test 'admin user can impersonate non-admin user' do
     admin_user = cas_users(:test_admin)
     cas_login(admin_user.cas_directory_id)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -44,6 +44,7 @@ class ActiveSupport::TestCase
       provider: 'cas',
       uid: cas_directory_id
     }
+
     get '/auth/cas/callback'
   end
 
@@ -54,6 +55,15 @@ class ActiveSupport::TestCase
     }
     request.env['omniauth.auth'] = OmniAuth.config.mock_auth[:cas]
     session[:cas_user] = cas_directory_id
+  end
+
+  def mock_cas_login_for_integration_tests(cas_directory_id)
+    allow(CasUser)
+      .to receive(:find_or_create_from_auth_hash)
+      .with(anything)
+      .and_return(CasUser.find_by(cas_directory_id: cas_directory_id))
+
+    cas_login(cas_directory_id)
   end
 
   # Runs the contents of a block using the given user as the current_user.


### PR DESCRIPTION
Added "rspec-mocks" gem, and added stubs for LDAP and Solr calls in the tests.

This enables all the tests to pass on Jenkins.

Note: The code also uses "minitest" mocks/stubs is some tests, but it did not appear that "minitest" was capable enough to be used for all the places that needed to be stubbed.

https://issues.umd.edu/browse/LIBHYDRA-185