### PR TITLE
LIBHYDRA-188. Replaced deprecated "chromedriver-helper" with "webdriv…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -94,8 +94,8 @@ group :test do
   # Adds support for Capybara system testing and selenium driver
 	gem 'capybara', '>= 2.15'
 	gem 'selenium-webdriver'
-	# Easy installation and use of chromedriver to run system tests with Chrome
-	gem 'chromedriver-helper'
+ 	# Easy installation and use of web drivers to run system tests with browsers
+	gem 'webdrivers'
 
   gem 'minitest-ci', '~> 3.0.3'
   gem 'minitest-reporters', '~> 1.1.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,8 +45,6 @@ GEM
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
     ansi (1.5.0)
-    archive-zip (0.12.0)
-      io-like (~> 0.3.0)
     arel (9.0.0)
     ast (2.4.0)
     autoprefixer-rails (9.6.1.1)
@@ -79,9 +77,6 @@ GEM
       xpath (~> 3.2)
     childprocess (1.0.1)
       rake (< 13.0)
-    chromedriver-helper (2.1.1)
-      archive-zip (~> 0.10)
-      nokogiri (~> 1.8)
     clipboard-rails (1.7.1)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
@@ -126,7 +121,6 @@ GEM
     http_parser.rb (0.6.0)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
-    io-like (0.3.0)
     jaro_winkler (1.5.3)
     jbuilder (2.9.1)
       activesupport (>= 4.2.0)
@@ -348,6 +342,10 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
+    webdrivers (4.1.2)
+      nokogiri (~> 1.6)
+      rubyzip (~> 1.0)
+      selenium-webdriver (>= 3.0, < 4.0)
     websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
@@ -366,7 +364,6 @@ DEPENDENCIES
   bootsnap (>= 1.1.0)
   byebug
   capybara (>= 2.15)
-  chromedriver-helper
   clipboard-rails (~> 1.7.1)
   coffee-rails (~> 4.2)
   dotenv-rails
@@ -406,6 +403,7 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
+  webdrivers
   will_paginate (~> 3.1.0)
   will_paginate-bootstrap (~> 1.0.0)
 


### PR DESCRIPTION
…ers"

As prompted by a warning when running "bundle install", replaced the
"chromedriver-helper" gem with the "webdrivers" gem.

https://issues.umd.edu/browse/LIBHYDRA-188