### PR TITLE
LIBHYDRA-186. Added workaround for https://login.umd.edu SSL issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,12 @@
 FROM ruby:2.6.3
 WORKDIR /opt/archelon
+
+# Workaround until https://login.umd.edu gets a better SSL certificate
+# This is intended to fix an "OpenSSL::SSL::SSLError (SSL_connect returned=1 errno=0 state=error: dh key too small)"
+# error when connecting to https://login.umd.edu
+RUN sed '/CipherString = DEFAULT@SECLEVEL=2/d' /etc/ssl/openssl.cnf > /etc/ssl/openssl.cnf.fixed && \
+    mv /etc/ssl/openssl.cnf.fixed /etc/ssl/openssl.cnf
+
 COPY ./Gemfile ./Gemfile.lock /opt/archelon/
 RUN bundle install --deployment
 COPY . /opt/archelon


### PR DESCRIPTION
Configured the Dockerfile to remove a line from the /etc/ssl/openssl.cnf
configuration file, to make it less strict about the SSL certificates
of servers it contacts.

This is intended to be a temporary fix until the SSL certificate on
https://login.umd.edu is updated.

https://issues.umd.edu/browse/LIBHYDRA-186