### PR TITLE
LIBHYDRA-190. Added LDAP_OVERRIDE environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ id=$(docker run -d --rm -p 3000:3000 \
     -e IIIF_BASE_URL=https://iiifdev.lib.umd.edu/ \
     -e MIRADOR_STATIC_VERSION=1.2.0 \
     -e RETRIEVE_BASE_URL=http://localhost:3000/retrieve/ \
+    -e LDAP_OVERRIDE=admin \
     archelon)
 ```
 
@@ -77,6 +78,9 @@ To stop the running docker container:
 ```
 docker kill "$id"
 ```
+
+See the "LDAP Override" section below for more information about the
+"LDAP_OVERRIDE" environment variable.
 
 ## Embedded Solr
 
@@ -253,6 +257,20 @@ In order to avoid this error:
 
 The batch export functionality relies on a running [Plastron](plastron)
 instance.
+
+## LDAP Override
+
+By default, Archelon determines the user type for a user ("admin", "user" or
+"unauthorized") using the list of Grouper groups in the "memberOf" attribute
+returned from an LDAP server for that user.
+
+The local development environment (or Docker container) can be run without
+connecting to an LDAP server using the "LDAP_OVERRIDE" environment variable.
+The "LDAP_OVERRIDE" environment variable specifies the user type for any user
+that logs in, i.e., either "admin" or "user".
+
+The "LDAP_OVERRIDE" environment variable only works in the "development"
+Rails environment.
 
 ## About CVE-2015-9284
 

--- a/app/models/cas_user.rb
+++ b/app/models/cas_user.rb
@@ -10,44 +10,32 @@ class CasUser < ApplicationRecord
   validates :name, presence: true
 
   def self.find_or_create_from_auth_hash(auth)
-    ldap_attrs = ldap_attributes(auth[:uid])
+    ldap_user_attributes = LdapUserAttributes.create(auth[:uid])
+    ldap_name = ldap_user_attributes.name
+    ldap_user_type = ldap_user_attributes.user_type
+
     where(cas_directory_id: auth[:uid]).first_or_initialize.tap do |user|
       user.cas_directory_id = auth[:uid]
-      update_name(user, ldap_attrs) unless user.name
-      update_user_type(user, ldap_attrs)
+      update_name(user, ldap_name) unless user.name
+      update_user_type(user, ldap_user_type)
       user.save!
     end
   end
 
   # The following methods are not intended to be called from outside this class.
-  def self.update_name(user, ldap_attrs)
-    name = ldap_attrs_value(ldap_attrs, :name)
+  def self.update_name(user, name)
     return if !name && user.name
 
     user.name = user.cas_directory_id and return unless name # rubocop:disable Style/AndOr
     user.name = name
   end
 
-  def self.update_user_type(user, ldap_attrs)
-    groups = ldap_attrs_value(ldap_attrs, :groups)
-    return if !groups && user.user_type
+  def self.update_user_type(user, user_type)
+    return if !user_type && user.user_type
 
     user.user_type = :unauthorized
-    return unless groups
+    return unless user_type
 
-    user.user_type = :user if groups.include?(GROUPER_USER_GROUP)
-    user.user_type = :admin if groups.include?(GROUPER_ADMIN_GROUP)
-  end
-
-  def self.ldap_attrs_value(result, key)
-    return result[key] if result&.key?(key)
-  end
-
-  def self.ldap_attributes(uid)
-    filter = Net::LDAP::Filter.eq('uid', uid)
-    first_entry = LDAP.search(base: LDAP_BASE, filter: filter, attributes: LDAP_ATTRIBUTES).first
-    return unless first_entry
-
-    { name: first_entry[LDAP_NAME_ATTR].first, groups: first_entry[LDAP_GROUPS_ATTR] }
+    user.user_type = user_type
   end
 end

--- a/app/models/ldap_user_attributes.rb
+++ b/app/models/ldap_user_attributes.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# Retrives user attributes from LDAP
+class LdapUserAttributes
+  attr_reader :name, :user_type
+
+  private_class_method :new
+
+  def initialize(name, user_type)
+    @name = name
+    @user_type = user_type
+  end
+
+  # Constructs a new instance from the CAS directory id,
+  # using LDAP.
+  #
+  # This method requires an LDAP server connection. Consider using
+  # LdapUserAttributes.create(name, groups) for testing.
+  #
+  # @param cas_directory_id the CAS directory id for the user.
+  # @return the LdapUserAttributes object
+  def self.create(cas_directory_id)
+    @cas_directory_id = cas_directory_id
+
+    filter = Net::LDAP::Filter.eq('uid', cas_directory_id)
+    first_entry = LDAP.search(base: LDAP_BASE, filter: filter, attributes: LDAP_ATTRIBUTES)&.first
+    return unless first_entry
+
+    name = first_entry[LDAP_NAME_ATTR].first
+    groups = first_entry[LDAP_GROUPS_ATTR]
+    user_type = user_type_from_groups(groups)
+    new(name, user_type)
+  end
+
+  # Returns a user type, based on the given list of Grouper groups
+  #
+  # @param groups [Array<String>] the Grouper groups the user is a member of
+  # @return the user type of the user. See CasUser.user_type enumeration
+  def self.user_type_from_groups(groups)
+    if groups
+      return :admin if groups.include?(GROUPER_ADMIN_GROUP)
+      return :user if groups.include?(GROUPER_USER_GROUP)
+    end
+    :unauthorized
+  end
+end

--- a/config/initializers/ldap.rb
+++ b/config/initializers/ldap.rb
@@ -11,6 +11,7 @@ LDAP_ATTRIBUTES = [LDAP_NAME_ATTR,LDAP_GROUPS_ATTR]
 LDAP_BASE = LDAP_CONFIG['base']
 GROUPER_ADMIN_GROUP = LDAP_CONFIG['grouper_admin_group']
 GROUPER_USER_GROUP = LDAP_CONFIG['grouper_user_group']
+LDAP_OVERRIDE = LDAP_CONFIG['ldap_override']
 
 # Initialize LDAP object
 LDAP = Net::LDAP.new

--- a/config/ldap.yml
+++ b/config/ldap.yml
@@ -13,6 +13,8 @@ default: &default
 
 development:
   <<: *default
+  # If set, skip LDAP search, and use LDAP_OVERRIDE as the user type
+  ldap_override: <%= ENV['LDAP_OVERRIDE'] %>
 
 vagrant:
   <<: *default

--- a/test/integration/cas_authorization_test.rb
+++ b/test/integration/cas_authorization_test.rb
@@ -15,8 +15,9 @@ class CasAuthorizationTest < ActionDispatch::IntegrationTest
   end
 
   # LDAP call will return the given CAS user ldap_attrs map
-  def stub_ldap_response(ldap_attrs)
-    expect(CasUser).to receive(:ldap_attributes).and_return(ldap_attrs)
+  def stub_ldap_response(name:, groups:)
+    user_type = LdapUserAttributes.user_type_from_groups(groups)
+    expect(LdapUserAttributes).to receive(:create).and_return(LdapUserAttributes.send(:new, name, user_type))
   end
 
   test 'existing cas_user can access application' do

--- a/test/models/ldap_user_attributes_test.rb
+++ b/test/models/ldap_user_attributes_test.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class LdapUserAttributesTest < ActiveSupport::TestCase
+  test 'Grouper groups to user type conversion' do
+    assert_equal :unauthorized, LdapUserAttributes.user_type_from_groups(nil)
+    assert_equal :unauthorized, LdapUserAttributes.user_type_from_groups([])
+    assert_equal :unauthorized, LdapUserAttributes.user_type_from_groups(['SOME_OTHER_GROUP'])
+
+    assert_equal :user, LdapUserAttributes.user_type_from_groups([GROUPER_USER_GROUP])
+    assert_equal :user, LdapUserAttributes.user_type_from_groups(['SOME_OTHER_GROUP', GROUPER_USER_GROUP])
+    assert_equal :user, LdapUserAttributes.user_type_from_groups([GROUPER_USER_GROUP, 'SOME_OTHER_GROUP'])
+
+    assert_equal :admin, LdapUserAttributes.user_type_from_groups([GROUPER_ADMIN_GROUP])
+    assert_equal :admin, LdapUserAttributes.user_type_from_groups([GROUPER_ADMIN_GROUP, 'SOME_OTHER_GROUP'])
+    assert_equal :admin, LdapUserAttributes.user_type_from_groups(['SOME_OTHER_GROUP', GROUPER_ADMIN_GROUP])
+    assert_equal :admin, LdapUserAttributes.user_type_from_groups([GROUPER_ADMIN_GROUP, GROUPER_USER_GROUP])
+    assert_equal :admin, LdapUserAttributes.user_type_from_groups([GROUPER_USER_GROUP, GROUPER_ADMIN_GROUP])
+    assert_equal :admin, LdapUserAttributes.user_type_from_groups(
+      ['SOME_OTHER_GROUP', GROUPER_USER_GROUP, GROUPER_ADMIN_GROUP]
+    )
+    assert_equal :admin, LdapUserAttributes.user_type_from_groups(
+      [GROUPER_USER_GROUP, GROUPER_ADMIN_GROUP, 'SOME_OTHER_GROUP']
+    )
+  end
+
+  test 'Creation from LDAP with valid result' do
+    ldap_entry = Net::LDAP::Entry.new
+    ldap_entry[LDAP_NAME_ATTR] = Faker::Name.name
+    ldap_entry[LDAP_GROUPS_ATTR] = [GROUPER_USER_GROUP, GROUPER_ADMIN_GROUP]
+
+    LDAP.stub :search, [ldap_entry] do
+      ldap_user_attributes = LdapUserAttributes.create('foo')
+      assert_equal :admin, ldap_user_attributes.user_type
+    end
+  end
+
+  test 'Creation from LDAP with nil result' do
+    LDAP.stub :search, nil do
+      ldap_user_attributes = LdapUserAttributes.create('foo')
+      assert_nil ldap_user_attributes
+    end
+  end
+
+  test 'Creation from LDAP with empty result' do
+    LDAP.stub :search, [] do
+      ldap_user_attributes = LdapUserAttributes.create('foo')
+      assert_nil ldap_user_attributes
+    end
+  end
+
+  test 'Creation from LDAP with missing attributes' do
+    ldap_entry = Net::LDAP::Entry.new
+    ldap_entry['unexpected_attribute1'] = Faker::Name.name
+    ldap_entry['unexpected_attribute2'] = [GROUPER_USER_GROUP, GROUPER_ADMIN_GROUP]
+
+    LDAP.stub :search, [ldap_entry] do
+      ldap_user_attributes = LdapUserAttributes.create('foo')
+      assert_nil ldap_user_attributes.name
+      assert_equal :unauthorized, ldap_user_attributes.user_type
+    end
+  end
+end


### PR DESCRIPTION
Added LDAP_OVERRIDE environment variable to skip LDAP searches in the development environment, and use the value of the variable as the user type.
The name of the user will be the cas_directory_id the user logged in with.

Also refactored LDAP-related code out of CasUser class and into LdapUserAttributes.

https://issues.umd.edu/browse/LIBHYDRA-190