### PR TITLE
LIBHYDRA-209. Only allow exportable items to be selected.

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -37,7 +37,8 @@ class BookmarksController < CatalogController
     search_params = current_search_session.query_params
     return redirect_back_to_catalog(params, search_params) unless current_user.bookmarks.count < 1000
 
-    search_params['rows'] = params[:result_count]
+    search_params[:rows] = params[:result_count]
+    search_params[:exportable_only] = true
     (@response, @document_list) = search_results(search_params)
     document_ids = @document_list.map(&:id)
     selected_ids = current_user.bookmarks.map(&:document_id)
@@ -49,8 +50,10 @@ class BookmarksController < CatalogController
       select_ids.each do |id|
         current_user.bookmarks.create(document_id: id, document_type: blacklight_config.document_model.to_s)
       end
-      flash[:notice] = I18n.t(:items_selected, selected_count: select_ids.length)
+      count = select_ids.length
+      flash[:notice] = I18n.t(:items_selected, selected_count: count, items: count == 1 ? 'item' : 'items')
     end
+    search_params.delete :exportable_only
     redirect_back_to_catalog(params, search_params)
   end
 

--- a/app/models/export_job.rb
+++ b/app/models/export_job.rb
@@ -25,6 +25,10 @@ class ExportJob < ApplicationRecord
 
   STATUSES = [IN_PROGRESS, READY, FAILED].freeze
 
+  def self.exportable_types
+    %w[Image Issue Letter]
+  end
+
   def download_file
     response = HTTP.get(download_url, ssl_context: SSL_CONTEXT)
     mime_type = response.content_type.mime_type

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -3,12 +3,18 @@
 # Customized SearchBuilder
 class SearchBuilder < Blacklight::SearchBuilder
   include Blacklight::Solr::SearchBuilderBehavior
-  self.default_processor_chain += [:allow_annotations_if_query_non_empty]
+  self.default_processor_chain += %i[allow_annotations_if_query_non_empty exportable_only]
 
   def allow_annotations_if_query_non_empty(solr_parameters)
     return if solr_parameters[:q].blank?
 
     solr_parameters[:fq].delete('is_pcdm:true') if solr_parameters[:fq].include? 'is_pcdm:true'
     solr_parameters[:fq] << 'is_pcdm:true OR rdf_type:oa\:Annotation'
+  end
+
+  def exportable_only(solr_parameters)
+    return unless blacklight_params[:exportable_only]
+
+    solr_parameters[:fq] << ExportJob.exportable_types.map { |type| "component:#{type}" }.join(' OR ')
   end
 end

--- a/app/views/catalog/_select_box.erb
+++ b/app/views/catalog/_select_box.erb
@@ -5,21 +5,23 @@
   # but it was simpler to leave them seperate instead of DRYing them, got confusing trying that.
   # the data-doc-id attribute is used by our JS that converts to a checkbox/label.
   -%>
-  <div class="select-box">
-    <% unless bookmarked? document %>
+  <% if ExportJob.exportable_types.include? document._source[:component] %>
+    <div class="select-box">
+      <% unless bookmarked? document %>
 
         <%= form_tag( bookmark_path( document ), :method => :put, :class => "bookmark_toggle", "data-doc-id" => document.id) do %>
-            <%= submit_tag(t('blacklight.bookmarks.add.button'), :id => "bookmark_toggle_#{document.id.to_s.parameterize}", :class => "compact-checkbox") %>
+          <%= submit_tag(t('blacklight.bookmarks.add.button'), :id => "bookmark_toggle_#{document.id.to_s.parameterize}", :class => "compact-checkbox") %>
         <% end %>
 
-    <% else %>
+      <% else %>
 
         <%= form_tag( bookmark_path( document ), :method => :delete, :class => "bookmark_toggle", "data-doc-id" => document.id) do %>
-            <%= submit_tag(t('blacklight.bookmarks.remove.button'), :id => "bookmark_toggle_#{document.id.to_s.parameterize}", :class => "compact-checkbox") %>
+          <%= submit_tag(t('blacklight.bookmarks.remove.button'), :id => "bookmark_toggle_#{document.id.to_s.parameterize}", :class => "compact-checkbox") %>
         <% end %>
 
-    <% end %>
-  </div>
+      <% end %>
+    </div>
+  <% end %>
 <% else %>
   &nbsp;
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,11 +33,11 @@ en:
   hello: 'Hello world'
   solr_is_down: 'Unable to connect to Solr index. Search functionality is unavailable at this time.'
   active_mq_is_down: 'Unable to connect to Active MQ. Export functionality is unavailable at this time.'
-  needs_selected_items: 'To create a export job, you need to select items first!'
-  already_selected: 'All items from this search are already selected!'
-  items_selected: '%{selected_count} item(s) from this search are added to your selected items list!'
-  max_limit: 'Maximum overall selection limit is %{limit}!'
-  selected_items_changed: 'Selected items has changed! Please review!'
+  needs_selected_items: 'To create a export job, you must select items first.'
+  already_selected: 'All exportable items from this search are already selected.'
+  items_selected: 'Added %{selected_count} exportable %{items} from this search to your selected items list.'
+  max_limit: 'Maximum overall selection limit is %{limit}.'
+  selected_items_changed: 'Selected items has changed. Please review.'
   activerecord:
     models:
       download_url: Download URL


### PR DESCRIPTION
* Remove checkbox from non-exportable content models
* The "select all in the search" function adds a filter query to only return exportable types

https://issues.umd.edu/browse/LIBHYDRA-209