### PR TITLE
LIBHYDRA-226. Add uniqueness constraints on identifiers.

### DIFF
--- a/app/models/individual.rb
+++ b/app/models/individual.rb
@@ -2,7 +2,15 @@
 
 # An individual entity in a vocabulary.
 class Individual < ApplicationRecord
-  validates :identifier, presence: true, format: { with: /\A[a-zA-Z0-9][a-zA-Z0-9_-]*\z/ }
+  validates :identifier,
+            presence: true,
+            format: { with: /\A[a-zA-Z0-9][a-zA-Z0-9_-]*\z/ },
+            uniqueness: {
+              scope: :vocabulary,
+              message: lambda do |object, data|
+                "\"#{data[:value]}\" is already used in the #{object.vocabulary.identifier} vocabulary"
+              end
+            }
   validates :label, presence: true
 
   belongs_to :vocabulary

--- a/app/models/type.rb
+++ b/app/models/type.rb
@@ -2,7 +2,15 @@
 
 # A type (RDF class) entity in a vocabulary
 class Type < ApplicationRecord
-  validates :identifier, presence: true, format: { with: /\A[A-Z][a-zA-Z0-9_-]*\z/ }
+  validates :identifier,
+            presence: true,
+            format: { with: /\A[A-Z][a-zA-Z0-9_-]*\z/ },
+            uniqueness: {
+              scope: :vocabulary,
+              message: lambda do |object, data|
+                "\"#{data[:value]}\" is already used in the #{object.vocabulary.identifier} vocabulary"
+              end
+            }
   belongs_to :vocabulary
 
   def uri

--- a/app/models/vocabulary.rb
+++ b/app/models/vocabulary.rb
@@ -2,7 +2,14 @@
 
 # A controlled vocabulary that can contain types and individuals.
 class Vocabulary < ApplicationRecord
-  validates :identifier, presence: true, format: { with: /\A[a-z][a-zA-Z0-9_-]*\z/ }
+  validates :identifier,
+            presence: true,
+            format: { with: /\A[a-z][a-zA-Z0-9_-]*\z/ },
+            uniqueness: {
+              message: lambda do |_object, data|
+                "\"#{data[:value]}\" is already used by another vocabulary"
+              end
+            }
 
   has_many :types, dependent: :destroy
   has_many :individuals, dependent: :destroy

--- a/test/models/individual_test.rb
+++ b/test/models/individual_test.rb
@@ -3,7 +3,14 @@
 require 'test_helper'
 
 class IndividualTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test 'identifier must be unique within vocabulary' do
+    v1 = Vocabulary.new(identifier: 'vocab1')
+    v2 = Vocabulary.new(identifier: 'vocab2')
+    i1 = Individual.new(identifier: 'foo', label: 'Foo', vocabulary: v1)
+    assert i1.save
+    i2 = Individual.new(identifier: 'foo', label: 'Foo Number 2', vocabulary: v1)
+    assert_not i2.save
+    i3 = Individual.new(identifier: 'foo', label: 'Foo', vocabulary: v2)
+    assert i3.save
+  end
 end

--- a/test/models/type_test.rb
+++ b/test/models/type_test.rb
@@ -3,7 +3,14 @@
 require 'test_helper'
 
 class TypeTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test 'identifier must be unique within vocabulary' do
+    v1 = Vocabulary.new(identifier: 'vocab1')
+    v2 = Vocabulary.new(identifier: 'vocab2')
+    t1 = Type.new(identifier: 'Foo', vocabulary: v1)
+    assert t1.save
+    t2 = Type.new(identifier: 'Foo', vocabulary: v1)
+    assert_not t2.save
+    t3 = Type.new(identifier: 'Foo', vocabulary: v2)
+    assert t3.save
+  end
 end

--- a/test/models/vocabulary_test.rb
+++ b/test/models/vocabulary_test.rb
@@ -3,7 +3,12 @@
 require 'test_helper'
 
 class VocabularyTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test 'identifier must be unique' do
+    v1 = Vocabulary.new(identifier: 'foo')
+    assert v1.save
+    v2 = Vocabulary.new(identifier: 'foo')
+    assert_not v2.save
+    v3 = Vocabulary.new(identifier: 'bar')
+    assert v3.save
+  end
 end


### PR DESCRIPTION
Vocabulary identifiers must be globally unique. Type and individual identifiers must be unique within their vocabulary.

https://issues.umd.edu/browse/LIBHYDRA-226