### PR TITLE
LIBHYDRA-234. Bootstrap GUI updates to Vocabulary/Individual/Type pages

### DIFF
--- a/app/views/individuals/_form.html.erb
+++ b/app/views/individuals/_form.html.erb
@@ -11,19 +11,32 @@
     </div>
   <% end %>
 
-  <%= form.label :label %>
-  <%= form.text_field :label %>
+  <div class="form-inline">
+    <div class="form-group">
+      <%= form.label :label %>
+      <%= form.text_field :label, class: "form-control" %>
+    </div>
 
-  <%= form.label :vocabulary_id %>
-  <%= form.collection_select :vocabulary_id, Vocabulary.all, :id, :identifier %>
+    <div class="form-group">
+      <%= form.label :vocabulary_id %>
+      <%= form.collection_select :vocabulary_id, Vocabulary.all, :id, :identifier, {}, { class: "form-control" } %>
+    </div>
 
-  <%= form.label :identifier %>
-  <%= form.text_field :identifier %>
+    <div class="form-group">
+      <%= form.label :identifier %>
+      <%= form.text_field :identifier, class: "form-control" %>
+    </div>
 
-  <%= form.label :same_as %>
-  <%= form.text_field :same_as %>
-
-  <div class="actions">
-    <%= form.submit %>
+    <div class="form-group">
+      <%= form.label :same_as %>
+      <%= form.text_field :same_as, class: "form-control" %>
+    </div>
   </div>
+
+  <div class="actions" style="margin: 10px 0px;">
+    <div class="form-group">
+      <%= form.submit class: "btn btn-success" %>
+    </div>
+  </div>
+
 <% end %>

--- a/app/views/individuals/edit.html.erb
+++ b/app/views/individuals/edit.html.erb
@@ -3,4 +3,4 @@
 <%= render 'form', individual: @individual %>
 
 <%= link_to 'Show', @individual %> |
-<%= link_to 'Back', individuals_path %>
+<%= link_to 'Cancel', individuals_path %>

--- a/app/views/individuals/new.html.erb
+++ b/app/views/individuals/new.html.erb
@@ -2,4 +2,4 @@
 
 <%= render 'form', individual: @individual %>
 
-<%= link_to 'Back', individuals_path %>
+<%= link_to 'Cancel', individuals_path %>

--- a/app/views/individuals/show.html.erb
+++ b/app/views/individuals/show.html.erb
@@ -17,5 +17,8 @@
   <%= link_to @individual.vocabulary.identifier, @individual.vocabulary %>
 </div>
 
-<%= link_to 'Edit', edit_individual_path(@individual) %> |
-<%= link_to 'Back', individuals_path %>
+<%= link_to 'Edit', edit_individual_path(@individual), class: 'btn btn-success' %>
+
+<div>
+  <%= link_to "All #{ActiveSupport::Inflector.pluralize(t('activerecord.models.individual'))}", individuals_path %>
+<div>

--- a/app/views/types/_form.html.erb
+++ b/app/views/types/_form.html.erb
@@ -11,12 +11,19 @@
     </div>
   <% end %>
 
-  <%= form.label :identifier %>
-  <%= form.text_field :identifier %>
-  <%= form.label :vocabulary_id %>
-  <%= form.collection_select :vocabulary_id, Vocabulary.all, :id, :identifier %>
+  <div class="form-inline">
+    <div class="form-group">
+      <%= form.label :identifier %>
+      <%= form.text_field :identifier, class: "form-control" %>
+    </div>
 
-  <div class="actions">
-    <%= form.submit %>
+    <div class="form-group">
+      <%= form.label :vocabulary_id %>
+      <%= form.collection_select :vocabulary_id, Vocabulary.all, :id, :identifier, {}, { class: "form-control" } %>
+    </div>
+  </div>
+
+  <div class="actions" style="margin: 10px 0px;">
+    <%= form.submit class: "btn btn-success" %>
   </div>
 <% end %>

--- a/app/views/types/edit.html.erb
+++ b/app/views/types/edit.html.erb
@@ -3,4 +3,4 @@
 <%= render 'form', type: @type %>
 
 <%= link_to 'Show', @type %> |
-<%= link_to 'Back', types_path %>
+<%= link_to 'Cancel', types_path %>

--- a/app/views/types/new.html.erb
+++ b/app/views/types/new.html.erb
@@ -2,4 +2,4 @@
 
 <%= render 'form', type: @type %>
 
-<%= link_to 'Back', types_path %>
+<%= link_to 'Cancel', types_path %>

--- a/app/views/types/show.html.erb
+++ b/app/views/types/show.html.erb
@@ -9,5 +9,7 @@
   <%= link_to @type.vocabulary.identifier, @type.vocabulary %>
 </div>
 
-<%= link_to 'Edit', edit_type_path(@type) %> |
-<%= link_to 'Back', types_path %>
+<%= link_to 'Edit', edit_type_path(@type), class: 'btn btn-success' %>
+<div>
+  <%= link_to "All #{ActiveSupport::Inflector.pluralize(t('activerecord.models.type'))}", types_path %>
+<div>

--- a/app/views/vocabularies/_form.html.erb
+++ b/app/views/vocabularies/_form.html.erb
@@ -11,12 +11,22 @@
     </div>
   <% end %>
 
-  <%= form.label :identifier%>
-  <%= form.text_field :identifier %>
-  <%= form.label :description %>
-  <%= form.text_field :description %>
+  <div class="form-inline">
+    <div class="form-group">
+      <%= form.label :identifier %>
+      <%= form.text_field :identifier, class: "form-control" %>
+    </div>
 
-  <div class="actions">
-    <%= form.submit %>
+    <div class="form-group">
+      <%= form.label :description %>
+      <%= form.text_field :description, class: "form-control" %>
+    </div>
   </div>
+
+  <div class="actions" style="margin: 10px 0px;">
+    <div class="form-group">
+      <%= form.submit class: "btn btn-success" %>
+    </div>
+  </div>
+
 <% end %>

--- a/app/views/vocabularies/edit.html.erb
+++ b/app/views/vocabularies/edit.html.erb
@@ -3,4 +3,4 @@
 <%= render 'form', vocabulary: @vocabulary %>
 
 <%= link_to 'Show', @vocabulary %> |
-<%= link_to 'Back', vocabularies_path %>
+<%= link_to 'Cancel', vocabularies_path %>

--- a/app/views/vocabularies/index.html.erb
+++ b/app/views/vocabularies/index.html.erb
@@ -18,8 +18,8 @@
         <td><%= vocabulary.uri %></td>
         <td><%= vocabulary.types.count %></td>
         <td><%= vocabulary.individuals.count %></td>
-        <td><%= link_to 'Edit', edit_vocabulary_path(vocabulary) %></td>
-        <td><%= link_to 'Destroy', vocabulary, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <td><%= link_to 'Edit', edit_vocabulary_path(vocabulary), class: 'btn btn-sm btn-success' %></td>
+        <td><%= link_to 'Delete', vocabulary, method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-sm btn-danger' %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/vocabularies/new.html.erb
+++ b/app/views/vocabularies/new.html.erb
@@ -2,4 +2,4 @@
 
 <%= render 'form', vocabulary: @vocabulary %>
 
-<%= link_to 'Back', vocabularies_path %>
+<%= link_to 'Cancel', vocabularies_path %>

--- a/app/views/vocabularies/show.html.erb
+++ b/app/views/vocabularies/show.html.erb
@@ -23,7 +23,7 @@
     <li><%= link_to type.identifier, type %></li>
   <% end %>
 </ul>
-<%= link_to "New #{t 'activerecord.models.type'}", new_type_path(vocabulary: @vocabulary), class: 'btn btn-sm btn-info' %>
+<%= link_to "New #{t 'activerecord.models.type'}", new_type_path(vocabulary: @vocabulary), class: 'btn btn-sm btn-success' %>
 
 <h2>
   <%= ActiveSupport::Inflector.pluralize(t('activerecord.models.individual')) %>
@@ -34,7 +34,7 @@
     <li><%= link_to "#{individual.label} (#{individual.identifier})", individual %></li>
   <% end %>
 </ul>
-<%= link_to "New #{t 'activerecord.models.individual'}", new_individual_path(vocabulary: @vocabulary), class: 'btn btn-sm btn-info' %>
+<%= link_to "New #{t 'activerecord.models.individual'}", new_individual_path(vocabulary: @vocabulary), class: 'btn btn-sm btn-success' %>
 
 <div>
   <%= link_to "All #{ActiveSupport::Inflector.pluralize(t('activerecord.models.vocabulary'))}", vocabularies_path %>


### PR DESCRIPTION
Updated the index, show, new, and edit pages of the
Vocabulary, Individual, Type models.

Among the changes:

* Changed "Back" link to "Cancel"
* Changed "Destroy" button to "Delete"
* Made "New" button color consistent across pages

https://issues.umd.edu/browse/LIBHYDRA-234