### PR TITLE
LIBHYDRA-239. Modified controllers to use I18n in flash notices

### DIFF
--- a/app/controllers/individuals_controller.rb
+++ b/app/controllers/individuals_controller.rb
@@ -33,7 +33,7 @@ class IndividualsController < ApplicationController
       if @individual.save
         format.html do
           redirect_to @individual.vocabulary,
-                      notice: "Individual #{@individual.label} was successfully created."
+                      notice: "#{t('activerecord.models.individual')} #{@individual.label} was successfully created."
         end
         format.json { render :show, status: :created, location: @individual }
       else
@@ -45,10 +45,12 @@ class IndividualsController < ApplicationController
 
   # PATCH/PUT /individuals/1
   # PATCH/PUT /individuals/1.json
-  def update
+  def update # rubocop:disable Metrics/MethodLength
     respond_to do |format|
       if @individual.update(individual_params)
-        format.html { redirect_to @individual, notice: 'Individual was successfully updated.' }
+        format.html do
+          redirect_to @individual, notice: "#{t('activerecord.models.individual')} was successfully updated."
+        end
         format.json { render :show, status: :ok, location: @individual }
       else
         format.html { render :edit }
@@ -62,7 +64,9 @@ class IndividualsController < ApplicationController
   def destroy
     @individual.destroy
     respond_to do |format|
-      format.html { redirect_to individuals_url, notice: 'Individual was successfully destroyed.' }
+      format.html do
+        redirect_to individuals_url, notice: "#{t('activerecord.models.individual')} was successfully deleted."
+      end
       format.json { head :no_content }
     end
   end

--- a/app/controllers/types_controller.rb
+++ b/app/controllers/types_controller.rb
@@ -26,12 +26,15 @@ class TypesController < ApplicationController
 
   # POST /types
   # POST /types.json
-  def create # rubocop:disable Metrics/AbcSize
+  def create # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     @type = Type.new(type_params)
 
     respond_to do |format|
       if @type.save
-        format.html { redirect_to @type.vocabulary, notice: "Type #{@type.identifier} was successfully created." }
+        format.html do
+          redirect_to @type.vocabulary,
+                      notice: "#{t('activerecord.models.type')} #{@type.identifier} was successfully created."
+        end
         format.json { render :show, status: :created, location: @type }
       else
         format.html { render :new }
@@ -45,7 +48,7 @@ class TypesController < ApplicationController
   def update
     respond_to do |format|
       if @type.update(type_params)
-        format.html { redirect_to @type, notice: 'Type was successfully updated.' }
+        format.html { redirect_to @type, notice: "#{t('activerecord.models.type')} was successfully updated." }
         format.json { render :show, status: :ok, location: @type }
       else
         format.html { render :edit }
@@ -59,7 +62,7 @@ class TypesController < ApplicationController
   def destroy
     @type.destroy
     respond_to do |format|
-      format.html { redirect_to types_url, notice: 'Type was successfully destroyed.' }
+      format.html { redirect_to types_url, notice: "#{t('activerecord.models.type')} was successfully deleted." }
       format.json { head :no_content }
     end
   end

--- a/app/controllers/vocabularies_controller.rb
+++ b/app/controllers/vocabularies_controller.rb
@@ -35,12 +35,14 @@ class VocabulariesController < ApplicationController
 
   # POST /vocabularies
   # POST /vocabularies.json
-  def create
+  def create # rubocop:disable Metrics/MethodLength
     @vocabulary = Vocabulary.new(vocabulary_params)
 
     respond_to do |format|
       if @vocabulary.save
-        format.html { redirect_to @vocabulary, notice: 'Vocabulary was successfully created.' }
+        format.html do
+          redirect_to @vocabulary, notice: "#{t('activerecord.models.vocabulary')} was successfully created."
+        end
         format.json { render :show, status: :created, location: @vocabulary }
       else
         format.html { render :new }
@@ -51,10 +53,12 @@ class VocabulariesController < ApplicationController
 
   # PATCH/PUT /vocabularies/1
   # PATCH/PUT /vocabularies/1.json
-  def update
+  def update # rubocop:disable Metrics/MethodLength
     respond_to do |format|
       if @vocabulary.update(vocabulary_params)
-        format.html { redirect_to @vocabulary, notice: 'Vocabulary was successfully updated.' }
+        format.html do
+          redirect_to @vocabulary, notice: "#{t('activerecord.models.vocabulary')} was successfully updated."
+        end
         format.json { render :show, status: :ok, location: @vocabulary }
       else
         format.html { render :edit }
@@ -68,7 +72,9 @@ class VocabulariesController < ApplicationController
   def destroy
     @vocabulary.destroy
     respond_to do |format|
-      format.html { redirect_to vocabularies_url, notice: 'Vocabulary was successfully destroyed.' }
+      format.html do
+        redirect_to vocabularies_url, notice: "#{t('activerecord.models.vocabulary')} was successfully deleted."
+      end
       format.json { head :no_content }
     end
   end


### PR DESCRIPTION
Modified the Vocabularies, Individuals, and Types controllers to use
I18n value in flash notices for consistency in the GUI.

https://issues.umd.edu/browse/LIBHYDRA-239