### PR TITLE
LIBHYDRA-237. Display a source next to the label for terms.

### DIFF
--- a/app/models/individual.rb
+++ b/app/models/individual.rb
@@ -18,4 +18,13 @@ class Individual < ApplicationRecord
   def uri
     vocabulary.uri + identifier
   end
+
+  def source
+    return nil if same_as.empty?
+
+    SAME_AS_ABBREVIATIONS.each do |prefix, abbreviation|
+      return abbreviation if same_as.starts_with? prefix
+    end
+    nil
+  end
 end

--- a/app/views/individuals/show.html.erb
+++ b/app/views/individuals/show.html.erb
@@ -7,6 +7,7 @@
 <div>
   <%= label :individual, :label %>
   <%= @individual.label %>
+  <%= "(#{@individual.source})" if @individual.source.present? %>
 </div>
 <div>
   <%= label :individual, :same_as %>
@@ -21,4 +22,4 @@
 
 <div>
   <%= link_to "All #{ActiveSupport::Inflector.pluralize(t('activerecord.models.individual'))}", individuals_path %>
-<div>
+</div>

--- a/config/initializers/same_as_abbreviations.rb
+++ b/config/initializers/same_as_abbreviations.rb
@@ -1,0 +1,1 @@
+SAME_AS_ABBREVIATIONS = YAML.load_file 'config/same_as_abbreviations.yml'

--- a/config/same_as_abbreviations.yml
+++ b/config/same_as_abbreviations.yml
@@ -1,0 +1,9 @@
+http://hdl.handle.net/1903.1/: ArchivesSpace
+https://id.loc.gov/authorities/names/: LCNAF
+https://id.loc.gov/authorities/genreForms/: LCGFT
+https://id.loc.gov/authorities/subjects/: LCSH
+http://vocab.getty.edu/page/aat/: AAT
+http://vocab.getty.edu/aat/: AAT
+http://sws.geonames.org/: GeoNames
+http://viaf.org/viaf/: VIAF
+http://id.loc.gov/vocabulary/graphicMaterials/: TGM


### PR DESCRIPTION
The lookup table is in config/same_as_abbreviations.yml, and is read at startup.

https://issues.umd.edu/browse/LIBHYDRA-237