### PR TITLE
LIBHYDRA-235. Added tooltip text to "Identifier" and "URI" form labels

### DIFF
--- a/app/assets/stylesheets/custom.css
+++ b/app/assets/stylesheets/custom.css
@@ -159,3 +159,53 @@ input {
 .panel-vocabulary .h2 {
   margin: 5px;
 }
+
+ /* Tooltip from https://www.w3schools.com/howto/howto_css_tooltip.asp */
+ /* Renamed to "umd_tooltip" to avoid conflict with "tooltip" definitions in other CSS includes */
+ /* Tooltip container */
+ .umd_tooltip {
+  position: relative;
+  display: inline-block;
+  border-bottom: 1px dotted black; /* If you want dots under the hoverable text */
+  opacity: 1;
+}
+
+/* Tooltip text */
+.umd_tooltip .umd_tooltiptext {
+  visibility: hidden;
+  width: 150px;
+  background-color: #555;
+  color: #fff;
+  text-align: center;
+  padding: 5px 0;
+  border-radius: 6px;
+
+  /* Position the tooltip text */
+  position: absolute;
+  z-index: 1;
+  bottom: 125%;
+  left: 0%;
+  margin-left: 0px;
+
+  /* Fade in tooltip */
+  opacity: 0;
+  transition: opacity 0.3s;
+}
+
+/* Tooltip arrow */
+.umd_tooltip .umd_tooltiptext::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  margin-left: -5px;
+  border-width: 5px;
+  border-style: solid;
+  border-color: #555 transparent transparent transparent;
+}
+
+/* Show the tooltip text when you mouse over the tooltip container */
+.umd_tooltip:hover .umd_tooltiptext {
+  visibility: visible;
+  opacity: 1;
+}

--- a/app/views/individuals/_form.html.erb
+++ b/app/views/individuals/_form.html.erb
@@ -23,12 +23,18 @@
     </div>
 
     <div class="form-group">
-      <%= form.label :identifier %>
+      <%= form.label :identifier, class: "umd_tooltip" do %>
+        <%= t("activerecord.attributes.individual.identifier") %>
+        <span class="umd_tooltiptext"><%= t("tooltips.identifier") %></span>
+      <% end %>
       <%= form.text_field :identifier, class: "form-control" %>
     </div>
 
     <div class="form-group">
-      <%= form.label :same_as %>
+      <%= form.label :same_as, class: "umd_tooltip" do %>
+        <%= t("activerecord.attributes.individual.same_as") %>
+        <span class="umd_tooltiptext"><%= t("tooltips.same_as") %></span>
+      <% end %>
       <%= form.text_field :same_as, class: "form-control" %>
     </div>
   </div>

--- a/app/views/types/_form.html.erb
+++ b/app/views/types/_form.html.erb
@@ -13,7 +13,10 @@
 
   <div class="form-inline">
     <div class="form-group">
-      <%= form.label :identifier %>
+      <%= form.label :identifier, class: "umd_tooltip" do %>
+        <%= t("activerecord.attributes.type.identifier") %>
+        <span class="umd_tooltiptext"><%= t("tooltips.identifier") %></span>
+      <% end %>
       <%= form.text_field :identifier, class: "form-control" %>
     </div>
 

--- a/app/views/vocabularies/_form.html.erb
+++ b/app/views/vocabularies/_form.html.erb
@@ -13,7 +13,10 @@
 
   <div class="form-inline">
     <div class="form-group">
-      <%= form.label :identifier %>
+      <%= form.label :identifier, class: "umd_tooltip" do %>
+        <%= t("activerecord.attributes.vocabulary.identifier") %>
+        <span class="umd_tooltiptext"><%= t("tooltips.identifier") %></span>
+      <% end %>
       <%= form.text_field :identifier, class: "form-control" %>
     </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -59,3 +59,6 @@ en:
       individual: Term
       type: Class
       vocabulary: Vocabulary
+  tooltips:
+    identifier: This will be used as the local id and populate the URI of the local vocabulary term.
+    same_as: This should be a full URI to an external vocabulary such as LC Genre/Form Terms, AAT, LCSH


### PR DESCRIPTION
On the forms, added tooltip text to the "Identifier" and "URI" labels
that appear when the mouse is hovered over the labels. The labels
display with a dotted underline to indicate that a tooltip is
available.

https://issues.umd.edu/browse/LIBHYDRA-235