### PR TITLE
LIBHYDRA-240. Allow retrieval of a vocabulary by its identifier.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,9 @@
 
 class ApplicationController < ActionController::Base
   include CasHelper
+
+  rescue_from ActiveRecord::RecordNotFound, with: :not_found
+
   before_action :authenticate
 
   # Adds a few additional behaviors into the application controller
@@ -11,7 +14,7 @@ class ApplicationController < ActionController::Base
 
   # Causes a "404 - Not Found" error page to be displayed.
   def not_found
-    raise ActionController::RoutingError, 'Not Found'
+    render file: Rails.root.join('public', '404.html'), status: :not_found
   end
 
   def impersonating?

--- a/app/controllers/download_urls_controller.rb
+++ b/app/controllers/download_urls_controller.rb
@@ -21,7 +21,7 @@ class DownloadUrlsController < ApplicationController
   # GET /download_urls/generate/:document_url
   def generate_download_url
     solr_document = find_solr_document(params['document_url'])
-    not_found unless solr_document
+    not_found && return unless solr_document
     @download_url = DownloadUrl.new
     @download_url.url = solr_document[:id]
     @download_url.title = create_default_title(solr_document)
@@ -30,7 +30,7 @@ class DownloadUrlsController < ApplicationController
   # POST /download_urls/create/:document_url
   def create_download_url # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     solr_document = find_solr_document(params['document_url'])
-    not_found unless solr_document
+    not_found && return unless solr_document
 
     @download_url = DownloadUrl.new(download_url_params)
     @download_url.url = solr_document[:id]

--- a/app/controllers/vocabularies_controller.rb
+++ b/app/controllers/vocabularies_controller.rb
@@ -6,7 +6,12 @@ class VocabulariesController < ApplicationController
   # GET /vocabularies
   # GET /vocabularies.json
   def index
-    @vocabularies = Vocabulary.all
+    if params[:identifier].present?
+      @vocabulary = Vocabulary.find_by! identifier: params[:identifier]
+      render :show
+    else
+      @vocabularies = Vocabulary.all
+    end
   end
 
   # GET /vocabularies/1

--- a/test/controllers/download_urls_controller_test.rb
+++ b/test/controllers/download_urls_controller_test.rb
@@ -110,19 +110,17 @@ class DownloadUrlsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
-  test 'generate_download_url should raise 404 RoutingError if document cannot be found' do
+  test 'generate_download_url should respond with 404 if document cannot be found' do
     @controller.stub(:find_solr_document, nil) do
-      assert_raises(ActionController::RoutingError) do
-        get :generate_download_url, params: { document_url: 'document does not exist' }
-      end
+      get :generate_download_url, params: { document_url: 'document does not exist' }
+      assert_response :not_found
     end
   end
 
-  test 'create_download_url should raise 404 RoutingError if document cannot be found' do
+  test 'create_download_url should respond with 404 if document cannot be found' do
     @controller.stub(:find_solr_document, nil) do
-      assert_raises(ActionController::RoutingError) do
-        get :create_download_url, params: { document_url: 'document does not exist' }
-      end
+      get :create_download_url, params: { document_url: 'document does not exist' }
+      assert_response :not_found
     end
   end
 


### PR DESCRIPTION
* If an ?identifier query param is passed to the vocabularies index controller method, search for the vocabulary by that identifier.
* Added a 404 response if a vocabulary cannot be found (by id or identifier)

https://issues.umd.edu/browse/LIBHYDRA-240