### PR TITLE
LIBHYDRA-230. Publish static RDF serialzations of vocabularies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ coverage
 
 # Ignore any SSL pem files in root
 *.pem
+
+# Ignore published vocabularies
+/public/vocabularies/

--- a/app/controllers/vocabularies_controller.rb
+++ b/app/controllers/vocabularies_controller.rb
@@ -31,11 +31,12 @@ class VocabulariesController < ApplicationController
 
   # POST /vocabularies
   # POST /vocabularies.json
-  def create # rubocop:disable Metrics/MethodLength
+  def create # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
     @vocabulary = Vocabulary.new(vocabulary_params)
 
     respond_to do |format|
       if @vocabulary.save
+        publish_rdf
         format.html do
           redirect_to @vocabulary, notice: "#{t('activerecord.models.vocabulary')} was successfully created."
         end
@@ -50,6 +51,7 @@ class VocabulariesController < ApplicationController
   # PATCH/PUT /vocabularies/1
   # PATCH/PUT /vocabularies/1.json
   def update # rubocop:disable Metrics/MethodLength
+    publish_rdf
     respond_to do |format|
       if @vocabulary.update(vocabulary_params)
         format.html do
@@ -67,6 +69,7 @@ class VocabulariesController < ApplicationController
   # DELETE /vocabularies/1.json
   def destroy
     @vocabulary.destroy
+    UnpublishVocabularyRdfJob.perform_later @vocabulary.identifier
     respond_to do |format|
       format.html do
         redirect_to vocabularies_url, notice: "#{t('activerecord.models.vocabulary')} was successfully deleted."
@@ -85,5 +88,9 @@ class VocabulariesController < ApplicationController
     # Never trust parameters from the scary internet, only allow the white list through.
     def vocabulary_params
       params.require(:vocabulary).permit(:identifier, :description)
+    end
+
+    def publish_rdf
+      PublishVocabularyRdfJob.perform_later @vocabulary, 'jsonld', 'ttl', 'ntriples'
     end
 end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class ApplicationJob < ActiveJob::Base
+  # Automatically retry jobs that encountered a deadlock
+  # retry_on ActiveRecord::Deadlocked
+
+  # Most jobs are safe to ignore if the underlying records are no longer available
+  # discard_on ActiveJob::DeserializationError
+end

--- a/app/jobs/publish_vocabulary_rdf_job.rb
+++ b/app/jobs/publish_vocabulary_rdf_job.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Publish RDF representations of a vocabulary
+class PublishVocabularyRdfJob < ApplicationJob
+  queue_as :default
+
+  def perform(vocabulary, *formats)
+    formats.each do |format|
+      vocabulary.publish_rdf format.to_sym
+    end
+  end
+end

--- a/app/jobs/unpublish_vocabulary_rdf_job.rb
+++ b/app/jobs/unpublish_vocabulary_rdf_job.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Unpublish (delete) RDF serializations of a vocabulary
+class UnpublishVocabularyRdfJob < ApplicationJob
+  queue_as :default
+
+  def perform(identifier)
+    Vocabulary.delete_published_rdf identifier
+  end
+end

--- a/test/jobs/publish_vocabulary_rdf_job_test.rb
+++ b/test/jobs/publish_vocabulary_rdf_job_test.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class PublishVocabularyRdfJobTest < ActiveJob::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/jobs/unpublish_vocabulary_rdf_job_test.rb
+++ b/test/jobs/unpublish_vocabulary_rdf_job_test.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class UnpublishVocabularyRdfJobTest < ActiveJob::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
* formats: JSON-LD, Turtle, N-Triples
* when a vocabulary is created or updated, write out the RDF to the public/vocabularies directory
* delete published files when a vocabulary is destroyed
* publish/unpublish are handled asynchronously by ActiveJobs

https://issues.umd.edu/browse/LIBHYDRA-240