### PR TITLE
LIBHYDRA-243. Separate local authority URI from published vocab URI.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,4 +45,4 @@ coverage
 *.pem
 
 # Ignore published vocabularies
-/public/vocabularies/
+/public/published_vocabularies/

--- a/app/models/vocabulary.rb
+++ b/app/models/vocabulary.rb
@@ -15,8 +15,6 @@ class Vocabulary < ApplicationRecord
     ntriples: 'nt'
   }.freeze
 
-  VOCAB_CONTEXT = 'http://vocab.lib.umd.edu/'
-
   validates :identifier,
             presence: true,
             format: { with: /\A[a-z][a-zA-Z0-9_-]*\z/ },
@@ -30,7 +28,11 @@ class Vocabulary < ApplicationRecord
   has_many :individuals, dependent: :destroy
 
   def uri
-    VOCAB_CONTEXT + identifier + '#'
+    VOCAB_CONFIG['local_authority_base_uri'] + identifier + '#'
+  end
+
+  def published_uri
+    VOCAB_CONFIG['publication_base_uri'] + identifier + '.json'
   end
 
   def term_count
@@ -47,7 +49,7 @@ class Vocabulary < ApplicationRecord
   def publish_rdf(format)
     FORMAT_EXTENSIONS.include?(format) || raise('Unrecognized format')
 
-    vocab_dir = Rails.root.join('public', 'vocabularies')
+    vocab_dir = Rails.root.join('public', 'published_vocabularies')
     FileUtils.makedirs vocab_dir
 
     extension = FORMAT_EXTENSIONS[format]
@@ -56,7 +58,7 @@ class Vocabulary < ApplicationRecord
   end
 
   def self.delete_published_rdf(identifier)
-    vocab_dir = Rails.root.join('public', 'vocabularies')
+    vocab_dir = Rails.root.join('public', 'published_vocabularies')
     Dir.glob(Rails.root.join(vocab_dir, "#{identifier}.*")).each do |file|
       FileUtils.safe_unlink file
     end

--- a/app/views/vocabularies/index.html.erb
+++ b/app/views/vocabularies/index.html.erb
@@ -5,6 +5,7 @@
     <tr>
       <th><%= t 'activerecord.attributes.vocabulary.identifier' %></th>
       <th><%= t 'activerecord.attributes.vocabulary.uri' %></th>
+      <th><%= t 'activerecord.attributes.vocabulary.published_uri' %></th>
       <th><%= ActiveSupport::Inflector.pluralize(t('activerecord.models.type')) %></th>
       <th><%= ActiveSupport::Inflector.pluralize(t('activerecord.models.individual')) %></th>
       <th colspan="2"></th>
@@ -16,6 +17,7 @@
       <tr>
         <td><%= link_to vocabulary.identifier, vocabulary %></td>
         <td><%= vocabulary.uri %></td>
+        <td><%= link_to vocabulary.published_uri, vocabulary.published_uri %></td>
         <td><%= vocabulary.types.count %></td>
         <td><%= vocabulary.individuals.count %></td>
         <td><%= link_to 'Edit', edit_vocabulary_path(vocabulary), class: 'btn btn-sm btn-success' %></td>

--- a/config/initializers/vocabularies.rb
+++ b/config/initializers/vocabularies.rb
@@ -1,0 +1,1 @@
+VOCAB_CONFIG = Archelon::Application.config_for :vocabularies

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -53,7 +53,8 @@ en:
       vocabulary:
         description: Description
         identifier: Identifier
-        uri: URI
+        uri: Local Authority URI
+        published_uri: Published URI
     models:
       download_url: Download URL
       individual: Term

--- a/config/vocabularies.yml
+++ b/config/vocabularies.yml
@@ -5,7 +5,7 @@ default: &default
 development:
   <<: *default
 
-testing:
+test:
   <<: *default
 
 production:

--- a/config/vocabularies.yml
+++ b/config/vocabularies.yml
@@ -1,0 +1,13 @@
+default: &default
+  local_authority_base_uri: http://vocab.lib.umd.edu/
+  publication_base_uri: http://localhost:3000/published_vocabularies/
+
+development:
+  <<: *default
+
+testing:
+  <<: *default
+
+production:
+  local_authority_base_uri: <%= ENV['VOCAB_LOCAL_AUTHORITY_BASE_URI'] %>
+  publication_base_uri: <%= ENV['VOCAB_PUBLICATION_BASE_URI'] %>


### PR DESCRIPTION
* serve published vocabularies using Rails for development.
* supply the configuration for production via environment variables

https://issues.umd.edu/browse/LIBHYDRA-243