### PR TITLE
LIBHYDRA-229. Support the Vocabulary Editors group.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -126,3 +126,4 @@ gem 'mechanize'
 
 gem 'rdf-turtle'
 gem 'json-ld'
+gem 'cancancan'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,6 +67,7 @@ GEM
       sassc (>= 2.0.0)
     builder (3.2.3)
     byebug (11.0.1)
+    cancancan (3.0.2)
     capybara (3.28.0)
       addressable
       mini_mime (>= 0.1.3)
@@ -388,6 +389,7 @@ DEPENDENCIES
   blacklight (~> 6.0)
   bootsnap (>= 1.1.0)
   byebug
+  cancancan
   capybara (>= 2.15)
   clipboard-rails (~> 1.7.1)
   coffee-rails (~> 4.2)

--- a/README.md
+++ b/README.md
@@ -263,8 +263,8 @@ returned from an LDAP server for that user.
 
 The local development environment (or Docker container) can be run without
 connecting to an LDAP server by setting the `LDAP_OVERRIDE` environment variable.
-The `LDAP_OVERRIDE` environment variable specifies the user type for any user
-that logs in, i.e., either "admin" or "user".
+The `LDAP_OVERRIDE` environment variable should contain a space-separated list
+of Grouper group DNs that any authenticated user should receive.
 
 The `LDAP_OVERRIDE` environment variable only works in the `development`
 Rails environment.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,10 @@ class ApplicationController < ActionController::Base
 
   rescue_from ActiveRecord::RecordNotFound, with: :not_found
 
+  rescue_from CanCan::AccessDenied do
+    render file: Rails.root.join('public', '403.html'), status: :forbidden, layout: false
+  end
+
   before_action :authenticate
 
   # Adds a few additional behaviors into the application controller

--- a/app/controllers/download_urls_controller.rb
+++ b/app/controllers/download_urls_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class DownloadUrlsController < ApplicationController
-  before_action :set_download_url, only: [:show]
+  load_and_authorize_resource
   include Blacklight::SearchHelper
 
   # GET /download_urls
@@ -99,11 +99,6 @@ class DownloadUrlsController < ApplicationController
       return solr_documents.first if solr_documents.any?
 
       nil
-    end
-
-    # Use callbacks to share common setup or constraints between actions.
-    def set_download_url
-      @download_url = DownloadUrl.find(params[:id])
     end
 
     # Never trust parameters from the scary internet, only allow the white list through.

--- a/app/controllers/export_jobs_controller.rb
+++ b/app/controllers/export_jobs_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class ExportJobsController < ApplicationController
+  before_action -> { authorize! :manage, ExportJob }
   before_action :cancel_workflow?, only: %i[create review]
   before_action :stomp_client_connected?, only: %i[new create review]
   before_action :selected_items?, only: %i[new create review]

--- a/app/controllers/individuals_controller.rb
+++ b/app/controllers/individuals_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class IndividualsController < ApplicationController
-  before_action :set_individual, only: %i[show edit update destroy]
+  load_and_authorize_resource
 
   # GET /individuals
   # GET /individuals.json
@@ -72,11 +72,6 @@ class IndividualsController < ApplicationController
   end
 
   private
-
-    # Use callbacks to share common setup or constraints between actions.
-    def set_individual
-      @individual = Individual.find(params[:id])
-    end
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def individual_params

--- a/app/controllers/types_controller.rb
+++ b/app/controllers/types_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class TypesController < ApplicationController
-  before_action :set_type, only: %i[show edit update destroy]
+  load_and_authorize_resource
 
   # GET /types
   # GET /types.json
@@ -68,11 +68,6 @@ class TypesController < ApplicationController
   end
 
   private
-
-    # Use callbacks to share common setup or constraints between actions.
-    def set_type
-      @type = Type.find(params[:id])
-    end
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def type_params

--- a/app/controllers/vocabularies_controller.rb
+++ b/app/controllers/vocabularies_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class VocabulariesController < ApplicationController
-  before_action :set_vocabulary, only: %i[show edit update destroy]
+  load_and_authorize_resource
 
   # GET /vocabularies
   # GET /vocabularies.json
@@ -84,11 +84,6 @@ class VocabulariesController < ApplicationController
   end
 
   private
-
-    # Use callbacks to share common setup or constraints between actions.
-    def set_vocabulary
-      @vocabulary = Vocabulary.find(params[:id])
-    end
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def vocabulary_params

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,7 +3,7 @@
 require 'erb'
 require 'addressable/template'
 
-module ApplicationHelper
+module ApplicationHelper # rubocop:disable Metrics/ModuleLength
   FEDORA_BASE_URL = Rails.application.config.fcrepo_base_url
   IIIF_BASE_URL = Rails.application.config.iiif_base_url
   PCDM_OBJECT = 'pcdm:Object'
@@ -124,5 +124,17 @@ module ApplicationHelper
       iiifURLPrefix: "#{IIIF_BASE_URL}manifests/",
       q: query
     ).to_s
+  end
+
+  def link_to_edit(resource)
+    return unless can? :edit, resource
+
+    link_to 'Edit', { action: :edit, id: resource }, class: 'btn btn-sm btn-success'
+  end
+
+  def link_to_delete(resource)
+    return unless can? :destroy, resource
+
+    link_to 'Delete', resource, method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-sm btn-danger'
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Define the permissions for users
+class Ability
+  include CanCan::Ability
+
+  def initialize(user)
+    if user.admin?
+      can :manage, :all
+    elsif user.user?
+      can %i[index show], :all
+      can :manage, DownloadUrl
+      can :manage, ExportJob
+      can :manage, [Vocabulary, Individual, Type] if user.in_group? :VocabularyEditors
+    end
+  end
+end

--- a/app/models/cas_user.rb
+++ b/app/models/cas_user.rb
@@ -5,6 +5,8 @@ class CasUser < ApplicationRecord
   # Connects this user object to Blacklight's Bookmarks.
   include Blacklight::User
 
+  has_and_belongs_to_many :groups # rubocop:disable Rails/HasAndBelongsToMany
+
   enum user_type: { admin: 'admin', user: 'user', unauthorized: 'unauthorized' }
   validates :cas_directory_id, presence: true, uniqueness: { case_sensitive: false }
   validates :name, presence: true
@@ -13,16 +15,25 @@ class CasUser < ApplicationRecord
     # update user info upon successful login, and return the user object
     where(cas_directory_id: auth[:uid]).first_or_initialize.tap do |user|
       user.cas_directory_id = auth[:uid]
-      # only update from LDAP if we found anything
-      if user.ldap_attributes
-        user.name = user.ldap_attributes.name || user.cas_directory_id
-        user.user_type = user.ldap_attributes.user_type
-      end
+      user.update_from_ldap
       user.save!
     end
   end
 
   def ldap_attributes
     @ldap_attributes ||= LdapUserAttributes.create(cas_directory_id)
+  end
+
+  def update_from_ldap
+    # only update from LDAP if we found anything
+    return unless ldap_attributes
+
+    self.name = ldap_attributes.name || cas_directory_id
+    self.user_type = ldap_attributes.user_type
+    self.groups = ldap_attributes.groups.map { |dn| Group.from_dn(dn) }.reject(&:nil?)
+  end
+
+  def in_group?(group_name)
+    groups.map(&:name).include? group_name.to_s
   end
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# User group
+class Group < ApplicationRecord
+  NAME_MAPPING = GROUPER_GROUPS.invert
+
+  has_and_belongs_to_many :cas_users # rubocop:disable Rails/HasAndBelongsToMany
+
+  def self.from_dn(ldap_dn)
+    return unless NAME_MAPPING.key? ldap_dn
+
+    find_or_create_by name: NAME_MAPPING[ldap_dn]
+  end
+end

--- a/app/models/ldap_user_attributes.rb
+++ b/app/models/ldap_user_attributes.rb
@@ -2,13 +2,11 @@
 
 # Retrieves user attributes from LDAP
 class LdapUserAttributes
-  attr_reader :name, :user_type
+  attr_reader :name, :groups
 
-  private_class_method :new
-
-  def initialize(name, user_type)
+  def initialize(name, groups)
     @name = name
-    @user_type = user_type
+    @groups = groups
   end
 
   # Constructs a new instance from the CAS directory id,
@@ -23,7 +21,7 @@ class LdapUserAttributes
     @cas_directory_id = cas_directory_id
 
     # Possible skip LDAP search (intended to only work in development environment)
-    return new(cas_directory_id, LDAP_OVERRIDE) if ldap_override?
+    return new(cas_directory_id, LDAP_OVERRIDE.split(' ')) if ldap_override?
 
     filter = Net::LDAP::Filter.eq('uid', cas_directory_id)
     first_entry = LDAP.search(base: LDAP_BASE, filter: filter, attributes: LDAP_ATTRIBUTES)&.first
@@ -31,8 +29,7 @@ class LdapUserAttributes
 
     name = first_entry[LDAP_NAME_ATTR].first
     groups = first_entry[LDAP_GROUPS_ATTR]
-    user_type = user_type_from_groups(groups)
-    new(name, user_type)
+    new(name, groups)
   end
 
   # Returns true if the LDAP search should be skipped
@@ -40,15 +37,18 @@ class LdapUserAttributes
     Rails.env.development? && LDAP_OVERRIDE.present?
   end
 
-  # Returns a user type, based on the given list of Grouper groups
-  #
-  # @param groups [Array<String>] the Grouper groups the user is a member of
-  # @return the user type of the user. See CasUser.user_type enumeration
   def self.user_type_from_groups(groups)
     if groups
-      return :admin if groups.include?(GROUPER_ADMIN_GROUP)
-      return :user if groups.include?(GROUPER_USER_GROUP)
+      return :admin if groups.include? GROUPER_GROUPS['Administrators']
+      return :user if groups.include? GROUPER_GROUPS['Users']
     end
     :unauthorized
+  end
+
+  # Returns a user type, based on list of Grouper groups
+  #
+  # @return the user type of the user. See CasUser.user_type enumeration
+  def user_type
+    self.class.user_type_from_groups(@groups)
   end
 end

--- a/app/views/cas_users/show.html.erb
+++ b/app/views/cas_users/show.html.erb
@@ -2,21 +2,30 @@
 
 <h1><%= content_for :page_title %></h1>
 
-<p>
+<div>
   <strong>Directory ID:</strong>
   <%= @cas_user.cas_directory_id %>
-</p>
+</div>
 
-<p>
+<div>
   <strong>Name:</strong>
   <%= @cas_user.name %>
-</p>
+</div>
+
+<div>
+  <strong>Groups:</strong>
+  <ul>
+    <% @cas_user.groups.each do |group| %>
+      <li><%= group.name %></li>
+    <% end %>
+  </ul>
+</div>
 
 <% if current_cas_user.admin? %>
-<p>
-  <strong>Type:</strong>
-  <%= @cas_user.user_type %>
-</p>
+  <div>
+    <strong>Type:</strong>
+    <%= @cas_user.user_type %>
+  </div>
 <% end %>
 
 <div class="actions">

--- a/app/views/individuals/index.html.erb
+++ b/app/views/individuals/index.html.erb
@@ -20,11 +20,15 @@
         <td><%= link_to individual.identifier, individual %></td>
         <td><%= link_to individual.same_as, individual.same_as unless individual.same_as.blank? %></td>
         <td><%= link_to individual.uri, individual.uri %></td>
-        <td><%= link_to 'Edit', edit_individual_path(individual), class: 'btn btn-sm btn-success' %></td>
-        <td><%= link_to 'Delete', individual, method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-sm btn-danger' %></td>
+        <td><%= link_to_edit individual %></td>
+        <td><%= link_to_delete individual %></td>
       </tr>
     <% end %>
   </tbody>
 </table>
 
-<%= link_to "New #{t 'activerecord.models.individual'}", new_individual_path, class: 'btn btn-success' %>
+<% if can? :create, Individual %>
+  <div>
+    <%= link_to "New #{t 'activerecord.models.individual'}", new_individual_path, class: 'btn btn-success' %>
+  </div>
+<% end %>

--- a/app/views/individuals/show.html.erb
+++ b/app/views/individuals/show.html.erb
@@ -18,7 +18,9 @@
   <%= link_to @individual.vocabulary.identifier, @individual.vocabulary %>
 </div>
 
-<%= link_to 'Edit', edit_individual_path(@individual), class: 'btn btn-success' %>
+<% if can? :edit, @individual %>
+  <%= link_to 'Edit', edit_individual_path(@individual), class: 'btn btn-success' %>
+<% end %>
 
 <div>
   <%= link_to "All #{ActiveSupport::Inflector.pluralize(t('activerecord.models.individual'))}", individuals_path %>

--- a/app/views/types/index.html.erb
+++ b/app/views/types/index.html.erb
@@ -16,13 +16,15 @@
         <td><%= link_to type.identifier, type %></td>
         <td><%= link_to type.vocabulary.identifier, type.vocabulary %></td>
         <td><%= link_to type.uri, type.uri %></td>
-        <td><%= link_to 'Edit', edit_type_path(type), class: 'btn btn-sm btn-success' %></td>
-        <td><%= link_to 'Delete', type, method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-sm btn-danger' %></td>
+        <td><%= link_to_edit type %></td>
+        <td><%= link_to_delete type %></td>
       </tr>
     <% end %>
   </tbody>
 </table>
 
-<div>
-  <%= link_to "New #{t 'activerecord.models.type'}", new_type_path, class: 'btn btn-success' %>
-</div>
+<% if can? :create, Type %>
+  <div>
+    <%= link_to "New #{t 'activerecord.models.type'}", new_type_path, class: 'btn btn-success' %>
+  </div>
+<% end %>

--- a/app/views/types/show.html.erb
+++ b/app/views/types/show.html.erb
@@ -9,7 +9,10 @@
   <%= link_to @type.vocabulary.identifier, @type.vocabulary %>
 </div>
 
-<%= link_to 'Edit', edit_type_path(@type), class: 'btn btn-success' %>
+<% if can? :edit, @type %>
+  <%= link_to 'Edit', edit_type_path(@type), class: 'btn btn-success' %>
+<% end %>
+
 <div>
   <%= link_to "All #{ActiveSupport::Inflector.pluralize(t('activerecord.models.type'))}", types_path %>
-<div>
+</div>

--- a/app/views/vocabularies/index.html.erb
+++ b/app/views/vocabularies/index.html.erb
@@ -20,13 +20,15 @@
         <td><%= link_to vocabulary.published_uri, vocabulary.published_uri %></td>
         <td><%= vocabulary.types.count %></td>
         <td><%= vocabulary.individuals.count %></td>
-        <td><%= link_to 'Edit', edit_vocabulary_path(vocabulary), class: 'btn btn-sm btn-success' %></td>
-        <td><%= link_to 'Delete', vocabulary, method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-sm btn-danger' %></td>
+        <td><%= link_to_edit vocabulary %></td>
+        <td><%= link_to_delete vocabulary %></td>
       </tr>
     <% end %>
   </tbody>
 </table>
 
-<div>
-  <%= link_to "New #{t 'activerecord.models.vocabulary'}", new_vocabulary_path, class: 'btn btn-success' %>
-</div>
+<% if can? :create, Vocabulary %>
+  <div>
+    <%= link_to "New #{t 'activerecord.models.vocabulary'}", new_vocabulary_path, class: 'btn btn-success' %>
+  </div>
+<% end %>

--- a/app/views/vocabularies/show.html.erb
+++ b/app/views/vocabularies/show.html.erb
@@ -12,7 +12,10 @@
   <%= label :vocabulary, :description %>
   <%= @vocabulary.description %>
 </div>
-<%= link_to 'Edit', edit_vocabulary_path(@vocabulary), class: 'btn btn-success' %>
+
+<% if can? :edit, @vocabulary %>
+  <%= link_to 'Edit', edit_vocabulary_path(@vocabulary), class: 'btn btn-success' %>
+<% end %>
 
 <div class="row">
   <div class="col-sm-6">
@@ -23,9 +26,11 @@
             <%= ActiveSupport::Inflector.pluralize(t('activerecord.models.type'))  %>
             <span class="badge badge-secondary"><%= @vocabulary.types.count %></span>
           <% end %>
-          <div class="pull-right">
-            <%= link_to "New #{t 'activerecord.models.type'}", new_type_path(vocabulary: @vocabulary), class: 'btn btn-sm btn-success' %>
-          </div>
+          <% if can? :create, Type %>
+            <div class="pull-right">
+              <%= link_to "New #{t 'activerecord.models.type'}", new_type_path(vocabulary: @vocabulary), class: 'btn btn-sm btn-success' %>
+            </div>
+          <% end %>
         </div>
       </div>
 
@@ -47,9 +52,11 @@
             <%= ActiveSupport::Inflector.pluralize(t('activerecord.models.individual')) %>
             <span class="badge badge-secondary"><%= @vocabulary.individuals.count %></span>
           <% end %>
-          <div class="pull-right">
-            <%= link_to "New #{t 'activerecord.models.individual'}", new_individual_path(vocabulary: @vocabulary), class: 'btn btn-sm btn-success' %>
-          </div>
+          <% if can? :create, Individual %>
+            <div class="pull-right">
+              <%= link_to "New #{t 'activerecord.models.individual'}", new_individual_path(vocabulary: @vocabulary), class: 'btn btn-sm btn-success' %>
+            </div>
+          <% end %>
         </div>
       </div>
       <div class="panel-body">

--- a/config/initializers/ldap.rb
+++ b/config/initializers/ldap.rb
@@ -8,8 +8,7 @@ LDAP_NAME_ATTR = LDAP_CONFIG['name_attr']
 LDAP_GROUPS_ATTR = LDAP_CONFIG['groups_attr']
 LDAP_ATTRIBUTES = [LDAP_NAME_ATTR,LDAP_GROUPS_ATTR]
 LDAP_BASE = LDAP_CONFIG['base']
-GROUPER_ADMIN_GROUP = LDAP_CONFIG['grouper_admin_group']
-GROUPER_USER_GROUP = LDAP_CONFIG['grouper_user_group']
+GROUPER_GROUPS = LDAP_CONFIG['grouper_groups']
 LDAP_OVERRIDE = LDAP_CONFIG['ldap_override']
 
 # Initialize LDAP object

--- a/config/ldap.yml
+++ b/config/ldap.yml
@@ -8,8 +8,10 @@ default: &default
   base: ou=people,dc=umd,dc=edu
   name_attr: umdisplayname
   groups_attr: memberOf
-  grouper_admin_group: cn=Application_Roles:Libraries:Archelon:Archelon-Administrator,ou=grouper,ou=group,dc=umd,dc=edu
-  grouper_user_group: cn=Application_Roles:Libraries:Archelon:Archelon-User,ou=grouper,ou=group,dc=umd,dc=edu
+  grouper_groups:
+    Administrators: cn=Application_Roles:Libraries:Archelon:Archelon-Administrator,ou=grouper,ou=group,dc=umd,dc=edu
+    Users: cn=Application_Roles:Libraries:Archelon:Archelon-User,ou=grouper,ou=group,dc=umd,dc=edu
+    VocabularyEditors: cn=Application_Roles:Libraries:Archelon:Archelon-VocabularyEditor,ou=grouper,ou=group,dc=umd,dc=edu
 
 development:
   <<: *default

--- a/db/migrate/20200219151411_create_groups.rb
+++ b/db/migrate/20200219151411_create_groups.rb
@@ -1,0 +1,13 @@
+class CreateGroups < ActiveRecord::Migration[5.2]
+  def change
+    create_table :groups do |t|
+      t.string :name
+      t.timestamps
+    end
+
+    create_table :cas_users_groups, id: false do |t|
+      t.belongs_to :cas_user
+      t.belongs_to :group
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_07_183911) do
+ActiveRecord::Schema.define(version: 2020_02_19_151411) do
 
   create_table "bookmarks", force: :cascade do |t|
     t.integer "user_id", null: false
@@ -31,6 +31,13 @@ ActiveRecord::Schema.define(version: 2020_02_07_183911) do
     t.datetime "updated_at", null: false
     t.string "user_type"
     t.index ["cas_directory_id"], name: "index_cas_users_on_cas_directory_id", unique: true
+  end
+
+  create_table "cas_users_groups", id: false, force: :cascade do |t|
+    t.integer "cas_user_id"
+    t.integer "group_id"
+    t.index ["cas_user_id"], name: "index_cas_users_groups_on_cas_user_id"
+    t.index ["group_id"], name: "index_cas_users_groups_on_group_id"
   end
 
   create_table "download_urls", force: :cascade do |t|
@@ -62,6 +69,12 @@ ActiveRecord::Schema.define(version: 2020_02_07_183911) do
     t.datetime "updated_at", null: false
     t.string "download_url"
     t.index ["cas_user_id"], name: "index_export_jobs_on_cas_user_id"
+  end
+
+  create_table "groups", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "individuals", force: :cascade do |t|

--- a/test/controllers/individuals_controller_test.rb
+++ b/test/controllers/individuals_controller_test.rb
@@ -5,7 +5,7 @@ require 'test_helper'
 class IndividualsControllerTest < ActionController::TestCase
   setup do
     @individual = individuals(:one)
-    @cas_user = cas_users(:one)
+    @cas_user = cas_users(:vocab_editor)
     mock_cas_login(@cas_user.cas_directory_id)
   end
 

--- a/test/controllers/vocabularies_controller_test.rb
+++ b/test/controllers/vocabularies_controller_test.rb
@@ -5,7 +5,7 @@ require 'test_helper'
 class VocabulariesControllerTest < ActionController::TestCase
   setup do
     @vocabulary = vocabularies(:vocab_one)
-    @cas_user = cas_users(:one)
+    @cas_user = cas_users(:vocab_editor)
     mock_cas_login(@cas_user.cas_directory_id)
   end
 

--- a/test/fixtures/cas_users.yml
+++ b/test/fixtures/cas_users.yml
@@ -49,3 +49,11 @@ test_admin2:
   cas_directory_id: test_admin2
   name: Test Admin
   user_type: admin
+
+vocab_editor:
+  cas_directory_id: vocab_editor
+  name: Vocabulary Editor
+  user_type: user
+  groups:
+    - Users
+    - VocabularyEditors

--- a/test/fixtures/groups.yml
+++ b/test/fixtures/groups.yml
@@ -1,0 +1,10 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+Administrators:
+  name: Administrators
+
+Users:
+  name: Users
+
+VocabularyEditors:
+  name: VocabularyEditors

--- a/test/integration/cas_authorization_test.rb
+++ b/test/integration/cas_authorization_test.rb
@@ -16,8 +16,7 @@ class CasAuthorizationTest < ActionDispatch::IntegrationTest
 
   # LDAP call will return the given CAS user ldap_attrs map
   def stub_ldap_response(name:, groups:)
-    user_type = LdapUserAttributes.user_type_from_groups(groups)
-    expect(LdapUserAttributes).to receive(:create).and_return(LdapUserAttributes.send(:new, name, user_type))
+    expect(LdapUserAttributes).to receive(:create).and_return(LdapUserAttributes.send(:new, name, groups))
   end
 
   test 'existing cas_user can access application' do
@@ -33,7 +32,7 @@ class CasAuthorizationTest < ActionDispatch::IntegrationTest
 
   test 'new cas_user with User Grouper group can access application' do
     stub_solr_response
-    stub_ldap_response(name: 'New CAS User', groups: [GROUPER_USER_GROUP])
+    stub_ldap_response(name: 'New CAS User', groups: [GROUPER_GROUPS['Users']])
 
     cas_login('new_cas_user1')
 
@@ -43,7 +42,7 @@ class CasAuthorizationTest < ActionDispatch::IntegrationTest
   end
 
   test 'new cas_user can with User Grouper group has assigned "user" type' do
-    stub_ldap_response(name: 'New CAS User', groups: [GROUPER_USER_GROUP])
+    stub_ldap_response(name: 'New CAS User', groups: [GROUPER_GROUPS['Users']])
 
     cas_login('new_cas_user2')
 
@@ -52,7 +51,7 @@ class CasAuthorizationTest < ActionDispatch::IntegrationTest
 
   test 'new cas_user can with Admin Grouper group can access application' do
     stub_solr_response
-    stub_ldap_response(name: 'New Admin CAS User', groups: [GROUPER_ADMIN_GROUP])
+    stub_ldap_response(name: 'New Admin CAS User', groups: [GROUPER_GROUPS['Administrators']])
 
     cas_login('new_admin_cas_user1')
 
@@ -62,7 +61,7 @@ class CasAuthorizationTest < ActionDispatch::IntegrationTest
   end
 
   test 'new cas_user can with Admin Grouper group has "admin" type' do
-    stub_ldap_response(name: 'New Admin CAS User', groups: [GROUPER_ADMIN_GROUP])
+    stub_ldap_response(name: 'New Admin CAS User', groups: [GROUPER_GROUPS['Administrators']])
 
     cas_login('new_admin_cas_user2')
 
@@ -89,7 +88,7 @@ class CasAuthorizationTest < ActionDispatch::IntegrationTest
   test 'existing admin cas_user type is updated based on Grouper group changes during login' do
     assert CasUser.find_by(cas_directory_id: 'prior_admin').admin?
 
-    stub_ldap_response(name: 'Prior Admin', groups: [GROUPER_USER_GROUP])
+    stub_ldap_response(name: 'Prior Admin', groups: [GROUPER_GROUPS['Users']])
 
     cas_login('prior_admin')
 
@@ -99,7 +98,7 @@ class CasAuthorizationTest < ActionDispatch::IntegrationTest
   test 'existing cas_user type is updated based on Grouper group changes during login' do
     assert CasUser.find_by(cas_directory_id: 'prior_user1').user?
 
-    stub_ldap_response(name: 'Prior User1', groups: [GROUPER_ADMIN_GROUP])
+    stub_ldap_response(name: 'Prior User1', groups: [GROUPER_GROUPS['Administrators']])
 
     cas_login('prior_user1')
 
@@ -123,7 +122,7 @@ class CasAuthorizationTest < ActionDispatch::IntegrationTest
     assert_not user.admin?
 
     # do the critical steps of a login
-    stub_ldap_response(name: 'Prior Unauthorized', groups: [GROUPER_USER_GROUP])
+    stub_ldap_response(name: 'Prior Unauthorized', groups: [GROUPER_GROUPS['Users']])
     user = CasUser.find_or_create_from_auth_hash(uid: user.cas_directory_id)
 
     # they should be a user now
@@ -139,7 +138,7 @@ class CasAuthorizationTest < ActionDispatch::IntegrationTest
     assert_not user.admin?
 
     # do the critical steps of a login
-    stub_ldap_response(name: 'Prior Unauthorized 2', groups: [GROUPER_ADMIN_GROUP])
+    stub_ldap_response(name: 'Prior Unauthorized 2', groups: [GROUPER_GROUPS['Administrators']])
     user = CasUser.find_or_create_from_auth_hash(uid: user.cas_directory_id)
 
     # they should be an admin now

--- a/test/models/group_test.rb
+++ b/test/models/group_test.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class GroupTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/ldap_user_attributes_test.rb
+++ b/test/models/ldap_user_attributes_test.rb
@@ -8,27 +8,35 @@ class LdapUserAttributesTest < ActiveSupport::TestCase
     assert_equal :unauthorized, LdapUserAttributes.user_type_from_groups([])
     assert_equal :unauthorized, LdapUserAttributes.user_type_from_groups(['SOME_OTHER_GROUP'])
 
-    assert_equal :user, LdapUserAttributes.user_type_from_groups([GROUPER_USER_GROUP])
-    assert_equal :user, LdapUserAttributes.user_type_from_groups(['SOME_OTHER_GROUP', GROUPER_USER_GROUP])
-    assert_equal :user, LdapUserAttributes.user_type_from_groups([GROUPER_USER_GROUP, 'SOME_OTHER_GROUP'])
+    assert_equal :user, LdapUserAttributes.user_type_from_groups([GROUPER_GROUPS['Users']])
+    assert_equal :user, LdapUserAttributes.user_type_from_groups(['SOME_OTHER_GROUP', GROUPER_GROUPS['Users']])
+    assert_equal :user, LdapUserAttributes.user_type_from_groups([GROUPER_GROUPS['Users'], 'SOME_OTHER_GROUP'])
 
-    assert_equal :admin, LdapUserAttributes.user_type_from_groups([GROUPER_ADMIN_GROUP])
-    assert_equal :admin, LdapUserAttributes.user_type_from_groups([GROUPER_ADMIN_GROUP, 'SOME_OTHER_GROUP'])
-    assert_equal :admin, LdapUserAttributes.user_type_from_groups(['SOME_OTHER_GROUP', GROUPER_ADMIN_GROUP])
-    assert_equal :admin, LdapUserAttributes.user_type_from_groups([GROUPER_ADMIN_GROUP, GROUPER_USER_GROUP])
-    assert_equal :admin, LdapUserAttributes.user_type_from_groups([GROUPER_USER_GROUP, GROUPER_ADMIN_GROUP])
+    assert_equal :admin, LdapUserAttributes.user_type_from_groups([GROUPER_GROUPS['Administrators']])
     assert_equal :admin, LdapUserAttributes.user_type_from_groups(
-      ['SOME_OTHER_GROUP', GROUPER_USER_GROUP, GROUPER_ADMIN_GROUP]
+      [GROUPER_GROUPS['Administrators'], 'SOME_OTHER_GROUP']
     )
     assert_equal :admin, LdapUserAttributes.user_type_from_groups(
-      [GROUPER_USER_GROUP, GROUPER_ADMIN_GROUP, 'SOME_OTHER_GROUP']
+      ['SOME_OTHER_GROUP', GROUPER_GROUPS['Administrators']]
+    )
+    assert_equal :admin, LdapUserAttributes.user_type_from_groups(
+      [GROUPER_GROUPS['Administrators'], GROUPER_GROUPS['Users']]
+    )
+    assert_equal :admin, LdapUserAttributes.user_type_from_groups(
+      [GROUPER_GROUPS['Users'], GROUPER_GROUPS['Administrators']]
+    )
+    assert_equal :admin, LdapUserAttributes.user_type_from_groups(
+      ['SOME_OTHER_GROUP', GROUPER_GROUPS['Users'], GROUPER_GROUPS['Administrators']]
+    )
+    assert_equal :admin, LdapUserAttributes.user_type_from_groups(
+      [GROUPER_GROUPS['Users'], GROUPER_GROUPS['Administrators'], 'SOME_OTHER_GROUP']
     )
   end
 
   test 'Creation from LDAP with valid result' do
     ldap_entry = Net::LDAP::Entry.new
     ldap_entry[LDAP_NAME_ATTR] = Faker::Name.name
-    ldap_entry[LDAP_GROUPS_ATTR] = [GROUPER_USER_GROUP, GROUPER_ADMIN_GROUP]
+    ldap_entry[LDAP_GROUPS_ATTR] = [GROUPER_GROUPS['Users'], GROUPER_GROUPS['Administrators']]
 
     LDAP.stub :search, [ldap_entry] do
       ldap_user_attributes = LdapUserAttributes.create('foo')
@@ -53,7 +61,7 @@ class LdapUserAttributesTest < ActiveSupport::TestCase
   test 'Creation from LDAP with missing attributes' do
     ldap_entry = Net::LDAP::Entry.new
     ldap_entry['unexpected_attribute1'] = Faker::Name.name
-    ldap_entry['unexpected_attribute2'] = [GROUPER_USER_GROUP, GROUPER_ADMIN_GROUP]
+    ldap_entry['unexpected_attribute2'] = [GROUPER_GROUPS['Users'], GROUPER_GROUPS['Administrators']]
 
     LDAP.stub :search, [ldap_entry] do
       ldap_user_attributes = LdapUserAttributes.create('foo')


### PR DESCRIPTION
* implemented a Group Rails model that represents a Grouper group
* the LDAP_OVERRIDE environment variable uses the full Grouper DNs
* added VocabularyEditor grouper group to the LDAP configuration
* changed ldap.yml structure to allow more flexible expansion of grouper groups
* use the cancancan gem for authorization

https://issues.umd.edu/browse/LIBHYDRA-229