### PR TITLE
LIBHYDRA-246. Add source to term list on vocabulary page.

### DIFF
--- a/app/views/vocabularies/show.html.erb
+++ b/app/views/vocabularies/show.html.erb
@@ -18,7 +18,35 @@
 <% end %>
 
 <div class="row">
-  <div class="col-sm-6">
+  <div class="col-sm-9">
+    <div class="panel panel-default panel-vocabulary">
+      <div class="panel-heading">
+        <div class="h2">
+          <%= link_to individuals_path do %>
+            <%= ActiveSupport::Inflector.pluralize(t('activerecord.models.individual')) %>
+            <span class="badge badge-secondary"><%= @vocabulary.individuals.count %></span>
+          <% end %>
+          <% if can? :create, Individual %>
+            <div class="pull-right">
+              <%= link_to "New #{t 'activerecord.models.individual'}", new_individual_path(vocabulary: @vocabulary), class: 'btn btn-sm btn-success' %>
+            </div>
+          <% end %>
+        </div>
+      </div>
+      <div class="panel-body">
+        <table class="table table-striped">
+          <% @vocabulary.individuals.each do |individual| %>
+            <tr>
+              <td class="col-xs-7"><%= link_to individual.label, individual %></td>
+              <td class="col-xs-3"><%= individual.identifier %></td>
+              <td class="col-xs-2" title="<%= t 'activerecord.attributes.individual.source' %>"><%= individual.source %></td>
+            </tr>
+          <% end %>
+        </table>
+      </div>
+    </div>
+  </div>
+  <div class="col-sm-3">
     <div class="panel panel-default panel-vocabulary">
       <div class="panel-heading">
         <div class="h2">
@@ -35,36 +63,15 @@
       </div>
 
       <div class="panel-body">
-        <ul>
+        <table class="table table-striped">
           <% @vocabulary.types.each do |type| %>
-            <li><%= link_to type.identifier, type %></li>
+            <tr>
+              <td>
+                <%= link_to type.identifier, type %>
+              </td>
+            </tr>
           <% end %>
-        </ul>
-      </div>
-    </div>
-  </div>
-
-  <div class="col-sm-6">
-    <div class="panel panel-default panel-vocabulary">
-      <div class="panel-heading">
-        <div class="h2">
-          <%= link_to individuals_path do %>
-            <%= ActiveSupport::Inflector.pluralize(t('activerecord.models.individual')) %>
-            <span class="badge badge-secondary"><%= @vocabulary.individuals.count %></span>
-          <% end %>
-          <% if can? :create, Individual %>
-            <div class="pull-right">
-              <%= link_to "New #{t 'activerecord.models.individual'}", new_individual_path(vocabulary: @vocabulary), class: 'btn btn-sm btn-success' %>
-            </div>
-          <% end %>
-        </div>
-      </div>
-      <div class="panel-body">
-        <ul>
-          <% @vocabulary.individuals.each do |individual| %>
-            <li><%= link_to "#{individual.label} (#{individual.identifier})", individual %></li>
-          <% end %>
-        </ul>
+        </table>
       </div>
     </div>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,6 +44,7 @@ en:
         identifier: Identifier
         label: Term
         same_as: URI
+        source: Source
         uri: Local URI
         vocabulary: Vocabulary
       type:


### PR DESCRIPTION
Also swapped the order of the panels so that terms is to the left of (or on top of) classes, and is wider.

https://issues.umd.edu/browse/LIBHYDRA-246