### PR TITLE
LIBHYDRA-247. Check LDAP group DNs ignoring case.

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -2,13 +2,14 @@
 
 # User group
 class Group < ApplicationRecord
-  NAME_MAPPING = GROUPER_GROUPS.invert
+  # the LDAP server returns some group DNs in all lowercase
+  NAME_MAPPING = GROUPER_GROUPS.invert.transform_keys(&:downcase)
 
   has_and_belongs_to_many :cas_users # rubocop:disable Rails/HasAndBelongsToMany
 
   def self.from_dn(ldap_dn)
-    return unless NAME_MAPPING.key? ldap_dn
+    return unless NAME_MAPPING.key? ldap_dn.downcase
 
-    find_or_create_by name: NAME_MAPPING[ldap_dn]
+    find_or_create_by name: NAME_MAPPING[ldap_dn.downcase]
   end
 end

--- a/app/models/ldap_user_attributes.rb
+++ b/app/models/ldap_user_attributes.rb
@@ -39,8 +39,10 @@ class LdapUserAttributes
 
   def self.user_type_from_groups(groups)
     if groups
-      return :admin if groups.include? GROUPER_GROUPS['Administrators']
-      return :user if groups.include? GROUPER_GROUPS['Users']
+      # the LDAP server returns some group DNs in all lowercase
+      groups_lc = groups.map(&:downcase)
+      return :admin if groups_lc.include? GROUPER_GROUPS['Administrators'].downcase
+      return :user if groups_lc.include? GROUPER_GROUPS['Users'].downcase
     end
     :unauthorized
   end
@@ -49,6 +51,6 @@ class LdapUserAttributes
   #
   # @return the user type of the user. See CasUser.user_type enumeration
   def user_type
-    self.class.user_type_from_groups(@groups)
+    @user_type ||= self.class.user_type_from_groups(@groups)
   end
 end

--- a/test/integration/cas_authorization_test.rb
+++ b/test/integration/cas_authorization_test.rb
@@ -158,6 +158,13 @@ class CasAuthorizationTest < ActionDispatch::IntegrationTest
     assert_response(:forbidden)
   end
 
+  test 'ldap group name checks should ignore case' do
+    stub_ldap_response(name: 'New User', groups: [GROUPER_GROUPS['VocabularyEditors'].downcase])
+    user = CasUser.find_or_create_from_auth_hash(uid: 'newuser')
+
+    assert user.in_group? :VocabularyEditors
+  end
+
   def teardown
   end
 end

--- a/test/models/ldap_user_attributes_test.rb
+++ b/test/models/ldap_user_attributes_test.rb
@@ -33,6 +33,12 @@ class LdapUserAttributesTest < ActiveSupport::TestCase
     )
   end
 
+  test 'group matching ignores case' do
+    # we shouldn't care about DN capitalization
+    assert_equal :user, LdapUserAttributes.user_type_from_groups([GROUPER_GROUPS['Users'].downcase])
+    assert_equal :admin, LdapUserAttributes.user_type_from_groups([GROUPER_GROUPS['Administrators'].downcase])
+  end
+
   test 'Creation from LDAP with valid result' do
     ldap_entry = Net::LDAP::Entry.new
     ldap_entry[LDAP_NAME_ATTR] = Faker::Name.name


### PR DESCRIPTION
Our LDAP server returns some (but not all) group DNs in all lowercase.

https://issues.umd.edu/browse/LIBHYDRA-247