### PR TITLE
LIBHYDRA-249. Use blank? instead of empty? to catch nils.

### DIFF
--- a/app/models/individual.rb
+++ b/app/models/individual.rb
@@ -20,7 +20,7 @@ class Individual < ApplicationRecord
   end
 
   def source
-    return nil if same_as.empty?
+    return nil if same_as.blank?
 
     SAME_AS_ABBREVIATIONS.each do |prefix, abbreviation|
       return abbreviation if same_as.starts_with? prefix


### PR DESCRIPTION
Rails extends Ruby's blank? method to return true for nil.

https://issues.umd.edu/browse/LIBHYDRA-249