### PR TITLE
LIBHYDRA-250. Added :all shortcut to publish all vocab RDF formats.

### DIFF
--- a/app/models/vocabulary.rb
+++ b/app/models/vocabulary.rb
@@ -46,15 +46,19 @@ class Vocabulary < ApplicationRecord
     end
   end
 
-  def publish_rdf(format)
-    FORMAT_EXTENSIONS.include?(format) || raise('Unrecognized format')
+  def publish_rdf(format) # rubocop:disable Metrics/AbcSize
+    if format == :all
+      FORMAT_EXTENSIONS.keys.each { |f| publish_rdf(f) }
+    else
+      FORMAT_EXTENSIONS.include?(format) || raise('Unrecognized format')
 
-    vocab_dir = Rails.root.join('public', 'published_vocabularies')
-    FileUtils.makedirs vocab_dir
+      vocab_dir = Rails.root.join('public', 'published_vocabularies')
+      FileUtils.makedirs vocab_dir
 
-    extension = FORMAT_EXTENSIONS[format]
-    path = Rails.root.join(vocab_dir, "#{identifier}.#{extension}")
-    File.open(path, 'w') { |f| f << graph.dump(format, prefixes: PREFIXES.dup) }
+      extension = FORMAT_EXTENSIONS[format]
+      path = Rails.root.join(vocab_dir, "#{identifier}.#{extension}")
+      File.open(path, 'w') { |f| f << graph.dump(format, prefixes: PREFIXES.dup) }
+    end
   end
 
   def self.delete_published_rdf(identifier)

--- a/lib/tasks/vocab.rake
+++ b/lib/tasks/vocab.rake
@@ -43,6 +43,7 @@ namespace :vocab do
         report_import_errors(individual, args.filename, index + 2)
       end
     end
+    vocabulary.publish_rdf :all
     puts "Imported #{import_count} terms from #{args.filename} into #{args.vocab_identifier}"
   end
 end


### PR DESCRIPTION
Call this from the rake task to publish the vocabulary after import.

https://issues.umd.edu/browse/LIBHYDRA-250