### PR TITLE
LIBHYDRA-221. Implemented unauthenticated "/ping" endpoint

### DIFF
--- a/app/controllers/ping_controller.rb
+++ b/app/controllers/ping_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Controller for Icinga network monitoring to use to determine whether the
+# application is running.
+class PingController < ApplicationController
+  # Controller actions should be accessible without requiring authenication.
+  skip_before_action :authenticate
+
+  def verify
+    if ActiveRecord::Base.connected?
+      render plain: 'Application is OK'
+    else
+      render plain: 'Cannot connect to database!', status: :service_unavailable
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -66,4 +66,6 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
   resources :vocabularies
   resources :types
   resources :individuals
+
+  get '/ping' => 'ping#verify'
 end

--- a/test/controllers/ping_controller_test.rb
+++ b/test/controllers/ping_controller_test.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class PingControllerTest < ActionController::TestCase
+  test 'ping service can be accessed without logging in' do
+    # Verify that no user is logged in.
+    assert session[:cas].nil?
+
+    get :verify
+    assert_response(:success)
+  end
+end


### PR DESCRIPTION
Implemented in similar manner to annual-staffing-request (see LIBITD-691
and LIBITD-1002), in which a "/ping" endpoint is provided that does not
require authentication, and tests whether is application is connected to
the database (via "ActiveRecord::Base.connected?")

https://issues.umd.edu/browse/LIBHYDRA-221