### PR TITLE
LIBHYDRA-259. Use generic header and queue names.

### DIFF
--- a/app/controllers/export_jobs_controller.rb
+++ b/app/controllers/export_jobs_controller.rb
@@ -88,11 +88,12 @@ class ExportJobsController < ApplicationController
 
     def message_headers(job)
       {
-        ArchelonExportJobName: job.name,
-        ArchelonExportJobId: job.id,
-        ArchelonExportJobUsername: job.cas_user.cas_directory_id,
-        ArchelonExportJobFormat: job.format,
-        ArchelonExportJobTimestamp: job.timestamp,
+        PlastronCommand: 'export',
+        PlastronJobId: export_job_url(job),
+        'PlastronArg-name': job.name,
+        'PlastronArg-username': job.cas_user.cas_directory_id,
+        'PlastronArg-format': job.format,
+        'PlastronArg-timestamp': job.timestamp,
         persistent: 'true'
       }
     end

--- a/app/models/export_job.rb
+++ b/app/models/export_job.rb
@@ -41,6 +41,12 @@ class ExportJob < ApplicationRecord
     ]
   end
 
+  def self.from_uri(uri)
+    # assume that the last path segment of the uri is the identifier
+    id = uri[uri.rindex('/') + 1..]
+    find(id)
+  end
+
   private
 
     def content_disposition(headers)

--- a/app/services/stomp_client.rb
+++ b/app/services/stomp_client.rb
@@ -41,11 +41,13 @@ class StompClient
 
   # Updates ExportJob based on a Stomp message
   def update_export_job(stomp_msg)
-    Rails.logger.debug 'Updating export job'
     headers = stomp_msg.headers
-    export_job = ExportJob.find(headers['ArchelonExportJobId'])
-    export_job.status = headers['ArchelonExportJobStatus']
-    export_job.download_url = headers['ArchelonExportJobDownloadUrl']
+    job_uri = headers['PlastronJobId']
+    Rails.logger.info "Updating export job #{job_uri}"
+    export_job = ExportJob.from_uri(job_uri)
+    export_job.status = headers['PlastronJobStatus']
+    body_data = JSON.parse(stomp_msg.body)
+    export_job.download_url = body_data['download_uri']
     export_job.save
   end
 end

--- a/config/stomp.yml
+++ b/config/stomp.yml
@@ -1,8 +1,8 @@
 default: &default
   host: <%= ENV['STOMP_HOST'] %>
   port: <%= ENV['STOMP_PORT'] %>
-  export_jobs_queue: /queue/exportjobs
-  export_jobs_completed_queue: /queue/exportjobs.completed
+  export_jobs_queue: /queue/plastron.jobs
+  export_jobs_completed_queue: /queue/plastron.jobs.completed
 
 development:
   <<: *default

--- a/test/services/stomp_client_test.rb
+++ b/test/services/stomp_client_test.rb
@@ -37,7 +37,7 @@ class StompClientTest < Minitest::Test
   def create_message(job_id)
     message = Stomp::Message.new('')
     headers = {}
-    headers['PlastronJobId'] = "http://example.com/job/#{job_id.to_s}"
+    headers['PlastronJobId'] = "http://example.com/job/#{job_id}"
     headers['PlastronJobStatus'] = 'Ready'
     message.command = 'MESSAGE'
     message.headers = headers

--- a/test/services/stomp_client_test.rb
+++ b/test/services/stomp_client_test.rb
@@ -37,10 +37,11 @@ class StompClientTest < Minitest::Test
   def create_message(job_id)
     message = Stomp::Message.new('')
     headers = {}
-    headers['ArchelonExportJobId'] = job_id.to_s
-    headers['ArchelonExportJobStatus'] = 'Ready'
+    headers['PlastronJobId'] = "http://example.com/job/#{job_id.to_s}"
+    headers['PlastronJobStatus'] = 'Ready'
     message.command = 'MESSAGE'
     message.headers = headers
+    message.body = JSON.generate(download_uri: 'http://example.com/foo')
     message
   end
 end


### PR DESCRIPTION
- changed from "ArchelonExport*" to "PlastronCommand", "PlastronJobId", and "PlastronArg-*"
- changed queue names to "plastron.jobs" and "plastron.jobs.completed"
- download URL is returned in the body of the message, along with other export stats

https://issues.umd.edu/browse/LIBHYDRA-259