### PR TITLE
LIBHYDRA-258. Update job progress based on plastron.job.status messages.

### DIFF
--- a/app/controllers/export_jobs_controller.rb
+++ b/app/controllers/export_jobs_controller.rb
@@ -103,7 +103,7 @@ class ExportJobsController < ApplicationController
     def submit_job(uris)
       body = uris.join("\n")
       headers = message_headers(@job)
-      STOMP_CLIENT.publish STOMP_CONFIG['export_jobs_queue'], body, headers
+      STOMP_CLIENT.publish STOMP_CONFIG['destinations']['jobs'], body, headers
       @job.plastron_operation.started = Time.zone.now
       @job.plastron_operation.status = :in_progress
       @job.plastron_operation.request_message = "#{headers_to_s(headers)}\n\n#{body}"

--- a/app/models/export_job.rb
+++ b/app/models/export_job.rb
@@ -41,11 +41,19 @@ class ExportJob < ApplicationRecord
     find(id)
   end
 
-  def mark_as_completed(status)
-    plastron_operation.completed = Time.zone.now
-    plastron_operation.status = status
+  def update_progress(message)
+    stats = message.body_json
+    progress = (stats['count']['exported'].to_f / stats['count']['total'] * 100).round
+    plastron_operation.progress = progress
     plastron_operation.save!
-    self
+  end
+
+  def update_status(message)
+    plastron_operation.completed = Time.zone.now
+    plastron_operation.status = message.headers['PlastronJobStatus']
+    plastron_operation.save!
+    self.download_url = message.body_json['download_uri']
+    save!
   end
 
   private

--- a/config/stomp.yml
+++ b/config/stomp.yml
@@ -1,10 +1,15 @@
 default: &default
   host: <%= ENV['STOMP_HOST'] %>
   port: <%= ENV['STOMP_PORT'] %>
-  export_jobs_queue: /queue/plastron.jobs
-  export_jobs_completed_queue: /queue/plastron.jobs.completed
+  destinations:
+    jobs: /queue/plastron.jobs
+    job_status: /topic/plastron.jobs.status
+    jobs_completed: /queue/plastron.jobs.completed
 
 development:
+  <<: *default
+
+test:
   <<: *default
 
 production:

--- a/test/services/stomp_client_test.rb
+++ b/test/services/stomp_client_test.rb
@@ -12,38 +12,50 @@ class StompClientTest < Minitest::Test
   def setup
   end
 
-  def test_update_export_job_when_message_received
+  def test_update_job_when_done
     mock = MockStompClient.instance
     cas_user = CasUser.first
     op = PlastronOperation.first
     job = ExportJob.new(name: 'test job', cas_user: cas_user, plastron_operation: op)
     job.save!
-    message = create_message(job.id)
-    mock.update_export_job(message)
+    message = create_message(job.id, 'Done')
+    mock.update_job_status(message)
     job.reload
     assert job.plastron_operation.done?
   end
 
-  def test_update_export_job_when_error_received
+  def test_update_job_on_error
     mock = MockStompClient.instance
     cas_user = CasUser.first
     op = PlastronOperation.first
     job = ExportJob.new(name: 'test job', cas_user: cas_user, plastron_operation: op)
     job.save!
-    message = create_message(job.id)
-    mock.update_export_job(message)
+    message = create_message(job.id, 'Error')
+    mock.update_job_status(message)
     job.reload
-    assert job.plastron_operation.done?
+    assert job.plastron_operation.error?
   end
 
-  def create_message(job_id)
-    message = Stomp::Message.new('')
-    headers = {}
-    headers['PlastronJobId'] = "http://example.com/job/#{job_id}"
-    headers['PlastronJobStatus'] = 'Done'
-    message.command = 'MESSAGE'
-    message.headers = headers
-    message.body = JSON.generate(download_uri: 'http://example.com/foo')
-    message
+  def test_update_job_when_failed
+    mock = MockStompClient.instance
+    cas_user = CasUser.first
+    op = PlastronOperation.first
+    job = ExportJob.new(name: 'test job', cas_user: cas_user, plastron_operation: op)
+    job.save!
+    message = create_message(job.id, 'Failed')
+    mock.update_job_status(message)
+    job.reload
+    assert job.plastron_operation.failed?
+  end
+
+  def create_message(job_id, status)
+    Stomp::Message.new('').tap do |message|
+      message.command = 'MESSAGE'
+      message.headers = {
+        PlastronJobId: "http://localhost:3000/export_jobs/#{job_id}",
+        PlastronJobStatus: status
+      }
+      message.body = JSON.generate(download_uri: 'http://example.com/foo')
+    end
   end
 end


### PR DESCRIPTION
Removed "export" from generic method and variable names.

https://issues.umd.edu/browse/LIBHYDRA-258