### PR TITLE
LIBHYDRA-268. Added a collapsed "JSON" panel to validation panel

### DIFF
--- a/app/assets/stylesheets/custom.css
+++ b/app/assets/stylesheets/custom.css
@@ -139,16 +139,19 @@ input {
   padding-right: 10px;
 }
 
-.plastron_status_in_progress {
+.plastron_status_in_progress, .import_job_status_in_progress {
   color: #000000;
   font-weight: bold;
 }
 
-.plastron_status_failed, .plastron_status_error {
+.plastron_status_failed, .plastron_status_error,
+.import_job_status_error, .import_job_status_validate_error, .import_job_status_import_error,
+.import_job_status_validate_failed, .import_job_status_import_failed {
   color: #d83935;
 }
 
-.plastron_status_done {
+.plastron_status_done, .import_job_status_done,
+.import_job_status_validate_success, .import_job_status_import_success {
   color: #03ab3a;
 }
 
@@ -208,13 +211,4 @@ input {
 .umd_tooltip:hover .umd_tooltiptext {
   visibility: visible;
   opacity: 1;
-}
-
-/* Import Job Status */
-.import_job_status_validate_success, .import_job_status_import_success {
-  color: #03ab3a;
-}
-
-.import_job_status_validate_error, .import_job_status_validate_failed, .import_job_status_import_failed {
-  color: #d83935;
 }

--- a/app/controllers/import_jobs_controller.rb
+++ b/app/controllers/import_jobs_controller.rb
@@ -105,17 +105,17 @@ class ImportJobsController < ApplicationController # rubocop:disable Metrics/Cla
   end
 
   # Generates status text display for the GUI
-  def status_text(import_job)
+  def status_text(import_job) # rubocop:disable Metrics/MethodLength
     if import_job.status == :in_progress
-      status_text = I18n.t("activerecord.attributes.import_job.status.in_progress")
+      status_text = I18n.t('activerecord.attributes.import_job.status.in_progress')
       progress = import_job.progress
-      if !progress.nil? && progress > 0
+      if !progress.nil? && progress.positive?
         stage_text = I18n.t("activerecord.attributes.import_job.stage.#{import_job.stage}")
         status_text = "#{stage_text} (#{progress}%)"
       end
-      return status_text
+      status_text
     else
-      return I18n.t("activerecord.attributes.import_job.status.#{import_job.status}")
+      I18n.t("activerecord.attributes.import_job.status.#{import_job.status}")
     end
   end
 

--- a/app/controllers/import_jobs_controller.rb
+++ b/app/controllers/import_jobs_controller.rb
@@ -3,6 +3,7 @@
 class ImportJobsController < ApplicationController # rubocop:disable Metrics/ClassLength
   before_action :set_import_job, only: %i[update show edit update import]
   before_action :cancel_workflow?, only: %i[create update]
+  helper_method :status_text
 
   # GET /import_jobs
   # GET /import_jobs.json
@@ -101,6 +102,21 @@ class ImportJobsController < ApplicationController # rubocop:disable Metrics/Cla
     @import_job.stage = 'import'
     @import_job.save!
     redirect_to action: 'index', status: :see_other
+  end
+
+  # Generates status text display for the GUI
+  def status_text(import_job)
+    if import_job.status == :in_progress
+      status_text = I18n.t("activerecord.attributes.import_job.status.in_progress")
+      progress = import_job.progress
+      if !progress.nil? && progress > 0
+        stage_text = I18n.t("activerecord.attributes.import_job.stage.#{import_job.stage}")
+        status_text = "#{stage_text} (#{progress}%)"
+      end
+      return status_text
+    else
+      return I18n.t("activerecord.attributes.import_job.status.#{import_job.status}")
+    end
   end
 
   private

--- a/app/models/import_job.rb
+++ b/app/models/import_job.rb
@@ -36,8 +36,12 @@
 #
 #   * :in_progress - Returned for any other status
 #
-#   * :error - An error has occurred, such as the STOMP client not being
-#              connected
+#   * :validate_error - An error has occurred during validation, such as the
+#                       STOMP client not being connected
+#
+#   * :import_error - An error has occurred during import, such as the
+#                     STOMP client not being connected
+#   * :error - Generic error when stage is nil
 class ImportJob < ApplicationRecord
   include PlastronStatus
 

--- a/app/services/import_job_response.rb
+++ b/app/services/import_job_response.rb
@@ -3,7 +3,7 @@
 # Parses the Plastron response for metadata import job.
 class ImportJobResponse
   attr_reader :server_error, :num_total, :num_updated, :num_unchanged,
-              :num_valid, :num_invalid, :num_error, :invalid_lines
+              :num_valid, :num_invalid, :num_error, :invalid_lines, :json
 
   def initialize(response_message) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity, Metrics/LineLength
     @valid = false
@@ -22,13 +22,13 @@ class ImportJobResponse
     end
 
     begin
-      msg = JSON.parse(response_message)
+      @json = JSON.parse(response_message)
     rescue JSON::ParserError
       @server_error = :invalid_response_from_server
       return
     end
 
-    count_hash = msg['count']
+    count_hash = @json['count']
     if count_hash.nil?
       @server_error = :invalid_response_from_server
       return
@@ -50,7 +50,7 @@ class ImportJobResponse
 
     return if @valid
 
-    validations = msg['validation']
+    validations = @json['validation']
 
     return unless validations
 
@@ -70,6 +70,14 @@ class ImportJobResponse
 
   def server_error?
     !@server_error.nil?
+  end
+
+  # Returns pretty-printed JSON suitable for display, or an empty
+  # string if the JSON cannot be parsed.
+  def json_pretty_print
+    JSON.pretty_generate(@json)
+  rescue StandardError
+    ''
   end
 end
 

--- a/app/views/import_jobs/_import_job_validation_panel.erb
+++ b/app/views/import_jobs/_import_job_validation_panel.erb
@@ -4,7 +4,7 @@
 <div class="panel panel-default">
   <div class="panel-heading">
     <h3 class="panel-title">
-      Status - <span class="<%= job_status_css_class %>"><%= job_status %></span>
+      Status - <span class="<%= job_status_css_class %>"><%= status_text %></span>
     </h3>
   </div>
   <div class="panel-body">

--- a/app/views/import_jobs/_import_job_validation_panel.erb
+++ b/app/views/import_jobs/_import_job_validation_panel.erb
@@ -62,5 +62,20 @@
         </div>
       </div>
     <% end %>
+
+    <% unless import_job_response.json_pretty_print.empty? %>
+      <div class="panel panel-default">
+        <div class="panel-heading">
+          <div class="panel-title">
+            <a role="button" data-toggle="collapse" data-target="#json_panel" class="btn-block">
+              JSON
+            </a>
+          </div>
+        </div>
+        <div id="json_panel" class="panel-body collapse">
+          <pre><code><%= import_job_response.json_pretty_print %></code></pre>
+        </div>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/import_jobs/edit.html.erb
+++ b/app/views/import_jobs/edit.html.erb
@@ -3,7 +3,8 @@
 <%= render partial: "import_job_info_panel", locals: {import_job: @import_job} %>
 
 <%= render partial: "import_job_validation_panel", locals: {import_job: @import_job,
-                                                            import_job_response: @import_job_response } %>
+                                                            import_job_response: @import_job_response,
+                                                            status_text: status_text(@import_job) } %>
 
 <div class="panel panel-default">
   <div class="panel-heading">

--- a/app/views/import_jobs/index.html.erb
+++ b/app/views/import_jobs/index.html.erb
@@ -33,22 +33,9 @@
           <td><%= import_job.cas_user&.name%></td>
           <td><%= import_job.timestamp %></td>
           <td><%= import_job.file_to_upload.filename %></td>
-          <td><%= import_job.model %></td>
-          <% if import_job.status == :in_progress %>
-            <% progress = import_job.progress %>
-            <% if progress.nil? || progress == 0 %>
-              <% progress = I18n.t("activerecord.attributes.import_job.status.in_progress") %>
-            <% else %>
-              <% progress = "#{progress}%" %>
-            <% end %>
-            <td class="plastron_status_<%= import_job.status %>">
-              <%= I18n.t("activerecord.attributes.import_job.stage.#{import_job.stage}") %> (<%= progress %>)
-            </td>
-          <% else %>
-            <td class="import_job_status_<%= import_job.status %>">
-              <%= I18n.t("activerecord.attributes.import_job.status.#{import_job.status}") %>
-            </td>
-          <% end %>
+          <td>
+            <%= link_to status_text(import_job), import_job_path(import_job), class: "import_job_status_#{import_job.status}" %>
+          </td>
           <% if import_job.workflow_action == :resubmit %>
             <td><%= button_to 'Resubmit', edit_import_job_path(import_job), method: :get, class: 'btn-xs btn-danger' %></td>
           <% elsif import_job.workflow_action == :import %>

--- a/app/views/import_jobs/index.html.erb
+++ b/app/views/import_jobs/index.html.erb
@@ -33,6 +33,7 @@
           <td><%= import_job.cas_user&.name%></td>
           <td><%= import_job.timestamp %></td>
           <td><%= import_job.file_to_upload.filename %></td>
+          <td><%= import_job.model %></td>
           <td>
             <%= link_to status_text(import_job), import_job_path(import_job), class: "import_job_status_#{import_job.status}" %>
           </td>

--- a/app/views/import_jobs/index.html.erb
+++ b/app/views/import_jobs/index.html.erb
@@ -40,7 +40,7 @@
           <% if import_job.workflow_action == :resubmit %>
             <td><%= button_to 'Resubmit', edit_import_job_path(import_job), method: :get, class: 'btn-xs btn-danger' %></td>
           <% elsif import_job.workflow_action == :import %>
-            <td><%= button_to 'Import', perform_import_import_jobs_path(import_job), class: 'btn-xs btn-success' %>
+            <td><%= button_to 'Import', perform_import_import_jobs_path(import_job), class: 'btn-xs btn-success' %></td>
           <% else %>
             <td></td>
           <% end %>

--- a/app/views/import_jobs/show.html.erb
+++ b/app/views/import_jobs/show.html.erb
@@ -8,3 +8,9 @@
                                                             import_job_response: @import_job_response } %>
 
 <%= link_to 'Back', import_jobs_path, class: 'btn btn-danger' %>
+
+<% if @import_job.workflow_action == :resubmit %>
+  <%= link_to 'Resubmit', edit_import_job_path(@import_job), class: 'btn btn-danger' %>
+<% elsif @import_job.workflow_action == :import %>
+  <%= link_to 'Import', perform_import_import_jobs_path(@import_job), method: :post, class: 'btn btn-success' %>
+<% end %>

--- a/app/views/import_jobs/show.html.erb
+++ b/app/views/import_jobs/show.html.erb
@@ -5,7 +5,8 @@
 <%= render partial: "import_job_info_panel", locals: {import_job: @import_job} %>
 
 <%= render partial: "import_job_validation_panel", locals: {import_job: @import_job,
-                                                            import_job_response: @import_job_response } %>
+                                                            import_job_response: @import_job_response,
+                                                            status_text: status_text(@import_job) } %>
 
 <%= link_to 'Back', import_jobs_path, class: 'btn btn-danger' %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -53,6 +53,7 @@ en:
           validate_error: Validation Error
           import_success: Import Successful
           import_failed: Import Failed
+          import_error: Import Error
           import_pending: Pending
           in_progress: In Progress
           error: Error

--- a/test/controllers/import_jobs_controller_test.rb
+++ b/test/controllers/import_jobs_controller_test.rb
@@ -225,42 +225,42 @@ class ImportJobsControllerTest < ActionController::TestCase
     end
   end
 
-  test 'status_text should show information about the current status' do
+  test 'status_text should show information about the current status' do # rubocop:disable Metrics/BlockLength:
     tests = [
       # Validate Stages
-      { stage: 'validate', status: :validate_pending,  progress: 0,
-        expected_text: I18n.t("activerecord.attributes.import_job.status.validate_pending") },
+      { stage: 'validate', status: :validate_pending, progress: 0,
+        expected_text: I18n.t('activerecord.attributes.import_job.status.validate_pending') },
       { stage: 'validate', status: :validate_success, progress: 100,
-        expected_text: I18n.t("activerecord.attributes.import_job.status.validate_success") },
+        expected_text: I18n.t('activerecord.attributes.import_job.status.validate_success') },
       { stage: 'validate', status: :validate_failed, progress: 100,
-        expected_text: I18n.t("activerecord.attributes.import_job.status.validate_failed") },
+        expected_text: I18n.t('activerecord.attributes.import_job.status.validate_failed') },
 
       # Import Stages
       { stage: 'import', status: :import_pending, progress: 0,
-        expected_text: I18n.t("activerecord.attributes.import_job.status.import_pending") },
+        expected_text: I18n.t('activerecord.attributes.import_job.status.import_pending') },
       { stage: 'import', status: :import_success, progress: 100,
-        expected_text: I18n.t("activerecord.attributes.import_job.status.import_success") },
+        expected_text: I18n.t('activerecord.attributes.import_job.status.import_success') },
       { stage: 'import', status: :import_failed, progress: 100,
-        expected_text: I18n.t("activerecord.attributes.import_job.status.import_failed") },
+        expected_text: I18n.t('activerecord.attributes.import_job.status.import_failed') },
 
       # Error
       { stage: 'validate', status: :error, progress: 0,
-        expected_text: I18n.t("activerecord.attributes.import_job.status.error") },
+        expected_text: I18n.t('activerecord.attributes.import_job.status.error') },
       { stage: 'import', status: :error, progress: 0,
-        expected_text: I18n.t("activerecord.attributes.import_job.status.error") },
+        expected_text: I18n.t('activerecord.attributes.import_job.status.error') },
 
       # In Progress (with non-zero percentage)
       { stage: 'validate', status: :in_progress, progress: 20,
-        expected_text: "#{I18n.t("activerecord.attributes.import_job.stage.validate")} (20%)" },
+        expected_text: "#{I18n.t('activerecord.attributes.import_job.stage.validate')} (20%)" },
       { stage: 'import', status: :in_progress, progress: 20,
-        expected_text: "#{I18n.t("activerecord.attributes.import_job.stage.import")} (20%)" },
+        expected_text: "#{I18n.t('activerecord.attributes.import_job.stage.import')} (20%)" },
 
       # In Progress (zero percentage)
       { stage: 'validate', status: :in_progress, progress: 0,
-        expected_text: I18n.t("activerecord.attributes.import_job.status.in_progress") },
+        expected_text: I18n.t('activerecord.attributes.import_job.status.in_progress') },
       { stage: 'import', status: :in_progress, progress: 0,
-        expected_text: I18n.t("activerecord.attributes.import_job.status.in_progress") },
-      ]
+        expected_text: I18n.t('activerecord.attributes.import_job.status.in_progress') }
+    ]
 
     tests.each do |test|
       import_job = ImportJob.first

--- a/test/controllers/import_jobs_controller_test.rb
+++ b/test/controllers/import_jobs_controller_test.rb
@@ -224,4 +224,52 @@ class ImportJobsControllerTest < ActionController::TestCase
       assert_equal I18n.t(:cannot_import_invalid_file), flash[:error], "Allowed import when status is #{status}"
     end
   end
+
+  test 'status_text should show information about the current status' do
+    tests = [
+      # Validate Stages
+      { stage: 'validate', status: :validate_pending,  progress: 0,
+        expected_text: I18n.t("activerecord.attributes.import_job.status.validate_pending") },
+      { stage: 'validate', status: :validate_success, progress: 100,
+        expected_text: I18n.t("activerecord.attributes.import_job.status.validate_success") },
+      { stage: 'validate', status: :validate_failed, progress: 100,
+        expected_text: I18n.t("activerecord.attributes.import_job.status.validate_failed") },
+
+      # Import Stages
+      { stage: 'import', status: :import_pending, progress: 0,
+        expected_text: I18n.t("activerecord.attributes.import_job.status.import_pending") },
+      { stage: 'import', status: :import_success, progress: 100,
+        expected_text: I18n.t("activerecord.attributes.import_job.status.import_success") },
+      { stage: 'import', status: :import_failed, progress: 100,
+        expected_text: I18n.t("activerecord.attributes.import_job.status.import_failed") },
+
+      # Error
+      { stage: 'validate', status: :error, progress: 0,
+        expected_text: I18n.t("activerecord.attributes.import_job.status.error") },
+      { stage: 'import', status: :error, progress: 0,
+        expected_text: I18n.t("activerecord.attributes.import_job.status.error") },
+
+      # In Progress (with non-zero percentage)
+      { stage: 'validate', status: :in_progress, progress: 20,
+        expected_text: "#{I18n.t("activerecord.attributes.import_job.stage.validate")} (20%)" },
+      { stage: 'import', status: :in_progress, progress: 20,
+        expected_text: "#{I18n.t("activerecord.attributes.import_job.stage.import")} (20%)" },
+
+      # In Progress (zero percentage)
+      { stage: 'validate', status: :in_progress, progress: 0,
+        expected_text: I18n.t("activerecord.attributes.import_job.status.in_progress") },
+      { stage: 'import', status: :in_progress, progress: 0,
+        expected_text: I18n.t("activerecord.attributes.import_job.status.in_progress") },
+      ]
+
+    tests.each do |test|
+      import_job = ImportJob.first
+      import_job.stage = test[:stage]
+      import_job.progress = test[:progress]
+      import_job.stub(:status, test[:status]) do
+        status_text = @controller.status_text(import_job)
+        assert_equal test[:expected_text], status_text, "Failed for #{test[:stage]}, #{test[:status]}, #{test[:progress]}"
+      end
+    end
+  end
 end

--- a/test/controllers/import_jobs_controller_test.rb
+++ b/test/controllers/import_jobs_controller_test.rb
@@ -244,9 +244,11 @@ class ImportJobsControllerTest < ActionController::TestCase
         expected_text: I18n.t('activerecord.attributes.import_job.status.import_failed') },
 
       # Error
-      { stage: 'validate', status: :error, progress: 0,
-        expected_text: I18n.t('activerecord.attributes.import_job.status.error') },
-      { stage: 'import', status: :error, progress: 0,
+      { stage: 'validate', status: :validate_error, progress: 0,
+        expected_text: I18n.t('activerecord.attributes.import_job.status.validate_error') },
+      { stage: 'import', status: :import_error, progress: 0,
+        expected_text: I18n.t('activerecord.attributes.import_job.status.import_error') },
+      { stage: nil, status: :error, progress: 0,
         expected_text: I18n.t('activerecord.attributes.import_job.status.error') },
 
       # In Progress (with non-zero percentage)

--- a/test/services/import_job_response_test.rb
+++ b/test/services/import_job_response_test.rb
@@ -12,6 +12,7 @@ class ImportJobResponseTest < Minitest::Test
     assert_equal(false, import_job_response.valid?)
     assert_equal(true, import_job_response.server_error?)
     assert_equal(:invalid_response_from_server, import_job_response.server_error)
+    assert_equal('', import_job_response.json_pretty_print)
   end
 
   def test_empty_response
@@ -20,6 +21,7 @@ class ImportJobResponseTest < Minitest::Test
     assert_equal(false, import_job_response.valid?)
     assert_equal(true, import_job_response.server_error?)
     assert_equal(:invalid_response_from_server, import_job_response.server_error)
+    assert_equal('', import_job_response.json_pretty_print)
   end
 
   def test_invalid_json # rubocop:disable Metrics/MethodLength
@@ -34,6 +36,7 @@ class ImportJobResponseTest < Minitest::Test
       assert_equal(false, import_job_response.valid?, "JSON: #{json}")
       assert_equal(true, import_job_response.server_error?, "JSON: #{json}")
       assert_equal(:invalid_response_from_server, import_job_response.server_error, "JSON: #{json}")
+      assert_equal(JSON.pretty_generate(JSON.parse(json)), import_job_response.json_pretty_print, "JSON: #{json}")
     end
   end
 
@@ -54,6 +57,7 @@ class ImportJobResponseTest < Minitest::Test
                    "JSON: #{json}")
       assert_equal(0, import_job_response.num_invalid, "JSON: #{json}")
       assert_equal(0, import_job_response.num_error, "JSON: #{json}")
+      assert_equal(JSON.pretty_generate(JSON.parse(json)), import_job_response.json_pretty_print, "JSON: #{json}")
     end
   end
 
@@ -73,10 +77,11 @@ class ImportJobResponseTest < Minitest::Test
       assert_equal(import_job_response.num_total,
                    import_job_response.num_valid + import_job_response.num_invalid + import_job_response.num_error,
                    "JSON: #{json}")
+      assert_equal(JSON.pretty_generate(JSON.parse(json)), import_job_response.json_pretty_print, "JSON: #{json}")
     end
   end
 
-  def test_valid_json_and_failed_validation_with_invalid_data # rubocop:disable Metrics/MethodLength
+  def test_valid_json_and_failed_validation_with_invalid_data # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
     json = <<~JSON_END
       { "count": {"total": 1, "updated": 0, "unchanged": 0, "valid": 0, "invalid": 1, "errors": 0},
         "validation": [
@@ -103,9 +108,10 @@ class ImportJobResponseTest < Minitest::Test
     assert_equal(1, invalid_lines.count)
     assert_equal('2', invalid_lines[0].line_location)
     assert_equal('date', invalid_lines[0].field_errors[0])
+    assert_equal(JSON.pretty_generate(JSON.parse(json)), import_job_response.json_pretty_print, "JSON: #{json}")
   end
 
-  def test_valid_json_and_failed_validation_with_wrong_number_of_columns # rubocop:disable Metrics/MethodLength
+  def test_valid_json_and_failed_validation_with_wrong_number_of_columns # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
     json = <<~JSON_END
       { "count": {"total": 1, "updated": 0, "unchanged": 0, "valid": 0, "invalid": 1, "errors": 0},
         "validation": [
@@ -125,5 +131,6 @@ class ImportJobResponseTest < Minitest::Test
     assert_equal(1, invalid_lines.count)
     assert_equal('3', invalid_lines[0].line_location)
     assert_equal('Line <>:3 has the wrong number of columns', invalid_lines[0].line_error)
+    assert_equal(JSON.pretty_generate(JSON.parse(json)), import_job_response.json_pretty_print, "JSON: #{json}")
   end
 end


### PR DESCRIPTION
Added a collapsed "JSON" panel to the "Validation" panel for import
jobs, which shows pretty-printed JSON when uncollapsed.

"JSON" panel will not be displayed if there is no JSON to display
(for example, if a server error occurred).

https://issues.umd.edu/browse/LIBHYDRA-268