### PR TITLE
LIBHYDRA-270. Refactored Import Jobs to store response headers

### DIFF
--- a/app/controllers/import_jobs_controller.rb
+++ b/app/controllers/import_jobs_controller.rb
@@ -19,8 +19,7 @@ class ImportJobsController < ApplicationController # rubocop:disable Metrics/Cla
   # GET /import_jobs/1
   # GET /import_jobs/1.json
   def show
-    response_message = @import_job.last_response
-    @import_job_response = ImportJobResponse.new(response_message)
+    @import_job_response = @import_job.last_response
   end
 
   # GET /import_jobs/new
@@ -37,8 +36,7 @@ class ImportJobsController < ApplicationController # rubocop:disable Metrics/Cla
       return
     end
 
-    response_message = @import_job.last_response
-    @import_job_response = ImportJobResponse.new(response_message)
+    @import_job_response = @import_job.last_response
   end
 
   # POST /import_jobs
@@ -80,8 +78,7 @@ class ImportJobsController < ApplicationController # rubocop:disable Metrics/Cla
       return
     end
 
-    response_message = @import_job.last_response
-    @import_job_response = ImportJobResponse.new(response_message)
+    @import_job_response = @import_job.last_response
     render :edit
   end
 

--- a/app/models/import_job.rb
+++ b/app/models/import_job.rb
@@ -67,7 +67,7 @@ class ImportJob < ApplicationRecord
 
     return :in_progress unless plastron_status_done?
 
-    response = ImportJobResponse.new(last_response)
+    response = ImportJobResponse.new(last_response_headers, last_response_body)
     return "#{stage}_success".to_sym if response.valid?
 
     "#{stage}_failed".to_sym
@@ -99,7 +99,12 @@ class ImportJob < ApplicationRecord
 
   def update_status(plastron_message)
     self.plastron_status = plastron_message.headers['PlastronJobStatus']
-    self.last_response = plastron_message.body
+    self.last_response_headers = plastron_message.headers_json
+    self.last_response_body = plastron_message.body
     save!
+  end
+
+  def last_response
+    ImportJobResponse.new(last_response_headers, last_response_body)
   end
 end

--- a/app/services/stomp_client.rb
+++ b/app/services/stomp_client.rb
@@ -77,6 +77,11 @@ class PlastronMessage
     @job_id = @headers['PlastronJobId']
   end
 
+  # Parse the message headers as JSON and return the result.
+  def headers_json
+    @headers.to_json
+  end
+
   # Parse the message body as JSON and return the result.
   def body_json
     JSON.parse(@body)

--- a/app/views/import_jobs/_import_job_validation_panel.erb
+++ b/app/views/import_jobs/_import_job_validation_panel.erb
@@ -63,7 +63,9 @@
       </div>
     <% end %>
 
-    <% unless import_job_response.json_pretty_print.empty? %>
+    <% json_headers = import_job_response.headers_pretty_print %>
+    <% json_body = import_job_response.body_pretty_print %>
+    <% if json_headers.present? or json_body.present? %>
       <div class="panel panel-default">
         <div class="panel-heading">
           <div class="panel-title">
@@ -73,7 +75,10 @@
           </div>
         </div>
         <div id="json_panel" class="panel-body collapse">
-          <pre><code><%= import_job_response.json_pretty_print %></code></pre>
+            <h4>Headers</h4>
+            <pre><code><%= json_headers %></code></pre>
+            <h4>Body</h4>
+            <pre><code><%= json_body %></code></pre>
         </div>
       </div>
     <% end %>

--- a/db/migrate/20200416134039_add_last_response_headers_to_import_job.rb
+++ b/db/migrate/20200416134039_add_last_response_headers_to_import_job.rb
@@ -1,0 +1,5 @@
+class AddLastResponseHeadersToImportJob < ActiveRecord::Migration[5.2]
+  def change
+    add_column :import_jobs, :last_response_headers, :text
+  end
+end

--- a/db/migrate/20200416134423_rename_last_response_to_last_response_body_in_import_job.rb
+++ b/db/migrate/20200416134423_rename_last_response_to_last_response_body_in_import_job.rb
@@ -1,0 +1,5 @@
+class RenameLastResponseToLastResponseBodyInImportJob < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :import_jobs, :last_response, :last_response_body
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_15_170216) do
+ActiveRecord::Schema.define(version: 2020_04_16_134039) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -111,6 +111,7 @@ ActiveRecord::Schema.define(version: 2020_04_15_170216) do
     t.integer "progress"
     t.text "last_response"
     t.string "model"
+    t.text "last_response_headers"
     t.index ["cas_user_id"], name: "index_import_jobs_on_cas_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_16_134039) do
+ActiveRecord::Schema.define(version: 2020_04_16_134423) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -109,7 +109,7 @@ ActiveRecord::Schema.define(version: 2020_04_16_134039) do
     t.string "status"
     t.string "plastron_status"
     t.integer "progress"
-    t.text "last_response"
+    t.text "last_response_body"
     t.string "model"
     t.text "last_response_headers"
     t.index ["cas_user_id"], name: "index_import_jobs_on_cas_user_id"

--- a/test/models/import_job_test.rb
+++ b/test/models/import_job_test.rb
@@ -3,7 +3,7 @@
 require 'test_helper'
 
 class ImportJobTest < ActiveSupport::TestCase
-  test 'status reflects current status of job' do
+  test 'status reflects current status of job' do # rubocop:disable Metrics/BlockLength
     import_job = import_jobs(:one)
 
     json_successful_response =
@@ -26,7 +26,8 @@ class ImportJobTest < ActiveSupport::TestCase
     tests.each do |test|
       import_job.stage = test[:import_job_stage]
       import_job.plastron_status = test[:plastron_status]
-      import_job.last_response = test[:response]
+      import_job.last_response_headers = '{}' # Simple valid header
+      import_job.last_response_body = test[:response]
       import_job.save!
       expected = test[:expected]
       assert_equal(expected, import_job.status, "Failed for (#{import_job.stage}, #{import_job.plastron_status})")

--- a/test/services/import_job_response_test.rb
+++ b/test/services/import_job_response_test.rb
@@ -6,48 +6,110 @@ class ImportJobResponseTest < Minitest::Test
   def setup
   end
 
-  def test_nil_response
-    json = nil
-    import_job_response = ImportJobResponse.new(json)
+  def test_nil_headers_and_body
+    headers_json = nil
+    body_json = nil
+    import_job_response = ImportJobResponse.new(headers_json, body_json)
     assert_equal(false, import_job_response.valid?)
     assert_equal(true, import_job_response.server_error?)
     assert_equal(:invalid_response_from_server, import_job_response.server_error)
-    assert_equal('', import_job_response.json_pretty_print)
+    assert_equal('', import_job_response.headers_pretty_print)
+    assert_equal('', import_job_response.body_pretty_print)
   end
 
-  def test_empty_response
-    json = ''
-    import_job_response = ImportJobResponse.new(json)
+  def test_empty_headers_and_body
+    headers_json = ''
+    body_json = ''
+    import_job_response = ImportJobResponse.new(headers_json, body_json)
     assert_equal(false, import_job_response.valid?)
     assert_equal(true, import_job_response.server_error?)
     assert_equal(:invalid_response_from_server, import_job_response.server_error)
-    assert_equal('', import_job_response.json_pretty_print)
+    assert_equal('', import_job_response.headers_pretty_print)
+    assert_equal('', import_job_response.body_pretty_print)
   end
 
-  def test_invalid_json # rubocop:disable Metrics/MethodLength
-    invalid_jsons = [
+  def test_nil_headers_and_valid_body
+    headers_json = nil
+    body_json = '{ "count": { "total": 2, "updated": 0, "unchanged": 0, "valid": 1, "invalid": 1, "errors": "0" }, "validation": [] }'
+    import_job_response = ImportJobResponse.new(headers_json, body_json)
+    assert_equal(false, import_job_response.valid?)
+    assert_equal(true, import_job_response.server_error?)
+    assert_equal(:invalid_response_from_server, import_job_response.server_error)
+    assert_equal('', import_job_response.headers_pretty_print)
+    assert_equal('', import_job_response.body_pretty_print)
+  end
+
+  def test_empty_headers_and_valid_body
+    headers_json = ''
+    body_json = '{ "count": { "total": 2, "updated": 0, "unchanged": 0, "valid": 1, "invalid": 1, "errors": "0" }, "validation": [] }'
+    import_job_response = ImportJobResponse.new(headers_json, body_json)
+    assert_equal(false, import_job_response.valid?)
+    assert_equal(true, import_job_response.server_error?)
+    assert_equal(:invalid_response_from_server, import_job_response.server_error)
+    assert_equal('', import_job_response.headers_pretty_print)
+    assert_equal('', import_job_response.body_pretty_print)
+  end
+
+  def test_invalid_headers_and_valid_body
+    headers_json = 'INVALID_JSON'
+    body_json = '{ "count": { "total": 2, "updated": 0, "unchanged": 0, "valid": 1, "invalid": 1, "errors": "0" }, "validation": [] }'
+    import_job_response = ImportJobResponse.new(headers_json, body_json)
+    assert_equal(false, import_job_response.valid?)
+    assert_equal(true, import_job_response.server_error?)
+    assert_equal(:invalid_response_from_server, import_job_response.server_error)
+    assert_equal('', import_job_response.headers_pretty_print)
+    assert_equal('', import_job_response.body_pretty_print)
+  end
+
+  def test_valid_headers_and_nil_body
+    headers_json = '{"expires":"0","destination":"/queue/plastron.jobs.completed","PlastronJobId":"http://localhost:3000/import_jobs/1","PlastronJobStatus":"Error","PlastronJobError":"Unrecognized header \"Volume\" in import file."}'
+    body_json = nil
+    import_job_response = ImportJobResponse.new(headers_json, body_json)
+    assert_equal(false, import_job_response.valid?)
+    assert_equal(true, import_job_response.server_error?)
+    assert_equal(:invalid_response_from_server, import_job_response.server_error)
+    assert_equal(JSON.pretty_generate(JSON.parse(headers_json)), import_job_response.headers_pretty_print)
+    assert_equal('', import_job_response.body_pretty_print)
+  end
+
+  def test_valid_headers_and_empty_body
+    headers_json = '{"expires":"0","destination":"/queue/plastron.jobs.completed","PlastronJobId":"http://localhost:3000/import_jobs/1","PlastronJobStatus":"Error","PlastronJobError":"Unrecognized header \"Volume\" in import file."}'
+    body_json = ''
+    import_job_response = ImportJobResponse.new(headers_json, body_json)
+    assert_equal(false, import_job_response.valid?)
+    assert_equal(true, import_job_response.server_error?)
+    assert_equal(:invalid_response_from_server, import_job_response.server_error)
+    assert_equal(JSON.pretty_generate(JSON.parse(headers_json)), import_job_response.headers_pretty_print)
+    assert_equal('', import_job_response.body_pretty_print)
+  end
+
+  def test_valid_headers_and_invalid_body # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+    headers_json = '{"expires":"0","destination":"/queue/plastron.jobs.completed"}'
+    invalid_body_jsons = [
       '{ "foo": "bar" }',
       '{ "count": { "foo": "bar" } }',
       '{ "count": { "total": 1, "updated": 0, "unchanged": 0, "valid": 1, "invalid": 0, "errors": "abc" } }'
     ]
 
-    invalid_jsons.each do |json|
-      import_job_response = ImportJobResponse.new(json)
+    invalid_body_jsons.each do |json|
+      import_job_response = ImportJobResponse.new(headers_json, json)
       assert_equal(false, import_job_response.valid?, "JSON: #{json}")
       assert_equal(true, import_job_response.server_error?, "JSON: #{json}")
       assert_equal(:invalid_response_from_server, import_job_response.server_error, "JSON: #{json}")
-      assert_equal(JSON.pretty_generate(JSON.parse(json)), import_job_response.json_pretty_print, "JSON: #{json}")
+      assert_equal(JSON.pretty_generate(JSON.parse(headers_json)), import_job_response.headers_pretty_print)
+      assert_equal(JSON.pretty_generate(JSON.parse(json)), import_job_response.body_pretty_print)
     end
   end
 
   def test_valid_json_and_successful_validation # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
-    jsons = [
+    headers_json = '{"expires":"0","destination":"/queue/plastron.jobs.completed"}'
+    valid_body_jsons = [
       '{ "count": { "total": 1, "updated": 0, "unchanged": 0, "valid": 1, "invalid": 0, "errors": 0 } }',
       '{ "count": { "total": 45, "updated": 0, "unchanged": 0, "valid": 45, "invalid": 0, "errors": 0 } }'
     ]
 
-    jsons.each do |json|
-      import_job_response = ImportJobResponse.new(json)
+    valid_body_jsons.each do |json|
+      import_job_response = ImportJobResponse.new(headers_json, json)
       assert_equal(true, import_job_response.valid?, "JSON: #{json}")
       assert_equal(false, import_job_response.server_error?, "JSON: #{json}")
       assert_nil import_job_response.server_error, "JSON: #{json}"
@@ -57,18 +119,20 @@ class ImportJobResponseTest < Minitest::Test
                    "JSON: #{json}")
       assert_equal(0, import_job_response.num_invalid, "JSON: #{json}")
       assert_equal(0, import_job_response.num_error, "JSON: #{json}")
-      assert_equal(JSON.pretty_generate(JSON.parse(json)), import_job_response.json_pretty_print, "JSON: #{json}")
+      assert_equal(JSON.pretty_generate(JSON.parse(headers_json)), import_job_response.headers_pretty_print)
+      assert_equal(JSON.pretty_generate(JSON.parse(json)), import_job_response.body_pretty_print)
     end
   end
 
   def test_valid_json_and_failed_validation # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
-    jsons = [
+    headers_json = '{"expires":"0","destination":"/queue/plastron.jobs.completed"}'
+    valid_body_jsons = [
       '{ "count": { "total": 2, "updated": 0, "unchanged": 0, "valid": 1, "invalid": 1, "errors": "0" }, "validation": [] }',
       '{ "count": { "total": 47, "updated": 0, "unchanged": 0, "valid": 45, "invalid": 0, "errors": 2 }, "validation": [] }'
     ]
 
-    jsons.each do |json|
-      import_job_response = ImportJobResponse.new(json)
+    valid_body_jsons.each do |json|
+      import_job_response = ImportJobResponse.new(headers_json, json)
       assert_equal(false, import_job_response.valid?, "JSON: #{json}")
       assert_equal(false, import_job_response.server_error?, "JSON: #{json}")
       assert_nil import_job_response.server_error, "JSON: #{json}"
@@ -77,12 +141,14 @@ class ImportJobResponseTest < Minitest::Test
       assert_equal(import_job_response.num_total,
                    import_job_response.num_valid + import_job_response.num_invalid + import_job_response.num_error,
                    "JSON: #{json}")
-      assert_equal(JSON.pretty_generate(JSON.parse(json)), import_job_response.json_pretty_print, "JSON: #{json}")
+      assert_equal(JSON.pretty_generate(JSON.parse(headers_json)), import_job_response.headers_pretty_print)
+      assert_equal(JSON.pretty_generate(JSON.parse(json)), import_job_response.body_pretty_print)
     end
   end
 
   def test_valid_json_and_failed_validation_with_invalid_data # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
-    json = <<~JSON_END
+    headers_json = '{"expires":"0","destination":"/queue/plastron.jobs.completed"}'
+    body_json = <<~JSON_END
       { "count": {"total": 1, "updated": 0, "unchanged": 0, "valid": 0, "invalid": 1, "errors": 0},
         "validation": [
           { "line": "<>:2", "is_valid": false,
@@ -101,18 +167,20 @@ class ImportJobResponseTest < Minitest::Test
       }
     JSON_END
 
-    import_job_response = ImportJobResponse.new(json)
+    import_job_response = ImportJobResponse.new(headers_json, body_json)
     invalid_lines = import_job_response.invalid_lines
 
     assert_equal(false, import_job_response.valid?)
     assert_equal(1, invalid_lines.count)
     assert_equal('2', invalid_lines[0].line_location)
     assert_equal('date', invalid_lines[0].field_errors[0])
-    assert_equal(JSON.pretty_generate(JSON.parse(json)), import_job_response.json_pretty_print, "JSON: #{json}")
+    assert_equal(JSON.pretty_generate(JSON.parse(headers_json)), import_job_response.headers_pretty_print)
+    assert_equal(JSON.pretty_generate(JSON.parse(body_json)), import_job_response.body_pretty_print)
   end
 
   def test_valid_json_and_failed_validation_with_wrong_number_of_columns # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
-    json = <<~JSON_END
+    headers_json = '{"expires":"0","destination":"/queue/plastron.jobs.completed"}'
+    body_json = <<~JSON_END
       { "count": {"total": 1, "updated": 0, "unchanged": 0, "valid": 0, "invalid": 1, "errors": 0},
         "validation": [
           {
@@ -124,13 +192,14 @@ class ImportJobResponseTest < Minitest::Test
       }
     JSON_END
 
-    import_job_response = ImportJobResponse.new(json)
+    import_job_response = ImportJobResponse.new(headers_json, body_json)
     invalid_lines = import_job_response.invalid_lines
 
     assert_equal(false, import_job_response.valid?)
     assert_equal(1, invalid_lines.count)
     assert_equal('3', invalid_lines[0].line_location)
     assert_equal('Line <>:3 has the wrong number of columns', invalid_lines[0].line_error)
-    assert_equal(JSON.pretty_generate(JSON.parse(json)), import_job_response.json_pretty_print, "JSON: #{json}")
+    assert_equal(JSON.pretty_generate(JSON.parse(headers_json)), import_job_response.headers_pretty_print)
+    assert_equal(JSON.pretty_generate(JSON.parse(body_json)), import_job_response.body_pretty_print)
   end
 end


### PR DESCRIPTION
In "import_jobs" table, renamed "last_response" to "last_response_body", and added a "last_response_headers" field.

Refactored ImportJobResponse to include headers. Replaced "json_pretty_print" method with "headers_pretty_print" and "body_pretty_print" methods to give extra flexibility to the views about how to display the JSON in the GUI.

Added "last_response" method to ImportJob model to return an ImportJobResponse object. This should hopefully better insulate the model and controllers from changes in the import job message formats.

Added "headers_json" method to StompClient, to enable the headers to be stored in the database in JSON format, instead of Ruby serialization.

Modified "_import_job_validation_panel.erb" to display headers and body in the "JSON" subpanel.

Updated the tests

https://issues.umd.edu/browse/LIBHYDRA-270