### PR TITLE
LIBHYDRA-271. Modified to use "PlastronArg-on-behalf-of" header

### DIFF
--- a/app/controllers/export_jobs_controller.rb
+++ b/app/controllers/export_jobs_controller.rb
@@ -92,7 +92,7 @@ class ExportJobsController < ApplicationController
         PlastronCommand: 'export',
         PlastronJobId: export_job_url(job),
         'PlastronArg-name': job.name,
-        'PlastronArg-username': job.cas_user.cas_directory_id,
+        'PlastronArg-on-behalf-of': job.cas_user.cas_directory_id,
         'PlastronArg-format': job.format,
         'PlastronArg-timestamp': job.timestamp,
         persistent: 'true'

--- a/app/controllers/import_jobs_controller.rb
+++ b/app/controllers/import_jobs_controller.rb
@@ -154,7 +154,7 @@ class ImportJobsController < ApplicationController # rubocop:disable Metrics/Cla
         PlastronJobId: import_job_url(job),
         'PlastronArg-model': job.model,
         'PlastronArg-name': job.name,
-        'PlastronArg-username': job.cas_user.cas_directory_id,
+        'PlastronArg-on-behalf-of': job.cas_user.cas_directory_id,
         'PlastronArg-timestamp': job.timestamp
       }
 


### PR DESCRIPTION
Replaced the "PlastronArg-username" argument in the "message_headers"
methods of the ImportJobsController and ExportJobsController with
"PlastronArg-on-behalf-of".

https://issues.umd.edu/browse/LIBHYDRA-271