### PR TITLE
LIBHYDRA-278. Added per-user authorization to export job downloads

### DIFF
--- a/app/controllers/export_jobs_controller.rb
+++ b/app/controllers/export_jobs_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ExportJobsController < ApplicationController
-  before_action -> { authorize! :manage, ExportJob }
+  before_action -> { authorize! :manage, ExportJob }, except: :download
   before_action :cancel_workflow?, only: %i[create review]
   before_action :stomp_client_connected?, only: %i[new create review]
   before_action :selected_items?, only: %i[new create review]
@@ -43,6 +43,10 @@ class ExportJobsController < ApplicationController
 
   def download
     job = ExportJob.find(params[:id])
+
+    # Authorizing here because we aren't using CanCanCan "load_and_authorize_resource"
+    authorize! :download, job
+
     send_data(*job.download_file)
   end
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -10,7 +10,12 @@ class Ability
     elsif user.user?
       can %i[index show], :all
       can :manage, DownloadUrl
+
       can :manage, ExportJob
+      # Users can only download export jobs they own
+      cannot :download, ExportJob
+      can :download, ExportJob, cas_user_id: user.id
+
       can :manage, [Vocabulary, Individual, Type] if user.in_group? :VocabularyEditors
     end
   end

--- a/test/controllers/export_jobs_controller_test.rb
+++ b/test/controllers/export_jobs_controller_test.rb
@@ -83,4 +83,21 @@ class ExportJobsControllerTest < ActionController::TestCase
     jobs = assigns(:jobs)
     assert_equal ExportJob.count, jobs.count
   end
+
+  test 'download can only be done by export job owner or admin' do
+    export_job = export_jobs(:one)
+
+    export_job_owner = export_job.cas_user
+    ability = Ability.new(export_job_owner)
+    assert ability.can?(:download, export_job)
+
+    admin_user = cas_users(:test_admin)
+    ability = Ability.new(admin_user)
+    assert ability.can?(:download, export_job)
+
+    invalid_user = cas_users(:two)
+    assert_not_equal export_job.cas_user, invalid_user
+    ability = Ability.new(invalid_user)
+    assert ability.cannot?(:download, export_job)
+  end
 end


### PR DESCRIPTION
Modified the export job downloads so that export files can only be
downloaded by the job owner and admins.

https://issues.umd.edu/browse/LIBHYDRA-278