### PR TITLE
LIBHYDRA-286. Added "by_identifier" scope to Vocabulary model

### DIFF
--- a/app/controllers/vocabularies_controller.rb
+++ b/app/controllers/vocabularies_controller.rb
@@ -10,7 +10,7 @@ class VocabulariesController < ApplicationController
       @vocabulary = Vocabulary.find_by! identifier: params[:identifier]
       render :show
     else
-      @vocabularies = Vocabulary.all
+      @vocabularies = Vocabulary.all.by_identifier
     end
   end
 

--- a/app/models/vocabulary.rb
+++ b/app/models/vocabulary.rb
@@ -31,6 +31,8 @@ class Vocabulary < ApplicationRecord
   after_save :publish_rdf_async
   after_destroy :delete_published_rdf_async
 
+  scope :by_identifier, -> { order('identifier ASC') }
+
   def uri
     VOCAB_CONFIG['local_authority_base_uri'] + identifier + '#'
   end

--- a/app/views/datatypes/_form.html.erb
+++ b/app/views/datatypes/_form.html.erb
@@ -22,7 +22,7 @@
 
     <div class="form-group">
       <%= form.label :vocabulary_id %>
-      <%= form.collection_select :vocabulary_id, Vocabulary.all, :id, :identifier, {}, { class: "form-control" } %>
+      <%= form.collection_select :vocabulary_id, Vocabulary.all.by_identifier, :id, :identifier, {}, { class: "form-control" } %>
     </div>
   </div>
 

--- a/app/views/individuals/_form.html.erb
+++ b/app/views/individuals/_form.html.erb
@@ -19,7 +19,7 @@
 
     <div class="form-group">
       <%= form.label :vocabulary_id %>
-      <%= form.collection_select :vocabulary_id, Vocabulary.all, :id, :identifier, {}, { class: "form-control" } %>
+      <%= form.collection_select :vocabulary_id, Vocabulary.all.by_identifier, :id, :identifier, {}, { class: "form-control" } %>
     </div>
 
     <div class="form-group">

--- a/app/views/types/_form.html.erb
+++ b/app/views/types/_form.html.erb
@@ -22,7 +22,7 @@
 
     <div class="form-group">
       <%= form.label :vocabulary_id %>
-      <%= form.collection_select :vocabulary_id, Vocabulary.all, :id, :identifier, {}, { class: "form-control" } %>
+      <%= form.collection_select :vocabulary_id, Vocabulary.all.by_identifier, :id, :identifier, {}, { class: "form-control" } %>
     </div>
   </div>
 


### PR DESCRIPTION
Added "by_identifier" scope to Vocabulary model to enable vocabularies
to be easily sorted into alphabetical order by identifiers.

Updated controller and ERB calls where multiple vocabularies are
returned to use the "by_identifier" scope to ensure that the
vocabularies are sorted.

https://issues.umd.edu/browse/LIBHYDRA-286