### PR TITLE
LIBHYDRA-290. Moved "New Import Job"/"New Vocabulary" buttons to top

### DIFF
--- a/app/views/import_jobs/index.html.erb
+++ b/app/views/import_jobs/index.html.erb
@@ -2,6 +2,8 @@
 
 <h1>Metadata Import</h1>
 
+<%= link_to 'New Import Job', new_import_job_path, class: 'btn btn-success' %>
+
 <% if @import_jobs.count > 0 %>
   <div class="row">
     <div class="btn-toolbar">
@@ -55,4 +57,3 @@
   <p>No Import jobs found</p>
 <% end %>
 
-<%= link_to 'New Import Job', new_import_job_path, class: 'btn btn-success' %>

--- a/app/views/vocabularies/index.html.erb
+++ b/app/views/vocabularies/index.html.erb
@@ -1,5 +1,11 @@
 <h1><%= ActiveSupport::Inflector.pluralize(t 'activerecord.models.vocabulary') %></h1>
 
+<% if can? :create, Vocabulary %>
+  <div>
+    <%= link_to "New #{t 'activerecord.models.vocabulary'}", new_vocabulary_path, class: 'btn btn-success' %>
+  </div>
+<% end %>
+
 <table class="table">
   <thead>
     <tr>
@@ -27,8 +33,3 @@
   </tbody>
 </table>
 
-<% if can? :create, Vocabulary %>
-  <div>
-    <%= link_to "New #{t 'activerecord.models.vocabulary'}", new_vocabulary_path, class: 'btn btn-success' %>
-  </div>
-<% end %>


### PR DESCRIPTION
Moved the "New Import Job"/"New Vocabulary" buttons to the the top of
their respective pages, between the page header and table.

https://issues.umd.edu/browse/LIBHYDRA-290