### PR TITLE
LIBHYDRA-292. Added binary source selection to the import jobs

### DIFF
--- a/app/controllers/import_jobs_controller.rb
+++ b/app/controllers/import_jobs_controller.rb
@@ -177,11 +177,14 @@ class ImportJobsController < ApplicationController # rubocop:disable Metrics/Cla
       }.tap do |headers|
         headers['PlastronArg-access'] = "<#{job.access}>" if job.access.present?
         headers['PlastronArg-validate-only'] = 'True' if validate_only
+        headers['PlastronArg-binaries-location'] = job.remote_server if job.remote_server.present?
       end
     end
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def import_job_params
-      params.require(:import_job).permit(:name, :model, :access, :collection, :file_to_upload, :binary_zip_file)
+      params.require(:import_job).permit(:name, :model, :access, :collection,
+                                         :file_to_upload, :binary_zip_file,
+                                         :remote_server)
     end
 end

--- a/app/controllers/import_jobs_controller.rb
+++ b/app/controllers/import_jobs_controller.rb
@@ -182,6 +182,6 @@ class ImportJobsController < ApplicationController # rubocop:disable Metrics/Cla
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def import_job_params
-      params.require(:import_job).permit(:name, :model, :access, :collection, :file_to_upload)
+      params.require(:import_job).permit(:name, :model, :access, :collection, :file_to_upload, :binary_zip_file)
     end
 end

--- a/app/controllers/import_jobs_controller.rb
+++ b/app/controllers/import_jobs_controller.rb
@@ -64,15 +64,15 @@ class ImportJobsController < ApplicationController # rubocop:disable Metrics/Cla
 
     valid_update = @import_job.update(import_job_params)
 
-    # Need special handing of "file_to_upload", because if we're gotten this
+    # Need special handing of "metadata_file", because if we're gotten this
     # far, the @import_job already has a file attached, so the
     # "attachment_validation" method on the model won't catch that the
     # update form submission doesn't have new file attached.
     #
     # Need to have the method after the call to @import_job.update, as
     # update clears the "errors" array
-    if import_job_params['file_to_upload'].nil?
-      @import_job.errors.add(:file_to_upload, :required)
+    if import_job_params['metadata_file'].nil?
+      @import_job.errors.add(:metadata_file, :required)
       valid_update = false
     end
 
@@ -153,7 +153,7 @@ class ImportJobsController < ApplicationController # rubocop:disable Metrics/Cla
     end
 
     def submit_job(import_job, validate_only)
-      body = import_job.file_to_upload.download
+      body = import_job.metadata_file.download
       headers = message_headers(import_job, validate_only)
 
       import_job.plastron_status = :plastron_status_in_progress
@@ -184,7 +184,7 @@ class ImportJobsController < ApplicationController # rubocop:disable Metrics/Cla
     # Never trust parameters from the scary internet, only allow the white list through.
     def import_job_params
       params.require(:import_job).permit(:name, :model, :access, :collection,
-                                         :file_to_upload, :binary_zip_file,
+                                         :metadata_file, :binary_zip_file,
                                          :remote_server)
     end
 end

--- a/app/models/import_job.rb
+++ b/app/models/import_job.rb
@@ -47,6 +47,7 @@ class ImportJob < ApplicationRecord
 
   belongs_to :cas_user
   has_one_attached :file_to_upload
+  has_one_attached :binary_zip_file
 
   after_commit { ImportJobRelayJob.perform_later(self) }
 
@@ -113,5 +114,9 @@ class ImportJob < ApplicationRecord
 
   def last_response
     ImportJobResponse.new(last_response_headers, last_response_body)
+  end
+
+  def binaries?
+    binary_zip_file.attached?
   end
 end

--- a/app/models/import_job.rb
+++ b/app/models/import_job.rb
@@ -54,6 +54,7 @@ class ImportJob < ApplicationRecord
   validates :name, presence: true
   validates :collection, presence: true
   validate :attachment_validation
+  validate :include_binaries_options
 
   def self.access_vocab
     @access_vocab ||= Vocabulary.find_by identifier: VOCAB_CONFIG['access_vocab_identifier']
@@ -63,6 +64,12 @@ class ImportJob < ApplicationRecord
   # until at least Rails 6 (see https://stackoverflow.com/questions/48158770/activestorage-file-attachment-validation)
   def attachment_validation
     errors.add(:file_to_upload, :required) unless file_to_upload.attached?
+  end
+
+  # Raises an error if both a "binary_zip_file" and a "remote server" field
+  # is provided
+  def include_binaries_options
+    errors.add(:base, :multiple_include_binaries_options) if binary_zip_file.attached? && remote_server.present?
   end
 
   # Returns a symbol reflecting the current status

--- a/app/models/import_job.rb
+++ b/app/models/import_job.rb
@@ -46,7 +46,7 @@ class ImportJob < ApplicationRecord
   include PlastronStatus
 
   belongs_to :cas_user
-  has_one_attached :file_to_upload
+  has_one_attached :metadata_file
   has_one_attached :binary_zip_file
 
   after_commit { ImportJobRelayJob.perform_later(self) }
@@ -63,7 +63,7 @@ class ImportJob < ApplicationRecord
   # Rails 5.2 does not have attachment validation, so this is needed
   # until at least Rails 6 (see https://stackoverflow.com/questions/48158770/activestorage-file-attachment-validation)
   def attachment_validation
-    errors.add(:file_to_upload, :required) unless file_to_upload.attached?
+    errors.add(:metadata_file, :required) unless metadata_file.attached?
   end
 
   # Raises an error if both a "binary_zip_file" and a "remote server" field

--- a/app/models/import_job.rb
+++ b/app/models/import_job.rb
@@ -116,7 +116,9 @@ class ImportJob < ApplicationRecord
     ImportJobResponse.new(last_response_headers, last_response_body)
   end
 
+  # Returns true if a binary zip file is attached, or remote server is
+  # specified, false otherwise.
   def binaries?
-    binary_zip_file.attached?
+    binary_zip_file.attached? || remote_server.present?
   end
 end

--- a/app/views/import_jobs/_form.html.erb
+++ b/app/views/import_jobs/_form.html.erb
@@ -54,7 +54,7 @@
 
   <div class="form-group">
     <div>
-      <%= form.label :file_to_upload, class: "col-form-label-lg" %>
+      <%= form.label :file_to_upload, 'Metadata File to Upload (CSV)', class: "col-form-label-lg" %>
     </div>
     <div class="p-3 ml-5">
       <%= form.file_field :file_to_upload, class: "form-control" %>

--- a/app/views/import_jobs/_form.html.erb
+++ b/app/views/import_jobs/_form.html.erb
@@ -54,10 +54,10 @@
 
   <div class="form-group">
     <div>
-      <%= form.label :file_to_upload, 'Metadata File to Upload (CSV)', class: "col-form-label-lg" %>
+      <%= form.label :metadata_file, 'Metadata File to Upload (CSV)', class: "col-form-label-lg" %>
     </div>
     <div class="p-3 ml-5">
-      <%= form.file_field :file_to_upload, class: "form-control" %>
+      <%= form.file_field :metadata_file, class: "form-control" %>
     </div>
   </div>
 

--- a/app/views/import_jobs/_form.html.erb
+++ b/app/views/import_jobs/_form.html.erb
@@ -61,8 +61,24 @@
     </div>
   </div>
 
-    <div class="form-group">
-      <%= form.submit "Cancel", class: 'btn btn-danger form-control' %>
-      <%= form.submit "Next", class: 'btn btn-primary form-control' %>
+  <div class="panel panel-default">
+    <div class="panel-heading">
+      <h3 class="panel-title">Include Binaries?</h3>
     </div>
+    <div class="panel-body">
+      <div class="form-group">
+        <div>
+          <%= form.label :binary_zip_file, 'Option 1: Upload binary files from my desktop computer', class: "col-form-label-lg" %>
+        </div>
+        <div class="p-3 ml-5">
+          <%= form.file_field :binary_zip_file, class: "form-control" %>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="form-group">
+    <%= form.submit "Cancel", class: 'btn btn-danger form-control' %>
+    <%= form.submit "Next", class: 'btn btn-primary form-control' %>
+  </div>
 <% end %>

--- a/app/views/import_jobs/_form.html.erb
+++ b/app/views/import_jobs/_form.html.erb
@@ -74,6 +74,14 @@
           <%= form.file_field :binary_zip_file, class: "form-control" %>
         </div>
       </div>
+      <div class="form-group">
+        <div>
+          <%= form.label :remote_server, 'Option 2: Upload binary files from a remote server', class: "col-form-label-lg" %>
+        </div>
+        <div class="p-3 ml-5">
+          <%= form.text_field :remote_server, class: "form-control", placeholder:  'sftp://[user@]host[:port]/path' %>
+        </div>
+      </div>
     </div>
   </div>
 

--- a/app/views/import_jobs/_import_job_info_panel.erb
+++ b/app/views/import_jobs/_import_job_info_panel.erb
@@ -49,5 +49,11 @@
         <%= import_job.binary_zip_file.filename %>
       </p>
     <% end %>
+    <% if import_job.remote_server.present? %>
+      <p>
+        <strong><%= t('activerecord.attributes.import_job.remote_server') %>:</strong>
+        <%= import_job.remote_server %>
+      </p>
+    <% end %>
   </div>
 </div>

--- a/app/views/import_jobs/_import_job_info_panel.erb
+++ b/app/views/import_jobs/_import_job_info_panel.erb
@@ -39,8 +39,8 @@
     </p>
 
     <p>
-      <strong><%= t('activerecord.attributes.import_job.file_to_upload') %>:</strong>
-      <%= import_job.file_to_upload.filename %>
+      <strong><%= t('activerecord.attributes.import_job.metadata_file') %>:</strong>
+      <%= import_job.metadata_file.filename %>
     </p>
 
     <% if import_job.binary_zip_file.attached? %>

--- a/app/views/import_jobs/_import_job_info_panel.erb
+++ b/app/views/import_jobs/_import_job_info_panel.erb
@@ -42,5 +42,12 @@
       <strong><%= t('activerecord.attributes.import_job.file_to_upload') %>:</strong>
       <%= import_job.file_to_upload.filename %>
     </p>
+
+    <% if import_job.binary_zip_file.attached? %>
+      <p>
+        <strong><%= t('activerecord.attributes.import_job.binary_zip_file') %>:</strong>
+        <%= import_job.binary_zip_file.filename %>
+      </p>
+    <% end %>
   </div>
 </div>

--- a/app/views/import_jobs/index.html.erb
+++ b/app/views/import_jobs/index.html.erb
@@ -18,7 +18,7 @@
         <th>Job Name</th>
         <th>User</th>
         <th>Timestamp</th>
-        <th>Uploaded File</th>
+        <th>Metadata File</th>
         <th>Binaries</th>
         <th>Content Model</th>
         <th>Status</th>

--- a/app/views/import_jobs/index.html.erb
+++ b/app/views/import_jobs/index.html.erb
@@ -19,6 +19,7 @@
         <th>User</th>
         <th>Timestamp</th>
         <th>Uploaded File</th>
+        <th>Binaries</th>
         <th>Content Model</th>
         <th>Status</th>
         <th></th>
@@ -33,6 +34,7 @@
           <td><%= import_job.cas_user&.name%></td>
           <td><%= import_job.timestamp %></td>
           <td><%= import_job.file_to_upload.filename %></td>
+          <td><%= import_job.binaries? ? t('activerecord.attributes.import_job.binaries.true') : t('activerecord.attributes.import_job.binaries.false') %></td>
           <td><%= import_job.model %></td>
           <%= render partial: 'import_job_status', locals: { import_job: import_job } %>
         </tr>

--- a/app/views/import_jobs/index.html.erb
+++ b/app/views/import_jobs/index.html.erb
@@ -33,7 +33,7 @@
           <td><%= import_job.name %></td>
           <td><%= import_job.cas_user&.name%></td>
           <td><%= import_job.timestamp %></td>
-          <td><%= import_job.file_to_upload.filename %></td>
+          <td><%= import_job.metadata_file.filename %></td>
           <td><%= import_job.binaries? ? t('activerecord.attributes.import_job.binaries.true') : t('activerecord.attributes.import_job.binaries.false') %></td>
           <td><%= import_job.model %></td>
           <%= render partial: 'import_job_status', locals: { import_job: import_job } %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -53,8 +53,8 @@ en:
           false: 'No'
         cas_user: User
         collection: Collection
-        file_to_upload: File to Upload
         id: Job ID
+        metadata_file: Metadata File
         model: Content Model
         name: Job Name
         remote_server: Remote server
@@ -95,7 +95,7 @@ en:
           attributes:
             base:
               multiple_include_binaries_options: When including binaries, choose either an uploaded binary file or remote server, not both.
-            file_to_upload:
+            metadata_file:
               required: 'is required'
     models:
       datatype: Datatype

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -69,6 +69,9 @@ en:
           in_progress: In Progress
           error: Error
         timestamp: Timestamp
+        binaries:
+          true: 'Yes'
+          false: 'No'
       individual:
         identifier: Identifier
         label: Term

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -48,12 +48,16 @@ en:
         description: Description
       import_job:
         access: Access
+        binaries:
+          true: 'Yes'
+          false: 'No'
         cas_user: User
         collection: Collection
         file_to_upload: File to Upload
         id: Job ID
         model: Content Model
         name: Job Name
+        remote_server: Remote server
         stage:
           import: Import
           validate: Validation
@@ -69,9 +73,6 @@ en:
           in_progress: In Progress
           error: Error
         timestamp: Timestamp
-        binaries:
-          true: 'Yes'
-          false: 'No'
       individual:
         identifier: Identifier
         label: Term

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -93,6 +93,8 @@ en:
       models:
         import_job:
           attributes:
+            base:
+              multiple_include_binaries_options: When including binaries, choose either an uploaded binary file or remote server, not both.
             file_to_upload:
               required: 'is required'
     models:

--- a/db/migrate/20200507113214_add_remote_server_to_import_job.rb
+++ b/db/migrate/20200507113214_add_remote_server_to_import_job.rb
@@ -1,0 +1,5 @@
+class AddRemoteServerToImportJob < ActiveRecord::Migration[5.2]
+  def change
+    add_column :import_jobs, :remote_server, :string
+  end
+end

--- a/db/migrate/20200507151009_import_jobs_file_to_upload_to_metadata_file.rb
+++ b/db/migrate/20200507151009_import_jobs_file_to_upload_to_metadata_file.rb
@@ -1,0 +1,5 @@
+class ImportJobsFileToUploadToMetadataFile < ActiveRecord::Migration[5.2]
+  def change
+    ImportJob.connection.execute("UPDATE active_storage_attachments SET name = 'metadata_file' WHERE name = 'file_to_upload'")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_07_113214) do
+ActiveRecord::Schema.define(version: 2020_05_07_151009) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_30_145550) do
+ActiveRecord::Schema.define(version: 2020_05_07_113214) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -122,6 +122,7 @@ ActiveRecord::Schema.define(version: 2020_04_30_145550) do
     t.text "last_response_headers"
     t.string "access"
     t.string "collection"
+    t.string "remote_server"
     t.index ["cas_user_id"], name: "index_import_jobs_on_cas_user_id"
   end
 

--- a/test/controllers/import_jobs_controller_test.rb
+++ b/test/controllers/import_jobs_controller_test.rb
@@ -70,7 +70,7 @@ class ImportJobsControllerTest < ActionController::TestCase
     assert_difference('ImportJob.count') do
       post :create, params: {
         import_job: { name: name, collection: 'http://example.com/foo/baz',
-                      file_to_upload: fixture_file_upload('files/valid_import.csv') }
+                      metadata_file: fixture_file_upload('files/valid_import.csv') }
       }
     end
 
@@ -82,7 +82,7 @@ class ImportJobsControllerTest < ActionController::TestCase
     assert_no_difference('ImportJob.count') do
       post :create, params: {
         import_job: { name: name, collection: 'http://example.com/foo/baz',
-                      file_to_upload: fixture_file_upload('files/valid_import.csv') }
+                      metadata_file: fixture_file_upload('files/valid_import.csv') }
       }
     end
 
@@ -102,8 +102,8 @@ class ImportJobsControllerTest < ActionController::TestCase
 
     # Verify that error message is provided
     import_job = assigns(:import_job)
-    assert_includes(import_job.errors.messages[:file_to_upload],
-                    I18n.t('activerecord.errors.models.import_job.attributes.file_to_upload.required'))
+    assert_includes(import_job.errors.messages[:metadata_file],
+                    I18n.t('activerecord.errors.models.import_job.attributes.metadata_file.required'))
   end
 
   test 'should get show' do
@@ -122,8 +122,8 @@ class ImportJobsControllerTest < ActionController::TestCase
     import_job = ImportJob.first
     patch :update, params: { id: import_job.id, import_job: { name: import_job.name } }
     result = assigns(:import_job)
-    assert_includes(result.errors.messages[:file_to_upload],
-                    I18n.t('activerecord.errors.models.import_job.attributes.file_to_upload.required'))
+    assert_includes(result.errors.messages[:metadata_file],
+                    I18n.t('activerecord.errors.models.import_job.attributes.metadata_file.required'))
     assert_template :edit
   end
 
@@ -146,7 +146,7 @@ class ImportJobsControllerTest < ActionController::TestCase
 
     post :create, params: {
       import_job: { name: name, collection: 'http://example.com/foo/baz',
-                    file_to_upload: fixture_file_upload('files/valid_import.csv') }
+                    metadata_file: fixture_file_upload('files/valid_import.csv') }
     }
 
     import_job = assigns(:import_job)
@@ -163,7 +163,7 @@ class ImportJobsControllerTest < ActionController::TestCase
 
     import_job = ImportJob.first
     patch :update, params: { id: import_job.id,
-                             import_job: { name: import_job.name, file_to_upload: fixture_file_upload('files/valid_import.csv') } }
+                             import_job: { name: import_job.name, metadata_file: fixture_file_upload('files/valid_import.csv') } }
     result = assigns(:import_job)
     assert_equal(:error, result.status)
   end
@@ -177,7 +177,7 @@ class ImportJobsControllerTest < ActionController::TestCase
     end
 
     import_job = ImportJob.first
-    import_job.file_to_upload = fixture_file_upload('files/valid_import.csv')
+    import_job.metadata_file = fixture_file_upload('files/valid_import.csv')
     import_job.save!
     patch :import, params: { id: import_job.id }
     result = assigns(:import_job)
@@ -198,7 +198,7 @@ class ImportJobsControllerTest < ActionController::TestCase
     import_job.stage = 'import'
     import_job.save!
     patch :update, params: { id: import_job.id,
-                             import_job: { name: import_job.name, file_to_upload: fixture_file_upload('files/valid_import.csv') } }
+                             import_job: { name: import_job.name, metadata_file: fixture_file_upload('files/valid_import.csv') } }
     assert_redirected_to import_jobs_url
     assert_equal I18n.t(:import_already_performed), flash[:error]
   end

--- a/test/fixtures/active_storage/attachments.yml
+++ b/test/fixtures/active_storage/attachments.yml
@@ -13,3 +13,19 @@ three:
   name: 'file_to_upload'
   record: test_admin_import_job (ImportJob)
   blob: three_blob
+
+import_job_without_binary_zip_file_file_to_upload:
+  name: 'file_to_upload'
+  record: import_job_without_binary_zip_file (ImportJob)
+  blob: four_blob
+
+import_job_with_binary_zip_file_file_to_upload:
+  name: 'file_to_upload'
+  record: import_job_with_binary_zip_file (ImportJob)
+  blob: five_blob
+
+import_job_with_binary_zip_file_binary_zip_file:
+  name: 'binary_zip_file'
+  record: import_job_with_binary_zip_file (ImportJob)
+  blob: six_blob
+

--- a/test/fixtures/active_storage/attachments.yml
+++ b/test/fixtures/active_storage/attachments.yml
@@ -14,9 +14,9 @@ three:
   record: test_admin_import_job (ImportJob)
   blob: three_blob
 
-import_job_without_binary_zip_file_file_to_upload:
+import_job_without_binaries_file_to_upload:
   name: 'file_to_upload'
-  record: import_job_without_binary_zip_file (ImportJob)
+  record: import_job_without_binaries (ImportJob)
   blob: four_blob
 
 import_job_with_binary_zip_file_file_to_upload:
@@ -29,3 +29,7 @@ import_job_with_binary_zip_file_binary_zip_file:
   record: import_job_with_binary_zip_file (ImportJob)
   blob: six_blob
 
+import_job_with_remote_server_file_to_upload:
+  name: 'file_to_upload'
+  record: import_job_with_remote_server (ImportJob)
+  blob: seven_blob

--- a/test/fixtures/active_storage/attachments.yml
+++ b/test/fixtures/active_storage/attachments.yml
@@ -1,26 +1,26 @@
 # See https://stackoverflow.com/a/55835955
 one:
-  name: 'file_to_upload'
+  name: 'metadata_file'
   record: one (ImportJob)
   blob: one_blob
 
 two:
-  name: 'file_to_upload'
+  name: 'metadata_file'
   record: two (ImportJob)
   blob: two_blob
 
 three:
-  name: 'file_to_upload'
+  name: 'metadata_file'
   record: test_admin_import_job (ImportJob)
   blob: three_blob
 
-import_job_without_binaries_file_to_upload:
-  name: 'file_to_upload'
+import_job_without_binaries_metadata_file:
+  name: 'metadata_file'
   record: import_job_without_binaries (ImportJob)
   blob: four_blob
 
-import_job_with_binary_zip_file_file_to_upload:
-  name: 'file_to_upload'
+import_job_with_binary_zip_file_metadata_file:
+  name: 'metadata_file'
   record: import_job_with_binary_zip_file (ImportJob)
   blob: five_blob
 
@@ -29,7 +29,7 @@ import_job_with_binary_zip_file_binary_zip_file:
   record: import_job_with_binary_zip_file (ImportJob)
   blob: six_blob
 
-import_job_with_remote_server_file_to_upload:
-  name: 'file_to_upload'
+import_job_with_remote_server_metadata_file:
+  name: 'metadata_file'
   record: import_job_with_remote_server (ImportJob)
   blob: seven_blob

--- a/test/fixtures/active_storage/blobs.yml
+++ b/test/fixtures/active_storage/blobs.yml
@@ -47,3 +47,11 @@ six_blob:
   metadata: nil
   byte_size: 1024
   checksum: "zJIVJPfwxpOUA3wsbeXocQ=="
+
+seven_blob:
+  key: 'mT7DQdgANwchBodPUbaNP7ay'
+  filename: 'seven.csv'
+  content_type: 'text/csv'
+  metadata: nil
+  byte_size: 275
+  checksum: "zJIVJPfwxpOUA3wsbeXocQ=="

--- a/test/fixtures/active_storage/blobs.yml
+++ b/test/fixtures/active_storage/blobs.yml
@@ -1,4 +1,5 @@
 # See https://stackoverflow.com/a/55835955
+# Keys can be generated using ActiveStorage::Blob.generate_unique_secure_token()
 one_blob:
   key: 'TW1WnEgc9juhWyqpdwW8ZzUp'
   filename: 'one.csv'
@@ -21,4 +22,28 @@ three_blob:
   content_type: 'text/csv'
   metadata: nil
   byte_size: 275
+  checksum: "zJIVJPfwxpOUA3wsbeXocQ=="
+
+four_blob:
+  key: '7ceayqBAijiwxsWJXbcsL4cK'
+  filename: 'four.csv'
+  content_type: 'text/csv'
+  metadata: nil
+  byte_size: 275
+  checksum: "zJIVJPfwxpOUA3wsbeXocQ=="
+
+five_blob:
+  key: 's6RELrUGZAGsQhwmj4oNkk9r'
+  filename: 'five.csv'
+  content_type: 'text/csv'
+  metadata: nil
+  byte_size: 275
+  checksum: "zJIVJPfwxpOUA3wsbeXocQ=="
+
+six_blob:
+  key: 'pUzZ8WwdpqyWhuj9cgEnW1WT'
+  filename: 'six.zip'
+  content_type: 'application/zip'
+  metadata: nil
+  byte_size: 1024
   checksum: "zJIVJPfwxpOUA3wsbeXocQ=="

--- a/test/fixtures/import_jobs.yml
+++ b/test/fixtures/import_jobs.yml
@@ -18,10 +18,10 @@ test_admin_import_job:
   name: MyString
   collection: http://example.com/bar/kludge
 
-import_job_without_binary_zip_file:
+import_job_without_binaries:
   cas_user: test_admin
   timestamp: 2020-05-06 14:38:42
-  name: import_job_without_binary_zip_file
+  name: import_job_without_binaries
   collection: http://example.com/foo/quuz
 
 import_job_with_binary_zip_file:
@@ -29,3 +29,10 @@ import_job_with_binary_zip_file:
   timestamp: 2020-05-06 14:38:42
   name: import_job_with_binary_zip_file
   collection: http://example.com/foo/quuz
+
+import_job_with_remote_server:
+  cas_user: test_admin
+  timestamp: 2020-05-06 14:38:42
+  name: import_job_with_remove_server
+  collection: http://example.com/foo/quuz
+  remote_server: stfp://example.com/foo/baz

--- a/test/fixtures/import_jobs.yml
+++ b/test/fixtures/import_jobs.yml
@@ -17,3 +17,15 @@ test_admin_import_job:
   timestamp: 2019-08-12 15:45:29
   name: MyString
   collection: http://example.com/bar/kludge
+
+import_job_without_binary_zip_file:
+  cas_user: test_admin
+  timestamp: 2020-05-06 14:38:42
+  name: import_job_without_binary_zip_file
+  collection: http://example.com/foo/quuz
+
+import_job_with_binary_zip_file:
+  cas_user: test_admin
+  timestamp: 2020-05-06 14:38:42
+  name: import_job_with_binary_zip_file
+  collection: http://example.com/foo/quuz

--- a/test/models/import_job_test.rb
+++ b/test/models/import_job_test.rb
@@ -60,11 +60,14 @@ class ImportJobTest < ActiveSupport::TestCase
     end
   end
 
-  test 'binaries? indicates whether the import job has a binary zip file' do
-    import_job = import_jobs(:import_job_without_binary_zip_file)
+  test 'binaries? indicates whether the import job has a binary zip file or remote server' do
+    import_job = import_jobs(:import_job_without_binaries)
     assert_equal false, import_job.binaries?
 
     import_job = import_jobs(:import_job_with_binary_zip_file)
+    assert import_job.binaries?
+
+    import_job = import_jobs(:import_job_with_remote_server)
     assert import_job.binaries?
   end
 end

--- a/test/models/import_job_test.rb
+++ b/test/models/import_job_test.rb
@@ -59,4 +59,12 @@ class ImportJobTest < ActiveSupport::TestCase
       end
     end
   end
+
+  test 'binaries? indicates whether the import job has a binary zip file' do
+    import_job = import_jobs(:import_job_without_binary_zip_file)
+    assert_equal false, import_job.binaries?
+
+    import_job = import_jobs(:import_job_with_binary_zip_file)
+    assert import_job.binaries?
+  end
 end

--- a/test/models/import_job_test.rb
+++ b/test/models/import_job_test.rb
@@ -70,4 +70,10 @@ class ImportJobTest < ActiveSupport::TestCase
     import_job = import_jobs(:import_job_with_remote_server)
     assert import_job.binaries?
   end
+
+  test 'job with both binary_zip_file and remote_server is invalid' do
+    import_job = import_jobs(:import_job_with_binary_zip_file)
+    import_job.remote_server = 'sftp://example.com/'
+    assert_not import_job.valid?
+  end
 end


### PR DESCRIPTION
Updated the new import jobs form to support attaching a binary file, or entering an SFTP string to retrieve the file from a remote server.

Also renamed the "file_to_upload" field in the ImportJob to "metadata_file", to make it more description. A migration has been provided to update entries in the "active_storage_attachments" table.

Note: The binary file option (Option 1) currently does not send anything to Plastron, as the method for doing so is TBD.

https://issues.umd.edu/browse/LIBHYDRA-292