### PR TITLE
LIBHYDRA-299. Add count fields for import jobs.

### DIFF
--- a/app/models/plastron_message.rb
+++ b/app/models/plastron_message.rb
@@ -10,16 +10,11 @@ class PlastronMessage
     @job_id = @headers['PlastronJobId']
   end
 
-  # Parse the message headers as JSON and return the result.
-  def headers_json
-    @headers.to_json
-  end
-
   # Parse the message body as JSON and return the result.
   def body_json
     return nil if @body.blank?
 
-    JSON.parse(@body)
+    @body_json ||= JSON.parse(@body)
   end
 
   # Use the PlastronJobId to find the ImportJob or ExportJob object

--- a/app/views/import_jobs/index.html.erb
+++ b/app/views/import_jobs/index.html.erb
@@ -22,6 +22,8 @@
         <th><%= t('activerecord.attributes.import_job.timestamp') %></th>
         <th><%= t('activerecord.attributes.import_job.metadata_file') %></th>
         <th><%= t('activerecord.attributes.import_job.binaries.label') %></th>
+        <th># of Records</th>
+        <th># of Binaries</th>
         <th><%= t('activerecord.attributes.import_job.model') %></th>
         <th><%= t('activerecord.attributes.import_job.status.label') %></th>
         <th></th>
@@ -29,16 +31,18 @@
     </thead>
 
     <tbody>
-      <% @import_jobs.each do |import_job| %>
+      <% @import_jobs.each do |job| %>
         <tr>
-          <td><%= link_to import_job.id, import_job_path(import_job) %></td>
-          <td><%= import_job.name %></td>
-          <td><%= import_job.cas_user&.name%></td>
-          <td><%= import_job.timestamp %></td>
-          <td><%= import_job.metadata_file.filename %></td>
-          <td><%= import_job.binaries? ? t('activerecord.attributes.import_job.binaries.true') : t('activerecord.attributes.import_job.binaries.false') %></td>
-          <td><%= import_job.model %></td>
-          <%= render partial: 'import_job_status', locals: { import_job: import_job } %>
+          <td><%= link_to job.id, import_job_path(job) %></td>
+          <td><%= job.name %></td>
+          <td><%= job.cas_user&.name%></td>
+          <td><%= job.timestamp %></td>
+          <td><%= job.metadata_file.filename %></td>
+          <td><%= job.binaries? ? t('activerecord.attributes.import_job.binaries.true') : t('activerecord.attributes.import_job.binaries.false') %></td>
+          <td><%= job.item_count %></td>
+          <td><%= job.binaries_count if job.binaries? %></td>
+          <td><%= job.model %></td>
+          <%= render partial: 'import_job_status', locals: { import_job: job } %>
         </tr>
       <% end %>
     </tbody>

--- a/db/migrate/20200527202323_add_counts_to_import_job.rb
+++ b/db/migrate/20200527202323_add_counts_to_import_job.rb
@@ -1,0 +1,6 @@
+class AddCountsToImportJob < ActiveRecord::Migration[5.2]
+  def change
+    add_column :import_jobs, :binaries_count, :integer
+    add_column :import_jobs, :item_count, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_13_152520) do
+ActiveRecord::Schema.define(version: 2020_05_27_202323) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -126,6 +126,8 @@ ActiveRecord::Schema.define(version: 2020_05_13_152520) do
     t.string "access"
     t.string "collection"
     t.string "remote_server"
+    t.integer "binaries_count"
+    t.integer "item_count"
     t.index ["cas_user_id"], name: "index_import_jobs_on_cas_user_id"
   end
 


### PR DESCRIPTION
If there is a message body in the status update message, update binary and item count. Also, removed the headers_json method from import_job.

https://issues.umd.edu/browse/LIBHYDRA-299