### PR TITLE
LIBHYDRA-304. Added "status_update" route for STOMP listener

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -27,6 +27,12 @@ LDAP_BIND_DN=uid=libr-fedora,cn=auth,ou=ldap,dc=umd,dc=edu
 STOMP_HOST=fcrepolocal
 STOMP_PORT=61613
 
+# Used by the STOMP listener to generate the URL of the Archelon web application
+# for triggering updates to import/export job status
+# Should be the root URL of the Archelon Rails application. For example, for
+# local development: http://localhost:3000/
+ARCHELON_URL=http://localhost:3000/
+
 # --- config/audit_database.yml
 AUDIT_DATABASE_NAME=fcrepo_audit
 AUDIT_DATABASE_HOST=192.168.40.12

--- a/app/assets/javascripts/channels/import_jobs.js
+++ b/app/assets/javascripts/channels/import_jobs.js
@@ -101,7 +101,7 @@
         div = importJobsDivs[i];
         stage = div.dataset.stage;
         status = div.dataset.status;
-        jobMayNeedUpdate = ((stage == "validate") && (status == "in_progress"));
+        jobMayNeedUpdate = (status == "in_progress");
         if (jobMayNeedUpdate) {
           jobs.push({ jobId: div.dataset.jobId, stage: div.dataset.stage, status: div.dataset.status });
           requestUpdate = true;

--- a/app/controllers/import_jobs_controller.rb
+++ b/app/controllers/import_jobs_controller.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 class ImportJobsController < ApplicationController # rubocop:disable Metrics/ClassLength
-  before_action :set_import_job, only: %i[update show edit import]
+  before_action :set_import_job, only: %i[update show edit import status_update]
   before_action :cancel_workflow?, only: %i[create update]
   helper_method :status_text
+  skip_before_action :authenticate, only: %i[status_update]
 
   # GET /import_jobs
   # GET /import_jobs.json
@@ -119,6 +120,13 @@ class ImportJobsController < ApplicationController # rubocop:disable Metrics/Cla
     else
       I18n.t("activerecord.attributes.import_job.status.#{import_job.status}")
     end
+  end
+
+  # GET /import_jobs/1/status_update
+  def status_update
+    # Triggers import job notification to channel
+    ImportJobRelayJob.perform_later(@import_job)
+    render :no_content
   end
 
   private

--- a/config/initializers/stomp.rb
+++ b/config/initializers/stomp.rb
@@ -2,4 +2,13 @@
 STOMP_CONFIG = Archelon::Application.config_for :stomp
 
 # Convenient shorthand for passing host and port to Stomp::Client and Stomp::Connection
-STOMP_SERVER = { host: STOMP_CONFIG['host'], port: STOMP_CONFIG['port'] }
+STOMP_SERVER = { host: STOMP_CONFIG['host'], port: STOMP_CONFIG['port'] }.freeze
+
+archelon_url = STOMP_CONFIG['archelon_url'] || 'http://localhost:3000/'
+
+archelon_uri = URI(archelon_url)
+valid_url = (archelon_uri.scheme == 'http' || archelon_uri.scheme == 'https') &&
+            archelon_uri.host && archelon_uri.port
+raise "'#{archelon_url}' cannot be parsed as a valid URL." unless valid_url
+
+ARCHELON_SERVER = { protocol: archelon_uri.scheme, host: archelon_uri.host, port: archelon_uri.port }.freeze

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,11 +52,17 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
       get ':id/file', to: 'export_jobs#download', as: 'download'
       get ':id/binaries', to: 'export_jobs#download_binaries', as: 'download_binaries'
     end
+    member do
+      get 'status_update', to: 'export_jobs#status_update', as: 'status_update'
+    end
   end
 
   resources :import_jobs do
     collection do
       post ':id/import', to: 'import_jobs#import', as: 'perform_import'
+    end
+    member do
+      get 'status_update', to: 'import_jobs#status_update', as: 'status_update'
     end
   end
 

--- a/config/stomp.yml
+++ b/config/stomp.yml
@@ -1,6 +1,7 @@
 default: &default
   host: <%= ENV['STOMP_HOST'] %>
   port: <%= ENV['STOMP_PORT'] %>
+  archelon_url: <%= ENV['ARCHELON_URL'] %>
   destinations:
     jobs: /queue/plastron.jobs
     job_status: /topic/plastron.jobs.status

--- a/env_example
+++ b/env_example
@@ -46,6 +46,12 @@ AUDIT_DATABASE_PASSWORD=archelon
 STOMP_HOST=
 STOMP_PORT=
 
+# Used by the STOMP listener to generate the URL of the Archelon web application
+# for triggering updates to import/export job status
+# Should be the root URL of the Archelon Rails application. For example, for
+# local development: http://localhost:3000/
+ARCHELON_URL=
+
 # --- config/database.yml
 # (Production only - not needed for local development)
 # The type of database


### PR DESCRIPTION
Added "status_update" routes to import and export job controllers which
are called by the STOMP listener to trigger an update message to the
import/export ActionCable channels.

This is needed because the web browser is connected to the Archelon
application, not the STOMP listener, so the "commit" hook in the
ImportJob and ExportJob models that triggers the
ImportJobRelayJob/ExportJobRelayJob has no effect. The "status_update"
routes on the import/export job controllers are called by the STOMP
listener to trigger the ImportJobRelayJob or ExportJobRelayJob, a
 appropriate, to send out the update notification to the ActionCable
channels.

Added "ARCHELON_URL" to "env_example", as the STOMP listener needs to
know the URL of the Archelon server to contact.

The "status_update" actions in the controllers skip authentication to
simplify the STOMP listener implementation, and because it seems
unlikely that they can be abused.

Modified "app/assets/javascripts/channels/import_jobs.js" to request an
update when any job is in an "in progress" state (instead of only for
jobs that were "in progress" and in the "validate" stage), because job
updates may come in quick enough succession that a notification may be
missed when the page is reloading.

https://issues.umd.edu/browse/LIBHYDRA-304