### PR TITLE
LIBHYDRA-307. Added Rake tasks for adding public keys for users

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ environment.
 To set up Archelon for development see
 [docs/ArchelonDevelopmentEnvironment.md](docs/ArchelonDevelopmentEnvironment.md).
 
-## Importing Controlled Vocabularies
+## Rake Tasks
+
+### Importing Controlled Vocabularies
 
 Archelon comes with a rake task, [vocab:import](lib/tasks/vocab.rake), to do a
 bulk load of vocabulary terms from a CSV file. Run:
@@ -72,6 +74,39 @@ Other columns are ignored.
 
 The import task currently only supports creating Individuals (a.k.a. Terms),
 and not Types (a.k.a. Classes).
+
+### Importing User Public Keys
+
+Two Rake tasks are provided for importing public keys for a user:
+
+* ```rails user:add_public_key[cas_directory_id,public_key]```
+
+    Adds the given public key for the user with the given CAS directory id.
+
+    A user with the given CAS directory id must already exist.
+
+    Note: Because of the way SSH public keys are expressed, the command
+    should be enclosed in quotes, i.e.:
+
+    ```
+    rails "user:add_public_key[jsmith,ssh-rsa AAAAB3NzaC1yc2E...]"
+    ```
+
+* ```rails user:add_public_key_file[cas_directory_id,public_key_file]```
+
+    Adds the public key from the given file for the user with the given CAS
+    directory id.
+
+    A user with the given CAS directory id must already exist.
+
+    Relative file paths are allowed. If the file path or file name contains
+    a space, the entire command should be enclosed in quotes.
+
+    Example:
+
+    ```
+    rails user:add_public_key_file[jsmith,/home/jsmith/.ssh/id_rsa.pub]
+    ```
 
 ## Docker
 

--- a/lib/tasks/add_public_key.rake
+++ b/lib/tasks/add_public_key.rake
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+# lib/tasks/add_public_key.rake
+namespace :user do # rubocop:disable Metrics/BlockLength
+  desc 'Add a public key for an existing user.'
+  task :add_public_key, %i[cas_directory_id public_key] => :environment do |_t, args|
+    # Given a CAS directory id and a public key string, the given public key
+    # will be added for the user.
+    cas_directory_id = args[:cas_directory_id]
+    public_key = args[:public_key].strip
+    create_public_key(cas_directory_id, public_key)
+  end
+
+  desc 'Add a public key file for an existing user.'
+  task :add_public_key_file, %i[cas_directory_id public_key_file] => :environment do |_t, args|
+    cas_directory_id = args[:cas_directory_id]
+    public_key_file = args[:public_key_file]
+
+    unless File.exist?(public_key_file)
+      puts "Cannot read file '#{public_key_file}'"
+      exit(1)
+    end
+
+    public_key = File.read(public_key_file).strip
+
+    create_public_key(cas_directory_id, public_key)
+  end
+
+  def create_public_key(cas_directory_id, public_key)
+    cas_user = retrieve_cas_user(cas_directory_id)
+    verify_public_key(public_key)
+
+    pub_key_record = PublicKey.new(key: public_key, cas_user: cas_user)
+    pub_key_record.save!
+    puts "Public key added for '#{pub_key_record.cas_user.cas_directory_id}'"
+  end
+
+  # Returns the CasUser associated with the given cas_directory, or exits
+  # if the cas_directory_id cannot be found.
+  def retrieve_cas_user(cas_directory_id)
+    cas_user = CasUser.find_by(cas_directory_id: cas_directory_id)
+    return cas_user if cas_user
+
+    puts "User '#{cas_directory_id}' does not exist!"
+    exit(1)
+  end
+
+  # Exits if the public key already exists in the database.
+  def verify_public_key(public_key)
+    public_key_record = PublicKey.find_by(key: public_key)
+    return unless public_key_record
+
+    puts "Public key already exists and belongs to '#{public_key_record.cas_user.cas_directory_id}'"
+    exit(1)
+  end
+end


### PR DESCRIPTION
Created two Rake tasks in "lib/tasks/add_public_key.rake" - one to take
the public key as a string, the other to read the public key from a
file:

* rails user:add_public_key[cas_directory_id,public_key]
* rails user:add_public_key_file[cas_directory_id,public_key_file]

The tasks assume:

* that the user exists
* the the public key does not exist
* that the public key file is readable

A message will be printed and the task will return with an exit status
of 1 if any of the assumptions are not true.

If the public key is added, a message will be printed, and the exit
status will be 0.

Updated the README.md with a "Rake Tasks" section.

https://issues.umd.edu/browse/LIBHYDRA-307