### PR TITLE
LIBHYDRA-312. Limit export jobs to 4GB binaries download

### DIFF
--- a/app/models/export_job.rb
+++ b/app/models/export_job.rb
@@ -22,6 +22,8 @@ class ExportJob < ApplicationRecord
     'application/zip' => '.zip'
   }.freeze
 
+  MAX_ALLOWED_BINARIES_DOWNLOAD_SIZE = 4_294_967_296 # 4 gibibytes in bytes
+
   def self.exportable_types
     %w[Image Issue Letter]
   end
@@ -59,6 +61,16 @@ class ExportJob < ApplicationRecord
     self.plastron_status = message.headers['PlastronJobStatus']
     self.download_url = message.body_json['download_uri'] unless message.body_json.nil?
     save!
+  end
+
+  # Returns true if the job can be submitted, false otherwise
+  def job_submission_allowed?
+    !export_binaries || binaries_size.nil? || binaries_size <= MAX_ALLOWED_BINARIES_DOWNLOAD_SIZE
+  end
+
+  # Returns the maximum allowed binaries file size, in bytes
+  def max_allowed_binaries_download_size
+    MAX_ALLOWED_BINARIES_DOWNLOAD_SIZE
   end
 
   private

--- a/app/views/export_jobs/job_submission_not_allowed.erb
+++ b/app/views/export_jobs/job_submission_not_allowed.erb
@@ -1,0 +1,13 @@
+<h1>Export Job</h1>
+
+<p>
+  The selected job has a binaries download size of
+  <%= number_to_human_size(@job.binaries_size) %> which
+  exceeds the maximum allowed size of  <%= number_to_human_size(@job.max_allowed_binaries_download_size) %>.
+</p>
+
+<p>
+  Please remove some of the selected items to reduce the binaries download size.
+</p>
+
+ <%= link_to "Selected Items", bookmarks_path, class: 'btn btn-success' %>

--- a/test/controllers/export_jobs_controller_test.rb
+++ b/test/controllers/export_jobs_controller_test.rb
@@ -94,4 +94,53 @@ class ExportJobsControllerTest < ActionController::TestCase
     ability = Ability.new(invalid_user)
     assert ability.cannot?(:download, export_job)
   end
+
+  test 'review allows submission when no binaries download' do
+    ExportJobsController.any_instance.stub(:selected_items?).and_return(true)
+    params = {}
+    params[:export_job] = { name: 'test', format: 'CSV', item_count: 2, export_binaries: false }
+    get :review, params: params
+    assert_template :review
+  end
+
+  test 'review allows submission when binaries file size is less than or equal to maximum' do
+    export_job = export_jobs(:one)
+
+    max_size = export_job.max_allowed_binaries_download_size
+    ExportJobsController.any_instance.stub(:selected_items?).and_return(true)
+    BinariesStats.stub(:get_stats, count: 1, total_size: max_size) do
+      params = {}
+      params[:export_job] = { name: 'test', format: 'CSV', item_count: 2, export_binaries: true }
+      get :review, params: params
+      assert_template :review
+    end
+  end
+
+  test 'review denies submission when binaries file size is greater than maximum' do
+    export_job = export_jobs(:one)
+
+    max_size = export_job.max_allowed_binaries_download_size
+    too_large = max_size + 1
+    ExportJobsController.any_instance.stub(:selected_items?).and_return(true)
+    BinariesStats.stub(:get_stats, count: 1, total_size: too_large) do
+      params = {}
+      params[:export_job] = { name: 'test', format: 'CSV', item_count: 2, export_binaries: true }
+      get :review, params: params
+      assert_template :job_submission_not_allowed
+    end
+  end
+
+  test 'create not allowed when when binaries file size is greater than maximum' do
+    export_job = export_jobs(:one)
+
+    max_size = export_job.max_allowed_binaries_download_size
+    too_large = max_size + 1
+    ExportJobsController.any_instance.stub(:selected_items?).and_return(true)
+    BinariesStats.stub(:get_stats, count: 1, total_size: too_large) do
+      params = {}
+      params[:export_job] = { name: 'test', format: 'CSV', item_count: 2, export_binaries: true }
+      post :create, params: params
+      assert_template :job_submission_not_allowed
+    end
+  end
 end

--- a/test/models/export_job_test.rb
+++ b/test/models/export_job_test.rb
@@ -3,7 +3,18 @@
 require 'test_helper'
 
 class ExportJobTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test 'binaries download that exceeds max size are not allowed' do
+    job = export_jobs(:one)
+    job.export_binaries = true
+
+    max_size = job.max_allowed_binaries_download_size
+    assert_equal(4_294_967_296, max_size)
+
+    job.binaries_size = max_size
+    assert job.job_submission_allowed?
+
+    too_large = max_size + 1
+    job.binaries_size = too_large
+    assert_not job.job_submission_allowed?
+  end
 end


### PR DESCRIPTION
Added a "MAX_ALLOWED_BINARIES_DOWNLOAD_SIZE" constant and
"max_allowed_binaries_download_size" method to the ExportJob model.
Also added a "job_submission_allowed?" to determine if an export job can
be submitted based on the size of the binaries download.

Added a "app/views/export_jobs/job_submission_not_allowed.erb" view to
display a message indicating that the binaries download is too large.

Modified the "review" and "create" methods to redirect to the
"job_submission_not_allowed" view when the "job_submission_allowed?"
method in ExportJob returns false.

Added tests.

https://issues.umd.edu/browse/LIBHYDRA-312