### PR TITLE
LIBHYDRA-311. Added MIME type selection to export jobs

### DIFF
--- a/app/controllers/export_jobs_controller.rb
+++ b/app/controllers/export_jobs_controller.rb
@@ -28,14 +28,10 @@ class ExportJobsController < ApplicationController # rubocop:disable Metrics/Cla
     @job = ExportJob.new(export_job_params)
     @job.item_count = bookmarks.count
 
-    if @job.export_binaries
-      selected_mime_types = params.dig('export_job', 'mime_types')
-      if selected_mime_types.blank?
-        flash[:error] = I18n.t(:export_job_no_mime_types_selected)
-        redirect_to controller: :export_jobs, action: :new
-        return
-      end
+    selected_mime_types = params.dig('export_job', 'mime_types')
+    @job.export_binaries = selected_mime_types.present?
 
+    if @job.export_binaries
       binary_stats = BinariesStats.get_stats(bookmarks.map(&:document_id), selected_mime_types)
       @job.binaries_size = binary_stats[:total_size]
       @job.binaries_count = binary_stats[:count]

--- a/app/controllers/export_jobs_controller.rb
+++ b/app/controllers/export_jobs_controller.rb
@@ -26,13 +26,9 @@ class ExportJobsController < ApplicationController # rubocop:disable Metrics/Cla
 
   def review # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
     @job = ExportJob.new(export_job_params)
+    @job.item_count = bookmarks.count
 
     if @job.export_binaries
-      binary_stats = BinariesStats.get_stats(bookmarks.map(&:document_id))
-      @job.binaries_size = binary_stats[:total_size]
-      @job.binaries_count = binary_stats[:count]
-      @job.item_count = bookmarks.count
-
       selected_mime_types = params.dig('export_job', 'mime_types')
       if selected_mime_types.blank?
         flash[:error] = I18n.t(:export_job_no_mime_types_selected)

--- a/app/controllers/export_jobs_controller.rb
+++ b/app/controllers/export_jobs_controller.rb
@@ -20,7 +20,8 @@ class ExportJobsController < ApplicationController # rubocop:disable Metrics/Cla
 
   def new
     @job = ExportJob.new(params.key?(:export_job) ? export_job_params : default_job_params)
-    @mime_types = MimeTypes.mime_types
+    export_uris = bookmarks.map(&:document_id)
+    @mime_types = MimeTypes.mime_types(export_uris)
   end
 
   def review # rubocop:disable Metrics/MethodLength, Metrics/AbcSize

--- a/app/controllers/export_jobs_controller.rb
+++ b/app/controllers/export_jobs_controller.rb
@@ -140,8 +140,8 @@ class ExportJobsController < ApplicationController # rubocop:disable Metrics/Cla
       end
     end
 
-    def message_headers(job)
-      {
+    def message_headers(job) # rubocop:disable Metrics/MethodLength
+      headers = {
         PlastronCommand: 'export',
         PlastronJobId: export_job_url(job),
         'PlastronArg-name': job.name,
@@ -151,6 +151,11 @@ class ExportJobsController < ApplicationController # rubocop:disable Metrics/Cla
         'PlastronArg-export-binaries': job.export_binaries.to_s,
         persistent: 'true'
       }
+      return headers unless job.export_binaries
+
+      mime_types = job.selected_mime_types.join(',')
+      headers['PlastronArg-binary-types'] = mime_types
+      headers
     end
 
     def submit_job(uris)

--- a/app/controllers/export_jobs_controller.rb
+++ b/app/controllers/export_jobs_controller.rb
@@ -20,9 +20,10 @@ class ExportJobsController < ApplicationController # rubocop:disable Metrics/Cla
 
   def new
     @job = ExportJob.new(params.key?(:export_job) ? export_job_params : default_job_params)
+    @mime_types = MimeTypes.mime_types
   end
 
-  def review # rubocop:disable Metrics/MethodLength
+  def review # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
     @job = ExportJob.new(export_job_params)
 
     if @job.export_binaries
@@ -30,6 +31,13 @@ class ExportJobsController < ApplicationController # rubocop:disable Metrics/Cla
       @job.binaries_size = binary_stats[:total_size]
       @job.binaries_count = binary_stats[:count]
       @job.item_count = bookmarks.count
+
+      mime_types = params.dig('export_job', 'mime_types')
+      if mime_types.blank?
+        flash[:error] = I18n.t(:export_job_no_mime_types_selected)
+        redirect_to controller: :export_jobs, action: :new
+        return
+      end
     end
 
     if @job.job_submission_allowed?

--- a/app/models/export_job.rb
+++ b/app/models/export_job.rb
@@ -63,6 +63,13 @@ class ExportJob < ApplicationRecord
     save!
   end
 
+  # Returns a array of the selected MIME types for the job
+  def selected_mime_types
+    return [] if mime_types.blank?
+
+    mime_types.split(',')
+  end
+
   # Returns true if the job can be submitted, false otherwise
   def job_submission_allowed?
     !export_binaries || binaries_size.nil? || binaries_size <= MAX_ALLOWED_BINARIES_DOWNLOAD_SIZE

--- a/app/services/binaries_stats.rb
+++ b/app/services/binaries_stats.rb
@@ -16,13 +16,15 @@ class BinariesStats
     'pages.q': '{!terms f=id v=$row.pcdm_members}'
   }.freeze
 
-  def self.query(uris)
-    QUERY.merge 'fq': uris.map { |uri| "id:\"#{uri}\"" }.join(' OR ')
+  def self.query(uris, mime_types)
+    fq = QUERY.merge 'fq': uris.map { |uri| "id:\"#{uri}\"" }.join(' OR ')
+    fq = fq.merge 'files.fq': mime_types.map { |mime_type| "mime_type:\"#{mime_type}\"" }.join(' OR ') if mime_types
+    fq
   end
 
-  def self.get_stats(uris)
+  def self.get_stats(uris, mime_types)
     solr = Blacklight::Solr::Repository.new(blacklight_config)
-    process_solr_response(solr.search(query(uris)))
+    process_solr_response(solr.search(query(uris, mime_types)))
   end
 
   def self.process_solr_response(solr_response)

--- a/app/services/mime_types.rb
+++ b/app/services/mime_types.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Utility to retrive MIME types from Solr
+class MimeTypes
+  include Blacklight::Configurable
+
+  QUERY = {
+    q: '*:*',
+    facet: 'on',
+    'facet.field': 'mime_type',
+    'facet.limit': '-1',
+    rows: '0'
+  }.freeze
+
+  # Queries Solr and returns an array of Strings representing the MIME types
+  def self.mime_types
+    solr = Blacklight::Solr::Repository.new(blacklight_config)
+    process_solr_response(solr.search(QUERY))
+  end
+
+  # Processes the Solr response, returning an array of Strings
+  def self.process_solr_response(solr_response)
+    mime_types_with_count = solr_response.dig('facet_counts', 'facet_fields', 'mime_type')
+    mime_types = mime_types_with_count.each_slice(2).map(&:first)
+    mime_types
+  end
+end

--- a/app/views/export_jobs/_back_to_new_button.erb
+++ b/app/views/export_jobs/_back_to_new_button.erb
@@ -1,0 +1,10 @@
+    <%= link_to "Back", url_for(action: :new, params:
+      {
+        export_job: {
+          name: export_job.name,
+          format: export_job.format,
+          export_binaries: export_job.export_binaries,
+          mime_types: export_job.mime_types
+        }
+      }
+    ), class: 'btn btn-danger' %>

--- a/app/views/export_jobs/_summary.html.erb
+++ b/app/views/export_jobs/_summary.html.erb
@@ -34,6 +34,15 @@
   <% if export_job.export_binaries %>
     <div class="row form-group">
       <div class="col-xs-2">
+        <strong>MIME Types:</strong>
+      </div>
+      <div class="col-xs-10">
+        <% mime_types_array = export_job.mime_types.split(',').map { |mt| I18n.t("mime_types.#{mt}") } %>
+        <%= mime_types_array.join(", ") %>
+      </div>
+    </div>
+    <div class="row form-group">
+      <div class="col-xs-2">
         <strong>Number of Binaries:</strong>
       </div>
       <div class="col-xs-10">

--- a/app/views/export_jobs/_summary.html.erb
+++ b/app/views/export_jobs/_summary.html.erb
@@ -37,7 +37,7 @@
         <strong>MIME Types:</strong>
       </div>
       <div class="col-xs-10">
-        <% mime_types_array = export_job.mime_types.split(',').map { |mt| I18n.t("mime_types.#{mt}") } %>
+        <% mime_types_array = export_job.selected_mime_types.map { |mt| I18n.t("mime_types.#{mt}") } %>
         <%= mime_types_array.join(", ") %>
       </div>
     </div>

--- a/app/views/export_jobs/_summary.html.erb
+++ b/app/views/export_jobs/_summary.html.erb
@@ -34,7 +34,7 @@
   <% if export_job.export_binaries %>
     <div class="row form-group">
       <div class="col-xs-2">
-        <strong>MIME Types:</strong>
+        <strong>Binary File Types:</strong>
       </div>
       <div class="col-xs-10">
         <% mime_types_array = export_job.selected_mime_types.map { |mt| I18n.t("mime_types.#{mt}") } %>

--- a/app/views/export_jobs/job_submission_not_allowed.erb
+++ b/app/views/export_jobs/job_submission_not_allowed.erb
@@ -10,4 +10,7 @@
   Please remove some of the selected items to reduce the binaries download size.
 </p>
 
- <%= link_to "Selected Items", bookmarks_path, class: 'btn btn-success' %>
+<div>
+  <%= render 'back_to_new_button', export_job: @job %>
+  <%= link_to "Selected Items", bookmarks_path, class: 'btn btn-success' %>
+</div>

--- a/app/views/export_jobs/new.html.erb
+++ b/app/views/export_jobs/new.html.erb
@@ -23,20 +23,21 @@
       </div>
     </div>
     <div class="form-group">
-      <div class="panel panel-default">
-        <div class="panel-heading">
-          <div>
-            <%= label_tag nil, "Include Binaries?", class: "col-form-label-lg" %>
-          </div>
-        </div>
-        <div class="panel-body">
+      <div>
+        <%= label_tag nil, "Include Binaries?", class: "col-form-label-lg" %>
+      </div>
+      <div>
+        <% if @mime_types.empty? %>
+          <p>No binaries available for the selected items</p>
+        <% else %>
           <p>Select any of the following to include binaries in the export:</p>
           <% @mime_types.each do |mime_type| %>
             <% selected = @job.selected_mime_types.include?(mime_type) ? true : false %>
             <%= check_box_tag('export_job[mime_types][]', mime_type, selected, id: "export_job_#{mime_type}", style: "margin-left: 20px") %>
             <label for="export_job_<%= mime_type %>"><%= t("mime_types.#{mime_type}") %></label>
           <% end %>
-        </div>
+        <% end %>
+      </div>
       </div>
     </div>
     <div class="form-group">

--- a/app/views/export_jobs/new.html.erb
+++ b/app/views/export_jobs/new.html.erb
@@ -34,7 +34,7 @@
         <div class="panel-body">
           <p>File Types to Export<!-- <input type="button" style="margin-left: 40px" class="btn btn-danger btn-sm" value="Select All"> <input type="button" class="btn btn-danger btn-sm" value="Clear Selected">--></p>
           <% @mime_types.each do |mime_type| %>
-            <% selected = @job.mime_types.include?(mime_type) ? true : false if @job.mime_types %>
+            <% selected = @job.selected_mime_types.include?(mime_type) ? true : false %>
             <%= check_box_tag('export_job[mime_types][]', mime_type, selected, id: "export_job_#{mime_type}", style: "margin-left: 20px") %>
             <label for="export_job_<%= mime_type %>"><%= t("mime_types.#{mime_type}") %></label>
           <% end %>

--- a/app/views/export_jobs/new.html.erb
+++ b/app/views/export_jobs/new.html.erb
@@ -10,7 +10,7 @@
           <div>
           <%= f.radio_button :format, type, class: "form-check-input" %>
           <%= f.label :format, label, value: type, class: "form-check-label font-weight-normal" %>
-          </div> 
+          </div>
         <% end %>
       </div>
     </div>
@@ -23,10 +23,21 @@
       </div>
     </div>
     <div class="form-group">
-      <div>
-        <%= check_box_tag 'export_job[export_binaries]', 1, @job.export_binaries %>
-        &nbsp;
-        <%= f.label :export_binaries, class: "col-form-label-lg" %>
+      <div class="panel panel-default">
+        <div class="panel-heading">
+          <div>
+            <%= check_box_tag 'export_job[export_binaries]', 1, @job.export_binaries %>
+            &nbsp;
+            <%= f.label :export_binaries, class: "col-form-label-lg" %>
+          </div>
+        </div>
+        <div class="panel-body">
+          <p>File Types to Export</p>
+          <% @mime_types.each do |mime_type| %>
+            <%= check_box_tag('export_job[mime_types][]', mime_type, false, id: "export_job_#{mime_type}", style: "margin-left: 20px") %>
+            <label for="export_job_<%= mime_type %>"><%= t("mime_types.#{mime_type}") %></label>
+          <% end %>
+        </div>
       </div>
     </div>
     <div class="form-group">

--- a/app/views/export_jobs/new.html.erb
+++ b/app/views/export_jobs/new.html.erb
@@ -26,7 +26,7 @@
       <div class="panel panel-default">
         <div class="panel-heading">
           <div>
-            Include Binaries?
+            <%= label_tag nil, "Include Binaries?", class: "col-form-label-lg" %>
           </div>
         </div>
         <div class="panel-body">

--- a/app/views/export_jobs/new.html.erb
+++ b/app/views/export_jobs/new.html.erb
@@ -32,9 +32,10 @@
           </div>
         </div>
         <div class="panel-body">
-          <p>File Types to Export</p>
+          <p>File Types to Export<!-- <input type="button" style="margin-left: 40px" class="btn btn-danger btn-sm" value="Select All"> <input type="button" class="btn btn-danger btn-sm" value="Clear Selected">--></p>
           <% @mime_types.each do |mime_type| %>
-            <%= check_box_tag('export_job[mime_types][]', mime_type, false, id: "export_job_#{mime_type}", style: "margin-left: 20px") %>
+            <% selected = @job.mime_types.include?(mime_type) ? true : false if @job.mime_types %>
+            <%= check_box_tag('export_job[mime_types][]', mime_type, selected, id: "export_job_#{mime_type}", style: "margin-left: 20px") %>
             <label for="export_job_<%= mime_type %>"><%= t("mime_types.#{mime_type}") %></label>
           <% end %>
         </div>

--- a/app/views/export_jobs/new.html.erb
+++ b/app/views/export_jobs/new.html.erb
@@ -26,13 +26,11 @@
       <div class="panel panel-default">
         <div class="panel-heading">
           <div>
-            <%= check_box_tag 'export_job[export_binaries]', 1, @job.export_binaries %>
-            &nbsp;
-            <%= f.label :export_binaries, class: "col-form-label-lg" %>
+            Include Binaries?
           </div>
         </div>
         <div class="panel-body">
-          <p>File Types to Export<!-- <input type="button" style="margin-left: 40px" class="btn btn-danger btn-sm" value="Select All"> <input type="button" class="btn btn-danger btn-sm" value="Clear Selected">--></p>
+          <p>Select any of the following to include binaries in the export:</p>
           <% @mime_types.each do |mime_type| %>
             <% selected = @job.selected_mime_types.include?(mime_type) ? true : false %>
             <%= check_box_tag('export_job[mime_types][]', mime_type, selected, id: "export_job_#{mime_type}", style: "margin-left: 20px") %>

--- a/app/views/export_jobs/review.html.erb
+++ b/app/views/export_jobs/review.html.erb
@@ -6,6 +6,7 @@
   <%= f.hidden_field :export_binaries, value: @job.export_binaries %>
   <%= f.hidden_field :binaries_size, value: @job.binaries_size %>
   <%= f.hidden_field :binaries_count, value: @job.binaries_count %>
+  <%= f.hidden_field :mime_types, value: @job.mime_types %>
 
   <%= render 'summary', export_job: @job %>
   <div>
@@ -14,7 +15,8 @@
         export_job: {
           name: @job.name,
           format: @job.format,
-          export_binaries: @job.export_binaries
+          export_binaries: @job.export_binaries,
+          mime_types: @job.mime_types
         }
       }
     ), class: 'btn btn-danger' %>

--- a/app/views/export_jobs/review.html.erb
+++ b/app/views/export_jobs/review.html.erb
@@ -10,16 +10,7 @@
 
   <%= render 'summary', export_job: @job %>
   <div>
-    <%= link_to "Back", url_for(action: :new, params:
-      {
-        export_job: {
-          name: @job.name,
-          format: @job.format,
-          export_binaries: @job.export_binaries,
-          mime_types: @job.mime_types
-        }
-      }
-    ), class: 'btn btn-danger' %>
+    <%= render 'back_to_new_button', export_job: @job %>
     <%= f.submit "Cancel", class: 'btn btn-danger' %>
     <%= f.submit "Submit Job", class: 'btn btn-primary' %>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,6 +40,7 @@ en:
   selected_items_changed: 'Selected items has changed. Please review.'
   import_already_performed: 'Import has completed. Cannot reimport or validate'
   cannot_import_invalid_file: 'Cannot import a file with validation errors.'
+  export_job_no_mime_types_selected: 'Please select at least one MIME type when exporting binaries'
   activerecord:
     attributes:
       datatype:
@@ -111,6 +112,13 @@ en:
       individual: Term
       type: Class
       vocabulary: Vocabulary
+  mime_types:
+    application/pdf: PDF
+    application/xml: XML (Application)
+    image/jp2: JPEG 2000
+    image/tiff: TIFF
+    text/csv: CSV
+    text/xml: XML (Text)
   tooltips:
     identifier: This will be used as the local id and populate the URI of the local vocabulary term.
     same_as: This should be a full URI to an external vocabulary such as LC Genre/Form Terms, AAT, LCSH

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -115,9 +115,13 @@ en:
   mime_types:
     application/pdf: PDF (application/pdf)
     application/xml: XML (application/xml)
+    application/zip: Zip (application/zip)
+    image/jpeg: JPEG (image/jpeg)
     image/jp2: JPEG 2000 (image/jp2)
     image/tiff: TIFF (image/tiff)
     text/csv: CSV (text/csv)
+    text/plain: Text (text/plain)
+    text/turtle: Turtle (text/turtle)
     text/xml: XML (text/xml)
   tooltips:
     identifier: This will be used as the local id and populate the URI of the local vocabulary term.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -113,12 +113,12 @@ en:
       type: Class
       vocabulary: Vocabulary
   mime_types:
-    application/pdf: PDF
-    application/xml: XML (Application)
-    image/jp2: JPEG 2000
-    image/tiff: TIFF
-    text/csv: CSV
-    text/xml: XML (Text)
+    application/pdf: PDF (application/pdf)
+    application/xml: XML (application/xml)
+    image/jp2: JPEG 2000 (image/jp2)
+    image/tiff: TIFF (image/tiff)
+    text/csv: CSV (text/csv)
+    text/xml: XML (text/xml)
   tooltips:
     identifier: This will be used as the local id and populate the URI of the local vocabulary term.
     same_as: This should be a full URI to an external vocabulary such as LC Genre/Form Terms, AAT, LCSH

--- a/db/migrate/20200611133117_add_mime_types_to_export_jobs.rb
+++ b/db/migrate/20200611133117_add_mime_types_to_export_jobs.rb
@@ -1,0 +1,5 @@
+class AddMimeTypesToExportJobs < ActiveRecord::Migration[5.2]
+  def change
+    add_column :export_jobs, :mime_types, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_05_171038) do
+ActiveRecord::Schema.define(version: 2020_06_11_133117) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -101,6 +101,7 @@ ActiveRecord::Schema.define(version: 2020_06_05_171038) do
     t.boolean "export_binaries"
     t.bigint "binaries_size"
     t.integer "binaries_count"
+    t.string "mime_types"
     t.index ["cas_user_id"], name: "index_export_jobs_on_cas_user_id"
   end
 

--- a/test/controllers/export_jobs_controller_test.rb
+++ b/test/controllers/export_jobs_controller_test.rb
@@ -110,7 +110,7 @@ class ExportJobsControllerTest < ActionController::TestCase
     ExportJobsController.any_instance.stub(:selected_items?).and_return(true)
     BinariesStats.stub(:get_stats, count: 1, total_size: max_size) do
       params = {}
-      params[:export_job] = { name: 'test', format: 'CSV', item_count: 2, export_binaries: true }
+      params[:export_job] = { name: 'test', format: 'CSV', item_count: 2, export_binaries: true, mime_types: ['application/pdf'] }
       get :review, params: params
       assert_template :review
     end
@@ -124,7 +124,7 @@ class ExportJobsControllerTest < ActionController::TestCase
     ExportJobsController.any_instance.stub(:selected_items?).and_return(true)
     BinariesStats.stub(:get_stats, count: 1, total_size: too_large) do
       params = {}
-      params[:export_job] = { name: 'test', format: 'CSV', item_count: 2, export_binaries: true }
+      params[:export_job] = { name: 'test', format: 'CSV', item_count: 2, export_binaries: true, mime_types: ['application/pdf'] }
       get :review, params: params
       assert_template :job_submission_not_allowed
     end
@@ -138,7 +138,7 @@ class ExportJobsControllerTest < ActionController::TestCase
     ExportJobsController.any_instance.stub(:selected_items?).and_return(true)
     BinariesStats.stub(:get_stats, count: 1, total_size: too_large) do
       params = {}
-      params[:export_job] = { name: 'test', format: 'CSV', item_count: 2, export_binaries: true }
+      params[:export_job] = { name: 'test', format: 'CSV', item_count: 2, export_binaries: true, mime_types: ['application/pdf'] }
       post :create, params: params
       assert_template :job_submission_not_allowed
     end


### PR DESCRIPTION
Modified export jobs to enable only binaries with particular MIME types from being
included in the export.

https://issues.umd.edu/browse/LIBHYDRA-311