### PR TITLE
LIBHYDRA-324. Changed 4 GB to 50 GB limit.

### DIFF
--- a/app/models/export_job.rb
+++ b/app/models/export_job.rb
@@ -22,7 +22,7 @@ class ExportJob < ApplicationRecord
     'application/zip' => '.zip'
   }.freeze
 
-  MAX_ALLOWED_BINARIES_DOWNLOAD_SIZE = 4_294_967_296 # 4 gibibytes in bytes
+  MAX_ALLOWED_BINARIES_DOWNLOAD_SIZE = 50.gigabytes
 
   def self.exportable_types
     %w[Image Issue Letter]

--- a/test/models/export_job_test.rb
+++ b/test/models/export_job_test.rb
@@ -8,7 +8,7 @@ class ExportJobTest < ActiveSupport::TestCase
     job.export_binaries = true
 
     max_size = job.max_allowed_binaries_download_size
-    assert_equal(4_294_967_296, max_size)
+    assert_equal(50.gigabytes, max_size)
 
     job.binaries_size = max_size
     assert job.job_submission_allowed?


### PR DESCRIPTION
Using the Rails ".gigabytes" method for self-documentation.

https://issues.umd.edu/browse/LIBHYDRA-324