### PR TITLE
LIBHYDRA-325. Use HTTP POST requests to Solr for service queries.

### DIFF
--- a/app/services/binaries_stats.rb
+++ b/app/services/binaries_stats.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 # Utility to get binary counts and sizes for items
-class BinariesStats
-  include Blacklight::Configurable
-
+class BinariesStats < SolrQueryService
   QUERY = {
     q: '*:*',
     'pages.fq': 'component:Page',
@@ -17,8 +15,8 @@ class BinariesStats
   }.freeze
 
   def self.query(uris, mime_types)
-    fq = QUERY.merge 'fq': uris.map { |uri| "id:\"#{uri}\"" }.join(' OR ')
-    fq = fq.merge 'files.fq': mime_types.map { |mime_type| "mime_type:\"#{mime_type}\"" }.join(' OR ') if mime_types
+    fq = QUERY.merge 'fq': match_any('id', uris)
+    fq = fq.merge 'files.fq': match_any('mime_type', mime_types) if mime_types
     fq
   end
 

--- a/app/services/mime_types.rb
+++ b/app/services/mime_types.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
-# Utility to retrive MIME types from Solr
-class MimeTypes
-  include Blacklight::Configurable
-
+# Utility to retrieve MIME types from Solr
+class MimeTypes < SolrQueryService
   QUERY = {
     q: '*:*',
     indent: 'on',
@@ -24,13 +22,13 @@ class MimeTypes
   end
 
   def self.query(uris)
-    QUERY.merge 'fq': uris.map { |uri| "id:\"#{uri}\"" }.join(' OR ')
+    QUERY.merge 'fq': match_any('id', uris)
   end
 
   # Processes the Solr response, returning an array of Strings
   def self.process_solr_response(solr_response) # rubocop:disable Metrics/MethodLength
     # This method is a bit of a kludge, because it's not clear how to get the
-    # facet list directly from a Solr query. This brute-force method interates
+    # facet list directly from a Solr query. This brute-force method iterates
     # through all the files in the response, generating a set of all the
     # "mime_type" fields encountered, and then converts it to an array.
     docs = solr_response.dig('response', 'docs')

--- a/app/services/solr_query_service.rb
+++ b/app/services/solr_query_service.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Base class for services implementing specific Solr queries
+class SolrQueryService
+  include Blacklight::Configurable
+
+  blacklight_config.http_method = :post
+
+  def self.match_any(field, values)
+    values.map { |value| "#{field}:\"#{value}\"" }.join(' OR ')
+  end
+end


### PR DESCRIPTION
Added a SolrQueryService base class that implements common functionality between the BinariesStats and MimeTypes classes.

https://issues.umd.edu/browse/LIBHYDRA-325