### PR TITLE
LIBHYDRA-331. Added ControlledURIRef component.

### DIFF
--- a/app/javascript/components/ControlledURIRef.jsx
+++ b/app/javascript/components/ControlledURIRef.jsx
@@ -1,0 +1,71 @@
+import React from "react"
+import PropTypes from "prop-types"
+
+/**
+ * Input component with a dropdown whose values come from a controlled vocabulary.
+ *
+ *  Sample Rails view usage:
+ *
+ * ```
+ * <%=
+ *   react_component(
+ *     :ControlledURIRef, {
+ *       paramPrefix: 'example',
+ *       name: 'object_type',
+ *       value: 'http://example.com/foo#bar',
+ *       vocab: Vocabulary.find_by(identifier: 'foo').as_hash
+ *     }
+ *   )
+ * %>
+ * ```
+ *
+ * When used in a form, this will submit the array `example[object_type][]`
+ * with a single value `'http://example.com/foo#bar'`
+ */
+class ControlledURIRef extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      value: props.value
+    }
+
+    this.handleChange = this.handleChange.bind(this);
+  };
+
+  handleChange(event) {
+    this.setState({value: event.target.value})
+  };
+
+  render () {
+    let inputName = `${this.props.paramPrefix}[${this.props.name}][]`
+    return (
+      <React.Fragment>
+        <select name={inputName} value={this.state.value} onChange={this.handleChange}>
+          <option key="" value=""/>
+          {Object.entries(this.props.vocab).map(([uri, label]) => (
+              <option key={uri} value={uri}>{label}</option>
+          ))}
+        </select>
+      </React.Fragment>
+    );
+  }
+}
+
+ControlledURIRef.propTypes = {
+  /**
+   * The name of the element, used to with `paramPrefix` to construct the
+   * parameter sent via the form submission.
+   */
+  name: PropTypes.string,
+  /**
+   * Combined with the name (`<paramPrefix>[<name>][]`) to construct the
+   * parameter sent via the form submission.
+   */
+  paramPrefix: PropTypes.string,
+  /**
+   * The default selected value for the dropdown
+   */
+  value: PropTypes.string
+}
+
+export default ControlledURIRef

--- a/app/javascript/components/ControlledURIRef.md
+++ b/app/javascript/components/ControlledURIRef.md
@@ -1,0 +1,15 @@
+### Basic Example:
+
+```js
+<ControlledURIRef paramPrefix='example' name='title'
+ vocab={{'http://example.com/vocab#foo': 'Foo', 'http://example.com/vocab#bar': 'Bar'}}/>
+```
+
+### Pre-populated example
+
+Default values can be pre-populated using the "value":
+
+```js
+<ControlledURIRef paramPrefix='example' name='title' value='http://example.com/vocab#bar'
+ vocab={{'http://example.com/vocab#foo': 'Foo', 'http://example.com/vocab#bar': 'Bar'}}/>
+```

--- a/app/javascript/components/PlainLiteral.jsx
+++ b/app/javascript/components/PlainLiteral.jsx
@@ -7,11 +7,11 @@ import PropTypes from "prop-types"
  *  Sample Rails view usage:
  *
  * ```
- * <%= react_component(:PlainLiteral, { param_prefix: 'example', name: 'title', value: "Lorem ipsum", language: "en"}) %>
+ * <%= react_component(:PlainLiteral, { paramPrefix: 'example', name: 'title', value: "Lorem ipsum", language: "en"}) %>
  * ```
  *
- * When used in a form, this will send two arrays `example[title][]` and
- * `example[title_language][]` as HTML paramaters.
+ * When used in a form, this will submit the array `example[title][]`
+ * with a single value, `{value: "Lorem ipsum", language: "en"}`.
  */
 class PlainLiteral extends React.Component {
   // The options for the dropdown, using ISO-639 language codes
@@ -40,8 +40,8 @@ class PlainLiteral extends React.Component {
   }
 
   render () {
-    let textbox_name = `${this.props.param_prefix}[${this.props.name}][]`
-    let language_name = `${this.props.param_prefix}[${this.props.name}_language][]`
+    let textbox_name = `${this.props.paramPrefix}[${this.props.name}][][value]`
+    let language_name = `${this.props.paramPrefix}[${this.props.name}][][language]`
 
     return (
       <React.Fragment>
@@ -61,15 +61,15 @@ class PlainLiteral extends React.Component {
 
 PlainLiteral.propTypes = {
   /**
-   * The name of the element, used to with `param_prefix` to construct the
+   * The name of the element, used to with `paramPrefix` to construct the
    * parameter sent via the form submission.
    */
   name: PropTypes.string,
   /**
-   * Combined with the name (`<param_prefix>[<name>][]`) to construct the
+   * Combined with the name (`<paramPrefix>[<name>][]`) to construct the
    * parameter sent via the form submission.
    */
-  param_prefix: PropTypes.string,
+  paramPrefix: PropTypes.string,
   /**
    * The default text for the textbox
    */

--- a/app/javascript/components/PlainLiteral.md
+++ b/app/javascript/components/PlainLiteral.md
@@ -1,7 +1,7 @@
 ### Basic Example:
 
 ```js
-<PlainLiteral param_prefix='example' name='title' />
+<PlainLiteral paramPrefix='example' name='title' />
 ```
 
 ### Pre-populated example
@@ -9,5 +9,5 @@
 Default values can be pre-populated using the "value" and "language" properties:
 
 ```js
-<PlainLiteral param_prefix='example' name='title' value='Lorem ipsum' language='en'/>
+<PlainLiteral paramPrefix='example' name='title' value='Lorem ipsum' language='en'/>
 ```

--- a/app/javascript/components/Repeatable.jsx
+++ b/app/javascript/components/Repeatable.jsx
@@ -77,8 +77,7 @@ class Repeatable extends React.Component {
 
   // Creates the new element to add
   createNewElement(value) {
-    let element = this.newElement(value);
-    return element;
+    return this.newElement(value);
   }
 
   // Adds an entry

--- a/app/javascript/components/Repeatable.md
+++ b/app/javascript/components/Repeatable.md
@@ -12,7 +12,7 @@
 ```js
 import PlainLiteral from './PlainLiteral';
 <Repeatable name="test"
-   newElement={(value) => {return <PlainLiteral param_prefix='example' name='title' value={value.value} language={value.language}/>; }}
+   newElement={(value) => {return <PlainLiteral paramPrefix='example' name='title' value={value.value} language={value.language}/>; }}
    defaultValue={{value: "Lorem ipsum", language: ""}}
 />
 ```
@@ -31,7 +31,7 @@ let values= [
 <Repeatable name="test"
    newElement={
      (value) => {
-       return <PlainLiteral param_prefix='example' name='title' value={value.value} language={value.language}/>;
+       return <PlainLiteral paramPrefix='example' name='title' value={value.value} language={value.language}/>;
      }
    }
    defaultValue={{value: "", language: ""}}
@@ -55,7 +55,7 @@ let values = [
    newElement={
      (value) => {
        return (
-         <TypedLiteral param_prefix='example' name='title' value={value.value}
+         <TypedLiteral paramPrefix='example' name='title' value={value.value}
                        datatype={value.datatype} />
         );
      }

--- a/app/javascript/components/RepeatableControlledURIRef.jsx
+++ b/app/javascript/components/RepeatableControlledURIRef.jsx
@@ -1,11 +1,12 @@
-import PropTypes from "prop-types"
 import React from "react"
-import Repeatable from "./Repeatable";
-import TypedLiteral from "./TypedLiteral";
+import PlainLiteral from "./PlainLiteral"
+import PropTypes from "prop-types"
+import Repeatable from "./Repeatable"
+import ControlledURIRef from "./ControlledURIRef";
 
 /**
  * This class is mainly intended to serve as "syntactic sugar" so that the
- * "react-rails" gem can use the "Repeatable" component with the TypedLiteral
+ * "react-rails" gem can use the "Repeatable" component with the ControlledURIRef
  * component, without having to pass anonymous JavaScript functions as
  * properties.
  *
@@ -13,33 +14,33 @@ import TypedLiteral from "./TypedLiteral";
  *
  * ```
  * <%= react_component(
- *       "RepeatableTypedLiteral", {
- *         paramPrefix: "repeatable_typed_literal",
- *         defaultValue: { value: '', datatype: 'http://id.loc.gov/datatypes/edtf' },
- *         name: 'title',
- *         values: [
- *           {value: '2020-06-23', datatype: 'http://id.loc.gov/datatypes/edtf'},
- *           {value: '1856-03-06', datatype: 'http://www.w3.org/2001/XMLSchema#date'}
- *         ]
+ *       "RepeatableControlledURIRef", {
+ *       maxValues: 5,
+ *       paramPrefix: "repeatable_controlled_value",
+ *       name: 'title',
+ *       values: [
+ *         "http://vocab.lib.umd.edu/form#maps",
+ *         "http://vocab.lib.umd.edu/form#newspapers"]
  *       }
  *     )
  * %>
  * ```
+ *
  */
-class RepeatableTypedLiteral extends React.Component {
+class RepeatableControlledURIRef extends React.Component {
   render() {
     return (
       <Repeatable
          maxValues={this.props.maxValues}
          values={this.props.values}
-         newElement={(value) => <TypedLiteral paramPrefix={this.props.paramPrefix} name={this.props.name} value={value.value} datatype={value.datatype} />}
+         newElement={(value) => <ControlledURIRef paramPrefix={this.props.paramPrefix} name={this.props.name} value={value.value} vocab={this.props.vocab} />}
          defaultValue={this.props.defaultValue}
       />
     );
   }
 }
 
-RepeatableTypedLiteral.propTypes = {
+RepeatableControlledURIRef.propTypes = {
   /**
    * The name of the element, used to with `paramPrefix` to construct the
    * parameter sent via the form submission.
@@ -51,7 +52,7 @@ RepeatableTypedLiteral.propTypes = {
    */
   paramPrefix: PropTypes.string,
   /**
-   * The default text and datatype properties for the TypedLiteral entries
+   * The default text and language properties for the PlainLiteral entries
    */
   values: PropTypes.array,
   /**
@@ -64,4 +65,4 @@ RepeatableTypedLiteral.propTypes = {
   defaultValue: PropTypes.object
 }
 
-export default RepeatableTypedLiteral;
+export default RepeatableControlledURIRef;

--- a/app/javascript/components/RepeatableControlledURIRef.md
+++ b/app/javascript/components/RepeatableControlledURIRef.md
@@ -1,0 +1,28 @@
+### Basic Example
+
+```js
+<RepeatableControlledURIRef paramPrefix='example' name='title'
+ vocab={{'http://example.com/vocab#foo': 'Foo', 'http://example.com/vocab#bar': 'Bar'}}/>
+```
+
+### RepeatableControlledURIRef with preset values
+
+```js
+let values= [
+  {value: 'http://example.com/vocab#bar'},
+  {value: 'http://example.com/vocab#foo'}
+];
+
+<RepeatableControlledURIRef paramPrefix='example' name='title'
+   defaultValue={{value: ""}}
+   values={values}
+   vocab={{'http://example.com/vocab#foo': 'Foo', 'http://example.com/vocab#bar': 'Bar'}}/>
+```
+
+### RepeatableControlledURIRef only allowing up to 3 entries
+
+```js
+<RepeatableControlledURIRef paramPrefix='example' name='title'
+   maxValues={3}
+   vocab={{'http://example.com/vocab#foo': 'Foo', 'http://example.com/vocab#bar': 'Bar'}}/>
+```

--- a/app/javascript/components/RepeatablePlainLiteral.jsx
+++ b/app/javascript/components/RepeatablePlainLiteral.jsx
@@ -15,7 +15,7 @@ import Repeatable from "./Repeatable"
  * <%= react_component(
  *       "RepeatablePlainLiteral", {
  *       maxValues: 5,
- *       param_prefix: "repeatable_plain_literal",
+ *       paramPrefix: "repeatable_plain_literal",
  *       name: 'title',
  *       values: [
  *         {value: 'First Line', language: 'en'},
@@ -33,7 +33,7 @@ class RepeatablePlainLiteral extends React.Component {
       <Repeatable
          maxValues={this.props.maxValues}
          values={this.props.values}
-         newElement={(value) => <PlainLiteral param_prefix={this.props.param_prefix} name={this.props.name} value={value.value} language={value.language} />}
+         newElement={(value) => <PlainLiteral paramPrefix={this.props.paramPrefix} name={this.props.name} value={value.value} language={value.language} />}
          defaultValue={this.props.defaultValue}
       />
     );
@@ -42,15 +42,15 @@ class RepeatablePlainLiteral extends React.Component {
 
 RepeatablePlainLiteral.propTypes = {
   /**
-   * The name of the element, used to with `param_prefix` to construct the
+   * The name of the element, used to with `paramPrefix` to construct the
    * parameter sent via the form submission.
    */
   name: PropTypes.string,
   /**
-   * Combined with the name (`<param_prefix>[<name>][]`) to construct the
+   * Combined with the name (`<paramPrefix>[<name>][]`) to construct the
    * parameter sent via the form submission.
    */
-  param_prefix: PropTypes.string,
+  paramPrefix: PropTypes.string,
   /**
    * The default text and language properties for the PlainLiteral entries
    */

--- a/app/javascript/components/RepeatablePlainLiteral.md
+++ b/app/javascript/components/RepeatablePlainLiteral.md
@@ -1,7 +1,7 @@
 ### Basic Example
 
 ```js
-<RepeatablePlainLiteral param_prefix='example' name='title' />
+<RepeatablePlainLiteral paramPrefix='example' name='title' />
 ```
 
 ### RepeatablePlainLiteral with preset values
@@ -13,7 +13,7 @@ let values= [
   {value: 'Third Line', language: 'en'},
 ];
 
-<RepeatablePlainLiteral param_prefix='example' name='title'
+<RepeatablePlainLiteral paramPrefix='example' name='title'
    defaultValue={{value: "", language: ""}}
    values={values}
 />
@@ -22,7 +22,7 @@ let values= [
 ### RepeatablePlainLiteral only allowing up to 3 entries
 
 ```js
-<RepeatablePlainLiteral param_prefix='example' name='title'
+<RepeatablePlainLiteral paramPrefix='example' name='title'
    maxValues={3}
 />
 ```

--- a/app/javascript/components/RepeatableTypedLiteral.md
+++ b/app/javascript/components/RepeatableTypedLiteral.md
@@ -1,7 +1,7 @@
 ### Basic Example
 
 ```js
-<RepeatableTypedLiteral param_prefix='example' name='title' />
+<RepeatableTypedLiteral paramPrefix='example' name='title' />
 ```
 
 ### RepeatableTypedLiteral with preset values
@@ -12,7 +12,7 @@ let values = [
   {value: '2019-07-04', datatype: "http://www.w3.org/2001/XMLSchema#date"}
 ];
 
-<RepeatableTypedLiteral param_prefix='example' name='title'
+<RepeatableTypedLiteral paramPrefix='example' name='title'
    defaultValue={{value: "", datatype: ""}}
    values={values}
 />
@@ -21,7 +21,7 @@ let values = [
 ### RepeatableTypedLiteral only allowing up to 3 entries
 
 ```js
-<RepeatableTypedLiteral param_prefix='example' name='title'
+<RepeatableTypedLiteral paramPrefix='example' name='title'
    maxValues={3}
 />
 ```

--- a/app/javascript/components/TypedLiteral.jsx
+++ b/app/javascript/components/TypedLiteral.jsx
@@ -7,11 +7,11 @@ import PropTypes from "prop-types"
  *  Sample Rails view usage:
  *
  * ```
- * <%= react_component(:TypedLiteralValue, { param_prefix: 'example', name: 'title', value: "Lorem ipsum", datatype: "http://id.loc.gov/datatypes/edtf"}) %>
+ * <%= react_component(:TypedLiteralValue, { paramPrefix: 'example', name: 'title', value: "2020-06-26", datatype: "http://id.loc.gov/datatypes/edtf"}) %>
  * ```
  *
- * When used in a form, this will send two arrays `example[title][]` and
- * `example[title_datatype][]` as HTML paramaters.
+ * When used in a form, this will submit the array `example[title][]`
+ * with a single value, `{value: "2020-06-26", datatype: "http://id.loc.gov/datatypes/edtf"}`.
  */
 class TypedLiteral extends React.Component {
   constructor(props) {
@@ -33,8 +33,8 @@ class TypedLiteral extends React.Component {
   }
 
   render () {
-    let textbox_name = `${this.props.param_prefix}[${this.props.name}][]`
-    let datatype_name = `${this.props.param_prefix}[${this.props.name}_datatype][]`
+    let textbox_name = `${this.props.paramPrefix}[${this.props.name}][][value]`
+    let datatype_name = `${this.props.paramPrefix}[${this.props.name}][][datatype]`
 
     return (
       <React.Fragment>
@@ -47,15 +47,15 @@ class TypedLiteral extends React.Component {
 
 TypedLiteral.propTypes = {
   /**
-   * The name of the element, used to with `param_prefix` to construct the
+   * The name of the element, used to with `paramPrefix` to construct the
    * parameter sent via the form submission.
    */
   name: PropTypes.string,
   /**
-   * Combined with the name (`<param_prefix>[<name>][]`) to construct the
+   * Combined with the name (`<paramPrefix>[<name>][]`) to construct the
    * parameter sent via the form submission.
    */
-  param_prefix: PropTypes.string,
+  paramPrefix: PropTypes.string,
   /**
    * The default text for the textbox
    */

--- a/app/javascript/components/TypedLiteral.md
+++ b/app/javascript/components/TypedLiteral.md
@@ -1,11 +1,11 @@
 Basic Example:
 
 ```js
-<TypedLiteral param_prefix="example" name="title" datatype="http://www.w3.org/2001/XMLSchema#date"/>
+<TypedLiteral paramPrefix="example" name="title" datatype="http://www.w3.org/2001/XMLSchema#date"/>
 ```
 
 Default values can be pre-populated using the "value" and "datatype" properties:
 
 ```js
-<TypedLiteral param_prefix="example" name="title" value="2020-06-23" datatype="http://id.loc.gov/datatypes/edtf" />
+<TypedLiteral paramPrefix="example" name="title" value="2020-06-23" datatype="http://id.loc.gov/datatypes/edtf" />
 ```

--- a/app/models/vocabulary.rb
+++ b/app/models/vocabulary.rb
@@ -33,6 +33,16 @@ class Vocabulary < ApplicationRecord
 
   scope :by_identifier, -> { order('identifier ASC') }
 
+  def as_hash
+    Hash[terms.map do |term|
+      [term.uri, term.respond_to?(:label) ? term.label : term.identifier]
+    end]
+  end
+
+  def terms
+    individuals + types + datatypes
+  end
+
   def uri
     VOCAB_CONFIG['local_authority_base_uri'] + identifier + '#'
   end
@@ -42,7 +52,7 @@ class Vocabulary < ApplicationRecord
   end
 
   def term_count
-    types.count + individuals.count
+    terms.count
   end
 
   def graph

--- a/app/views/react_components/react_components.html.erb
+++ b/app/views/react_components/react_components.html.erb
@@ -6,7 +6,7 @@
   <h2>PlainLiteral</h2>
 
   <div class="form-group">
-    <%= react_component("PlainLiteral", { param_prefix: 'plain_literal', name: 'title', value: "Lorem ipsum", language: "en"}) %>
+    <%= react_component("PlainLiteral", {paramPrefix: 'plain_literal', name: 'title', value: "Lorem ipsum", language: "en"}) %>
   </div>
 
   <h2>TypedLiteral</h2>
@@ -14,20 +14,20 @@
   <div>Hover the mouse over the textbox to display a tooltip with the datatype.</div>
 
   <div class="form-group">
-    <%= react_component("TypedLiteral", { param_prefix: 'typed_literal', name: 'title', value: "2020-06-23", datatype: "http://id.loc.gov/datatypes/edtf"}) %>
+    <%= react_component("TypedLiteral", {paramPrefix: 'typed_literal', name: 'title', value: "2020-06-23", datatype: "http://id.loc.gov/datatypes/edtf"}) %>
   </div>
 
   <h2>Repeatable</h2>
 
   <h3>RepeatablePlainLiteral</h3>
 
-  <div>The following example is limited to 5 entries:<div>
+  <div>The following example is limited to 5 entries:</div>
 
   <div class="form-group">
     <%= react_component(
           "RepeatablePlainLiteral", {
             maxValues: 5,
-            param_prefix: "repeatable_plain_literal",
+            paramPrefix: "repeatable_plain_literal",
             name: 'title',
             values: [
               {value: 'First Line', language: 'en'},
@@ -45,7 +45,7 @@
   <div class="form-group">
     <%= react_component(
           "RepeatableTypedLiteral", {
-            param_prefix: "repeatable_typed_literal",
+            paramPrefix: "repeatable_typed_literal",
             defaultValue: { value: '', datatype: 'http://id.loc.gov/datatypes/edtf' },
             name: 'title',
             values: [
@@ -56,6 +56,48 @@
         )
     %>
   </div>
+
+  <h3>ControlledURIRef</h3>
+
+  <div>This component presents a dropdown using the values defined in the
+  <%= link_to 'controlled vocabularies', vocabularies_url %>.</div>
+
+  <% Vocabulary.all.each do |vocab| %>
+    <div><%= vocab.identifier %></div>
+    <div class="form-group">
+      <%=
+        react_component(
+            "ControlledURIRef", {
+            paramPrefix: 'controlled_value',
+            name: vocab.identifier,
+            vocab: vocab.as_hash,
+            value: vocab.terms[0].uri
+        }
+        )
+      %>
+    </div>
+  <% end %>
+
+  <h3>RepeatableControlledURIRef</h3>
+
+  <% Vocabulary.all.each do |vocab| %>
+    <div><%= vocab.identifier %> (repeated)</div>
+    <div class="form-group">
+      <%=
+        react_component(
+            "RepeatableControlledURIRef", {
+            paramPrefix: 'repeated_controlled_value',
+            name: vocab.identifier,
+            vocab: vocab.as_hash,
+            values: [
+                { value: vocab.terms[0].uri }
+            ],
+            defaultValue: { value: '' }
+        }
+        )
+      %>
+    </div>
+  <% end %>
 
   <div class="form-group">
     <input type="submit" name="submit" value="Submit" class="btn btn-primary form-control" />


### PR DESCRIPTION
* Gets values from a vocabulary
* Displays as a dropdown
* Renamed param_prefix to paramPrefix (to follow Javascript camelCase conventions)
* Modified input element names so plain literals submit arrays of "{value: '', language: ''}" hashes, and typed literals submit arrays of "{value: '', datatype: ''}" hashes

https://issues.umd.edu/browse/LIBHYDRA-331