### PR TITLE
LIBHYDRA-336. Increase the number of rows returned in the binaries_stats query.

### DIFF
--- a/app/services/binaries_stats.rb
+++ b/app/services/binaries_stats.rb
@@ -4,14 +4,12 @@
 class BinariesStats < SolrQueryService
   QUERY = {
     q: '*:*',
-    'pages.fq': 'component:Page',
+    rows: '10000',
     'files.q': '{!terms f=pcdm_file_of v=$row.pcdm_members}',
     indent: 'on',
-    fl: 'id,pages:[subquery],files:[subquery]',
+    fl: 'id,files:[subquery]',
     'files.fl': 'id,size',
-    'files.rows': '10000',
-    'pages.rows': '0',
-    'pages.q': '{!terms f=id v=$row.pcdm_members}'
+    'files.rows': '10000'
   }.freeze
 
   def self.query(uris, mime_types)


### PR DESCRIPTION
This should make the binary size estimates more accurate, as it should include all items selected for export, not just the first 10. Also, removed unneeded "pages" middle-level subquery.

Backported to M5 from https://issues.umd.edu/browse/LIBHYDRA-334

https://issues.umd.edu/browse/LIBHYDRA-336