### PR TITLE
LIBHYDRA-335. Make MAX_ALLOWED_BINARIES_DOWNLOAD_SIZE configurable

### DIFF
--- a/app/models/export_job.rb
+++ b/app/models/export_job.rb
@@ -16,7 +16,12 @@ class ExportJob < ApplicationRecord
     TURTLE_FORMAT => 'Turtle'
   }.freeze
 
-  MAX_ALLOWED_BINARIES_DOWNLOAD_SIZE = 50.gigabytes
+  #  Maximum allowed binaries file size, in bytes
+  MAX_ALLOWED_BINARIES_DOWNLOAD_SIZE = if ENV['MAX_ALLOWED_BINARIES_DOWNLOAD_SIZE']
+                                         ENV['MAX_ALLOWED_BINARIES_DOWNLOAD_SIZE'].to_i
+                                       else
+                                         50.gigabytes
+                                       end
 
   def self.exportable_types
     %w[Image Issue Letter]

--- a/env_example
+++ b/env_example
@@ -92,6 +92,9 @@ VOCAB_LOCAL_AUTHORITY_BASE_URI=
 # Base URI for the location where the vocabularies are published
 VOCAB_PUBLICATION_BASE_URI=
 
+# The maximum allowed binaries export download size, in bytes
+MAX_ALLOWED_BINARIES_DOWNLOAD_SIZE=53687091200
+
 # --- config/application.rb
 # Set this if you need to change the default logging level of "info"
 # RAILS_LOG_LEVEL=debug


### PR DESCRIPTION
Modified ExportJob so that MAX_ALLOWED_BINARIES_DOWNLOAD_SIZE is
configurable via the .env file.

Updated the "env_example" file with a default size of 50 gigabytes.

https://issues.umd.edu/browse/LIBHYDRA-335