### PR TITLE
LIBHYDRA-346. Hide "Edit Metadata" link for non-top-level components

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -201,6 +201,17 @@ class CatalogController < ApplicationController
     config.autocomplete_path = 'suggest'
   end
 
+  def show
+    super
+    @show_edit_metadata = CatalogController.show_edit_metadata(@document['component'])
+  end
+
+  # Returns true if the given component has editable metadata, false otherwise.
+  def self.show_edit_metadata(component)
+    uneditable_types = %w[Page Article]
+    !uneditable_types.include?(component)
+  end
+
   private
 
     def solr_connection_error

--- a/app/views/mirador/_show.html.erb
+++ b/app/views/mirador/_show.html.erb
@@ -1,8 +1,10 @@
 <% if mirador_displayable?(document) %>
   <div class="skip-link">
     <a href="#metadata" data-turbolinks="false">Go to Metadata</a>
-    &nbsp;
-    <a href="<%= resource_edit_url(id: @document.id) %>">Edit Metadata</a>
+    <% if @show_edit_metadata %>
+      &nbsp;
+      <a href="<%= resource_edit_url(id: @document.id) %>">Edit Metadata</a>
+    <% end %>
 
   </div>
   <div class="image-viewer intrinsic-container ratio-4x3">

--- a/test/controllers/catalog_controller_test.rb
+++ b/test/controllers/catalog_controller_test.rb
@@ -27,4 +27,13 @@ class CatalogControllerTest < ActionController::TestCase
       assert_equal flash[:error], I18n.t(:solr_is_down)
     end
   end
+
+  test 'show_edit_metadata should be "true" for top-level components' do
+    assert CatalogController.show_edit_metadata('Issue')
+  end
+
+  test 'show_edit_metadata should be "false" for non-top-level components' do
+    assert_not CatalogController.show_edit_metadata('Article')
+    assert_not CatalogController.show_edit_metadata('Page')
+  end
 end


### PR DESCRIPTION
Hide the "Edit Metadata" link when the document "component" is "Page"
or "Article".

https://issues.umd.edu/browse/LIBHYDRA-346