### PR TITLE
LIBHYDRA-349. Sort vocabularies in ControlledURIRef dropdowns

### DIFF
--- a/app/javascript/components/ControlledURIRef.jsx
+++ b/app/javascript/components/ControlledURIRef.jsx
@@ -40,11 +40,16 @@ class ControlledURIRef extends React.Component {
 
   render () {
     let inputName = `${this.props.paramPrefix}[${this.props.name}][][@id]`
+    let entries = Object.entries(this.props.vocab).map(([uri, label]) => ([uri, label]));
+
+    const sortStringValues = (a, b) => (a[1] > b[1] && 1) || (a[1] === b[1] ? 0 : -1)
+    entries.sort(sortStringValues); // Note: sort is "in-place"
+
     return (
       <React.Fragment>
         <select name={inputName} value={this.state.uri} onChange={this.handleChange}>
           <option key="" value=""/>
-          {Object.entries(this.props.vocab).map(([uri, label]) => (
+          {entries.map(([uri, label]) => (
               <option key={uri} value={uri}>{label}</option>
           ))}
         </select>

--- a/app/javascript/components/ControlledURIRef.jsx
+++ b/app/javascript/components/ControlledURIRef.jsx
@@ -28,7 +28,7 @@ class ControlledURIRef extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      uri: props.value['@id']
+      uri: props.value['@id'] || ""
     }
 
     this.handleChange = this.handleChange.bind(this);


### PR DESCRIPTION
Modified "app/javascript/components/ControlledURIRef.jsx" to sort the entries in the "vocab" prop by the "label" for the entry (as the "label" is what is displayed in the dropdown).

Also, in the constructor, provided empty string for the "uri" property if "props.value['@id']" is not defined, to fix the following error in the JavaScript console:

```
Warning: `value` prop on `select` should not be null. Consider using an empty string to clear the component or `undefined` for uncontrolled components.
    in select (at ControlledURIRef.jsx:50)
    in ControlledURIRef react-dom.development.js:91
```

https://issues.umd.edu/browse/LIBHYDRA-349