### PR TITLE
LIBHYDRA-352. Letter and Poster content models.

### DIFF
--- a/app/controllers/resource_controller.rb
+++ b/app/controllers/resource_controller.rb
@@ -25,6 +25,10 @@ class ResourceController < ApplicationController
     def content_model_from_rdf_type
       if @item['@type'].include? 'http://purl.org/ontology/bibo/Issue'
         ContentModels::NEWSPAPER
+      elsif @item['@type'].include? 'http://purl.org/ontology/bibo/Letter'
+        ContentModels::LETTER
+      elsif @item['@type'].include? 'http://purl.org/ontology/bibo/Image'
+        ContentModels::POSTER
       else
         ContentModels::ITEM
       end

--- a/app/helpers/resource_helper.rb
+++ b/app/helpers/resource_helper.rb
@@ -4,12 +4,10 @@ module ResourceHelper
   # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
   def define_react_components(fields, items, uri)
     item = items[uri]
-    label_predicate = 'http://www.w3.org/2000/01/rdf-schema#label'
-    same_as_predicate = 'http://www.w3.org/2002/07/owl#sameAs'
-    fields.map do |field| # rubocop:disable Metrics/BlockLength
+    fields.map do |field|
       component_type = field[:repeatable] ? 'Repeatable' : field[:type]
       values = item[field[:uri]]
-      component_args = { # rubocop:disable Metrics/BlockLength
+      component_args = {
         # this will group fields by their subject ...
         paramPrefix: uri,
         # ... and key them by their predicate
@@ -17,21 +15,17 @@ module ResourceHelper
       }.tap do |args|
         if field[:repeatable]
           args[:values] = values
+          # special handling for LabeledThing fields
+          if field[:type] == :LabeledThing
+            args[:values] = values&.map do |value|
+              get_labeled_thing_value(value, items)
+            end
+          end
         else
           # TODO: what do we do when there is more than value in a non-repeatable field?
           args[:value] = values&.first || {}
           # special handling for LabeledThing fields
-          if field[:type] == :LabeledThing
-            target_uri = args[:value].fetch('@id', nil)
-            if target_uri
-              obj = items[target_uri]
-              args[:value] = {
-                value: args[:value],
-                label: obj[label_predicate]&.first || '',
-                sameAs: obj[same_as_predicate]&.first || ''
-              }
-            end
-          end
+          args[:value] = get_labeled_thing_value(args[:value], items) if field[:type] == :LabeledThing
           # remove the value, so that the component will apply the defaultProps
           # if there is no value for this field
           args.delete(:value) if args[:value].empty?
@@ -53,4 +47,19 @@ module ResourceHelper
     end
   end
   # rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+
+  def get_labeled_thing_value(value, items)
+    target_uri = value.fetch('@id', nil)
+    return value unless target_uri
+
+    label_predicate = 'http://www.w3.org/2000/01/rdf-schema#label'
+    same_as_predicate = 'http://www.w3.org/2002/07/owl#sameAs'
+    obj = items[target_uri]
+    {
+      value: value,
+      label: obj[label_predicate]&.first || '',
+      sameAs: obj[same_as_predicate]&.first || ''
+    }
+
+  end
 end

--- a/app/helpers/resource_helper.rb
+++ b/app/helpers/resource_helper.rb
@@ -4,7 +4,7 @@ module ResourceHelper
   # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
   def define_react_components(fields, items, uri)
     item = items[uri]
-    fields.map do |field|
+    fields.map do |field| # rubocop:disable Metrics/BlockLength
       component_type = field[:repeatable] ? 'Repeatable' : field[:type]
       values = item[field[:uri]]
       component_args = {
@@ -60,6 +60,5 @@ module ResourceHelper
       label: obj[label_predicate]&.first || '',
       sameAs: obj[same_as_predicate]&.first || ''
     }
-
   end
 end

--- a/app/javascript/components/PlainLiteral.jsx
+++ b/app/javascript/components/PlainLiteral.jsx
@@ -28,7 +28,8 @@ class PlainLiteral extends React.Component {
   LANGUAGES = {
     '': 'None',
     'en': 'English',
-    'ja': 'Japanese'
+    'ja': 'Japanese',
+    'ja-latn': 'Japanese (Romanized)',
   };
 
   constructor(props) {

--- a/app/models/content_models.rb
+++ b/app/models/content_models.rb
@@ -79,25 +79,29 @@ module ContentModels # rubocop:disable Metrics/ModuleLength
         name: 'creator',
         uri: 'http://purl.org/dc/terms/creator',
         label: 'Creator',
-        type: :LabeledThing
+        type: :LabeledThing,
+        repeatable: true
       },
       {
         name: 'contributor',
         uri: 'http://purl.org/dc/terms/contributor',
         label: 'Contributor',
-        type: :LabeledThing
+        type: :LabeledThing,
+        repeatable: true
       },
       {
         name: 'publisher',
         uri: 'http://purl.org/dc/terms/publisher',
         label: 'Publisher',
-        type: :LabeledThing
+        type: :LabeledThing,
+        repeatable: true
       },
       {
         name: 'location',
         uri: 'http://purl.org/dc/terms/spatial',
         label: 'Location',
-        type: :LabeledThing
+        type: :LabeledThing,
+        repeatable: true
       },
       {
         name: 'extent',
@@ -110,7 +114,8 @@ module ContentModels # rubocop:disable Metrics/ModuleLength
         name: 'subject',
         uri: 'http://purl.org/dc/terms/subject',
         label: 'Subject',
-        type: :LabeledThing
+        type: :LabeledThing,
+        repeatable: true
       },
       {
         name: 'language',
@@ -123,7 +128,8 @@ module ContentModels # rubocop:disable Metrics/ModuleLength
         name: 'rights_holder',
         uri: 'http://purl.org/dc/terms/rightsHolder',
         label: 'Rights Holder',
-        type: :LabeledThing
+        type: :LabeledThing,
+        repeatable: true
       },
       {
         name: 'bibliographic_citation',
@@ -212,13 +218,15 @@ module ContentModels # rubocop:disable Metrics/ModuleLength
         name: 'author',
         uri: 'http://id.loc.gov/vocabulary/relators/aut',
         label: 'Author',
-        type: :LabeledThing
+        type: :LabeledThing,
+        repeatable: true
       },
       {
         name: 'recipient',
         uri: 'http://purl.org/ontology/bibo/recipient',
         label: 'Recipient',
-        type: :LabeledThing
+        type: :LabeledThing,
+        repeatable: true
       },
       {
         name: 'place',

--- a/app/models/content_models.rb
+++ b/app/models/content_models.rb
@@ -157,6 +157,232 @@ module ContentModels # rubocop:disable Metrics/ModuleLength
     ]
   }.freeze
 
+  LETTER = {
+    required: [
+      {
+        name: 'identifier',
+        uri: 'http://purl.org/dc/terms/identifier',
+        label: 'Identifier',
+        type: :TypedLiteral,
+        repeatable: true
+      },
+      {
+        name: 'rights',
+        uri: 'http://purl.org/dc/terms/rights',
+        label: 'Rights Statement',
+        type: :URIRef
+      },
+      {
+        name: 'title',
+        uri: 'http://purl.org/dc/terms/title',
+        label: 'Title',
+        type: :PlainLiteral
+      },
+      {
+        name: 'access',
+        label: 'Access Level',
+        type: :ControlledURIRef,
+        vocab: 'access'
+      },
+      {
+        name: 'type',
+        uri: 'http://www.europeana.eu/schemas/edm/hasType',
+        label: 'Resource Type',
+        type: :PlainLiteral
+      },
+      {
+        name: 'part_of',
+        uri: 'http://purl.org/dc/terms/isPartOf',
+        label: 'Archival Collection',
+        type: :LabeledThing
+      },
+      {
+        name: 'date',
+        uri: 'http://purl.org/dc/elements/1.1/date',
+        label: 'Date',
+        type: :TypedLiteral
+      },
+      {
+        name: 'description',
+        uri: 'http://purl.org/dc/terms/description',
+        label: 'Description',
+        type: :PlainLiteral
+      },
+      {
+        name: 'author',
+        uri: 'http://id.loc.gov/vocabulary/relators/aut',
+        label: 'Author',
+        type: :LabeledThing
+      },
+      {
+        name: 'recipient',
+        uri: 'http://purl.org/ontology/bibo/recipient',
+        label: 'Recipient',
+        type: :LabeledThing
+      },
+      {
+        name: 'place',
+        uri: 'http://purl.org/dc/terms/spatial',
+        label: 'Location',
+        type: :LabeledThing
+      },
+      {
+        name: 'extent',
+        uri: 'http://purl.org/dc/terms/extent',
+        label: 'Extent',
+        type: :PlainLiteral
+      },
+      {
+        name: 'subject',
+        uri: 'http://purl.org/dc/terms/subject',
+        label: 'Subject',
+        type: :LabeledThing
+      },
+      {
+        name: 'language',
+        uri: 'http://purl.org/dc/elements/1.1/language',
+        label: 'Language',
+        type: :TypedLiteral
+      },
+      {
+        name: 'rights_holder',
+        uri: 'http://purl.org/dc/terms/rightsHolder',
+        label: 'Rights Holder',
+        type: :PlainLiteral
+      },
+      {
+        name: 'bibliographic_citation',
+        uri: 'http://purl.org/dc/terms/bibliographicCitation',
+        label: 'Collection Information',
+        type: :PlainLiteral
+      }
+    ],
+    recommended: [],
+    optional: []
+  }.freeze
+
+  POSTER = {
+    required: [
+      {
+        name: 'identifier',
+        uri: 'http://purl.org/dc/terms/identifier',
+        label: 'Identifier',
+        type: :TypedLiteral
+      },
+      {
+        name: 'rights',
+        uri: 'http://purl.org/dc/terms/rights',
+        label: 'Rights Statement',
+        type: :URIRef
+      },
+      {
+        name: 'title',
+        uri: 'http://purl.org/dc/terms/title',
+        label: 'Title',
+        type: :PlainLiteral,
+        repeatable: true
+      },
+      {
+        name: 'access',
+        label: 'Access Level',
+        type: :ControlledURIRef,
+        vocab: 'access'
+      },
+      {
+        name: 'format',
+        uri: 'http://purl.org/dc/elements/1.1/format',
+        label: 'Resource Type',
+        type: :PlainLiteral
+      },
+      {
+        name: 'part_of',
+        uri: 'http://purl.org/dc/terms/isPartOf',
+        label: 'Collection',
+        type: :PlainLiteral,
+        repeatable: true
+      },
+      {
+        name: 'publisher',
+        uri: 'http://purl.org/dc/elements/1.1/publisher',
+        label: 'Publisher',
+        type: :PlainLiteral,
+        repeatable: true
+      },
+      {
+        name: 'date',
+        uri: 'http://purl.org/dc/elements/1.1/date',
+        label: 'Date',
+        type: :TypedLiteral
+      },
+      {
+        name: 'description',
+        uri: 'http://purl.org/dc/terms/description',
+        label: 'Description',
+        type: :PlainLiteral
+      },
+      {
+        name: 'location',
+        uri: 'http://purl.org/dc/elements/1.1/coverage',
+        label: 'Location',
+        type: :PlainLiteral,
+        repeatable: true
+      },
+      {
+        name: 'latitude',
+        uri: 'http://www.w3.org/2003/01/geo/wgs84_pos#lat',
+        label: 'Latitude',
+        type: :TypedLiteral
+      },
+      {
+        name: 'longitude',
+        uri: 'http://www.w3.org/2003/01/geo/wgs84_pos#long',
+        label: 'Longitude',
+        type: :TypedLiteral
+      },
+      {
+        name: 'extent',
+        uri: 'http://purl.org/dc/terms/extent',
+        label: 'Extent',
+        type: :PlainLiteral
+      },
+      {
+        name: 'subject',
+        uri: 'http://purl.org/dc/elements/1.1/subject',
+        label: 'Subject',
+        type: :PlainLiteral
+      },
+      {
+        name: 'language',
+        uri: 'http://purl.org/dc/elements/1.1/language',
+        label: 'Language',
+        type: :TypedLiteral
+      },
+      {
+        name: 'locator',
+        uri: 'http://purl.org/ontology/bibo/locator',
+        label: 'Identifier/Call Number',
+        type: :TypedLiteral
+      },
+      {
+        name: 'issue',
+        uri: 'http://purl.org/ontology/bibo/issue',
+        label: 'Issue',
+        type: :TypedLiteral
+      }
+    ],
+    recommended: [],
+    optional: [
+      {
+        name: 'alternate_title',
+        uri: 'http://purl.org/dc/terms/alternative',
+        label: 'Alternate Title',
+        type: :PlainLiteral,
+        repeatable: true
+      }
+    ]
+
+  }.freeze
+
   NEWSPAPER = {
     required: [
       {

--- a/app/models/content_models.rb
+++ b/app/models/content_models.rb
@@ -297,9 +297,15 @@ module ContentModels # rubocop:disable Metrics/ModuleLength
         vocab: 'access'
       },
       {
+        name: 'type',
+        uri: 'http://www.europeana.eu/schemas/edm/hasType',
+        label: 'Resource Type',
+        type: :PlainLiteral
+      },
+      {
         name: 'format',
         uri: 'http://purl.org/dc/elements/1.1/format',
-        label: 'Resource Type',
+        label: 'Format',
         type: :PlainLiteral
       },
       {


### PR DESCRIPTION
- Content model is determined in the resource controller by checking the RDF type of the resource to be edited.
- Also added ja-latn to languages dropdown in PlainLiteral.

https://issues.umd.edu/browse/LIBHYDRA-352