### PR TITLE
LIBHYDRA-350. Rename paramPrefix and name properties in React components

### DIFF
--- a/app/helpers/resource_helper.rb
+++ b/app/helpers/resource_helper.rb
@@ -11,7 +11,7 @@ module ResourceHelper
         # this will group fields by their subject ...
         subjectURI: uri,
         # ... and key them by their predicate
-        name: field[:uri]
+        predicateURI: field[:uri]
       }.tap do |args|
         if field[:repeatable]
           args[:values] = values
@@ -37,7 +37,7 @@ module ResourceHelper
           types = item['@type']
           values = types.select { |type_uri| access_vocab.key? type_uri }
           args[:value] = { '@id' => values[0] }
-          args[:name] = field[:name]
+          args[:predicateURI] = field[:name]
         end
 
         args[:vocab] = (Vocabulary[field[:vocab]] || {}) if field[:vocab].present?

--- a/app/helpers/resource_helper.rb
+++ b/app/helpers/resource_helper.rb
@@ -48,17 +48,20 @@ module ResourceHelper
   end
   # rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
-  def get_labeled_thing_value(value, items)
+  def get_labeled_thing_value(value, items) # rubocop:disable Metrics/MethodLength
     target_uri = value.fetch('@id', nil)
     return value unless target_uri
 
     label_predicate = 'http://www.w3.org/2000/01/rdf-schema#label'
     same_as_predicate = 'http://www.w3.org/2002/07/owl#sameAs'
     obj = items[target_uri]
-    {
-      value: value,
-      label: obj[label_predicate]&.first || '',
-      sameAs: obj[same_as_predicate]&.first || ''
+
+    result = {
+      value: value
     }
+
+    result[:label] = obj[label_predicate]&.first if obj[label_predicate]&.first
+    result[:sameAs] = obj[same_as_predicate]&.first if obj[same_as_predicate]&.first
+    result
   end
 end

--- a/app/helpers/resource_helper.rb
+++ b/app/helpers/resource_helper.rb
@@ -9,7 +9,7 @@ module ResourceHelper
       values = item[field[:uri]]
       component_args = {
         # this will group fields by their subject ...
-        paramPrefix: uri,
+        subjectURI: uri,
         # ... and key them by their predicate
         name: field[:uri]
       }.tap do |args|

--- a/app/javascript/components/ControlledURIRef.jsx
+++ b/app/javascript/components/ControlledURIRef.jsx
@@ -11,7 +11,7 @@ import PropTypes from "prop-types"
  *   react_component(
  *     :ControlledURIRef, {
  *       subjectURI: 'example',
- *       name: 'object_type',
+ *       predicateURI: 'object_type',
  *       vocab: Vocabulary.find_by(identifier: 'object_type').as_hash,
  *       value: {
  *         '@id' => 'http://example.com/foo#bar'
@@ -39,7 +39,7 @@ class ControlledURIRef extends React.Component {
   };
 
   render () {
-    let inputName = `${this.props.subjectURI}[${this.props.name}][][@id]`
+    let inputName = `${this.props.subjectURI}[${this.props.predicateURI}][][@id]`
     let entries = Object.entries(this.props.vocab).map(([uri, label]) => ([uri, label]));
 
     const sortStringValues = (a, b) => (a[1] > b[1] && 1) || (a[1] === b[1] ? 0 : -1)
@@ -60,13 +60,13 @@ class ControlledURIRef extends React.Component {
 
 ControlledURIRef.propTypes = {
   /**
-   * The name of the element, used to with `subjectURI` to construct the
+   * The predicateURI of the element, used with `subjectURI` to construct the
    * parameter sent via the form submission.
    */
-  name: PropTypes.string,
+  predicateURI: PropTypes.string,
   /**
-   * Combined with the name (`<subjectURI>[<name>][]`) to construct the
-   * parameter sent via the form submission.
+   * Combined with the predicateURI (`<subjectURI>[<predicateURI>][]`) to
+   * construct the parameter sent via the form submission.
    */
   subjectURI: PropTypes.string,
   /**

--- a/app/javascript/components/ControlledURIRef.jsx
+++ b/app/javascript/components/ControlledURIRef.jsx
@@ -10,7 +10,7 @@ import PropTypes from "prop-types"
  * <%=
  *   react_component(
  *     :ControlledURIRef, {
- *       paramPrefix: 'example',
+ *       subjectURI: 'example',
  *       name: 'object_type',
  *       vocab: Vocabulary.find_by(identifier: 'object_type').as_hash,
  *       value: {
@@ -39,7 +39,7 @@ class ControlledURIRef extends React.Component {
   };
 
   render () {
-    let inputName = `${this.props.paramPrefix}[${this.props.name}][][@id]`
+    let inputName = `${this.props.subjectURI}[${this.props.name}][][@id]`
     let entries = Object.entries(this.props.vocab).map(([uri, label]) => ([uri, label]));
 
     const sortStringValues = (a, b) => (a[1] > b[1] && 1) || (a[1] === b[1] ? 0 : -1)
@@ -60,15 +60,15 @@ class ControlledURIRef extends React.Component {
 
 ControlledURIRef.propTypes = {
   /**
-   * The name of the element, used to with `paramPrefix` to construct the
+   * The name of the element, used to with `subjectURI` to construct the
    * parameter sent via the form submission.
    */
   name: PropTypes.string,
   /**
-   * Combined with the name (`<paramPrefix>[<name>][]`) to construct the
+   * Combined with the name (`<subjectURI>[<name>][]`) to construct the
    * parameter sent via the form submission.
    */
-  paramPrefix: PropTypes.string,
+  subjectURI: PropTypes.string,
   /**
    * The default selected value for the dropdown
    */

--- a/app/javascript/components/ControlledURIRef.md
+++ b/app/javascript/components/ControlledURIRef.md
@@ -1,7 +1,7 @@
 ### Basic Example:
 
 ```js
-<ControlledURIRef subjectURI='example' name='title'
+<ControlledURIRef subjectURI='example' predicateURI='title'
  vocab={{'http://example.com/vocab#foo': 'Foo', 'http://example.com/vocab#bar': 'Bar'}}/>
 ```
 
@@ -10,6 +10,6 @@
 Default values can be pre-populated using the "value" property:
 
 ```js
-<ControlledURIRef subjectURI='example' name='title' value={{'@id': 'http://example.com/vocab#bar'}}
+<ControlledURIRef subjectURI='example' predicateURI='title' value={{'@id': 'http://example.com/vocab#bar'}}
  vocab={{'http://example.com/vocab#foo': 'Foo', 'http://example.com/vocab#bar': 'Bar'}}/>
 ```

--- a/app/javascript/components/ControlledURIRef.md
+++ b/app/javascript/components/ControlledURIRef.md
@@ -1,7 +1,7 @@
 ### Basic Example:
 
 ```js
-<ControlledURIRef paramPrefix='example' name='title'
+<ControlledURIRef subjectURI='example' name='title'
  vocab={{'http://example.com/vocab#foo': 'Foo', 'http://example.com/vocab#bar': 'Bar'}}/>
 ```
 
@@ -10,6 +10,6 @@
 Default values can be pre-populated using the "value" property:
 
 ```js
-<ControlledURIRef paramPrefix='example' name='title' value={{'@id': 'http://example.com/vocab#bar'}}
+<ControlledURIRef subjectURI='example' name='title' value={{'@id': 'http://example.com/vocab#bar'}}
  vocab={{'http://example.com/vocab#foo': 'Foo', 'http://example.com/vocab#bar': 'Bar'}}/>
 ```

--- a/app/javascript/components/LabeledThing.jsx
+++ b/app/javascript/components/LabeledThing.jsx
@@ -21,7 +21,7 @@ class LabeledThing extends React.Component {
       this.subject = value['value']['@id'];
     }
     if (this.subject === '') {
-      this.subject = props.paramPrefix + '#' + uuid();
+      this.subject = props.subjectURI + '#' + uuid();
     }
 
     // Modify subject with "key" value when used via "Repeatable"
@@ -40,13 +40,13 @@ class LabeledThing extends React.Component {
   }
 
   render () {
-    let fieldName = `${this.props.paramPrefix}[${this.props.name}][][@id]`
+    let fieldName = `${this.props.subjectURI}[${this.props.name}][][@id]`
     return (
         <React.Fragment>
           <input type="hidden" name={fieldName} value={this.subject}/>
-          <PlainLiteral paramPrefix={this.subject} name={labelPredicate} value={this.state.label}/>
+          <PlainLiteral subjectURI={this.subject} name={labelPredicate} value={this.state.label}/>
           &nbsp;URI:&nbsp;
-          <URIRef paramPrefix={this.subject} name={sameAsPredicate} value={this.state.sameAs}/>
+          <URIRef subjectURI={this.subject} name={sameAsPredicate} value={this.state.sameAs}/>
         </React.Fragment>
     );
   }
@@ -54,15 +54,15 @@ class LabeledThing extends React.Component {
 
 LabeledThing.propTypes = {
   /**
-   * The name of the element, used to with `paramPrefix` to construct the
+   * The name of the element, used to with `subjectURI` to construct the
    * parameter sent via the form submission.
    */
   name: PropTypes.string,
   /**
-   * Combined with the name (`<paramPrefix>[<name>][]`) to construct the
+   * Combined with the name (`<subjectURI>[<name>][]`) to construct the
    * parameter sent via the form submission.
    */
-  paramPrefix: PropTypes.string,
+  subjectURI: PropTypes.string,
   /**
    * The subject URI of the embedded object, as `{"@id": "..."}`
    */

--- a/app/javascript/components/LabeledThing.jsx
+++ b/app/javascript/components/LabeledThing.jsx
@@ -40,13 +40,13 @@ class LabeledThing extends React.Component {
   }
 
   render () {
-    let fieldName = `${this.props.subjectURI}[${this.props.name}][][@id]`
+    let fieldName = `${this.props.subjectURI}[${this.props.predicateURI}][][@id]`
     return (
         <React.Fragment>
           <input type="hidden" name={fieldName} value={this.subject}/>
-          <PlainLiteral subjectURI={this.subject} name={labelPredicate} value={this.state.label}/>
+          <PlainLiteral subjectURI={this.subject} predicateURI={labelPredicate} value={this.state.label}/>
           &nbsp;URI:&nbsp;
-          <URIRef subjectURI={this.subject} name={sameAsPredicate} value={this.state.sameAs}/>
+          <URIRef subjectURI={this.subject} predicateURI={sameAsPredicate} value={this.state.sameAs}/>
         </React.Fragment>
     );
   }
@@ -54,13 +54,13 @@ class LabeledThing extends React.Component {
 
 LabeledThing.propTypes = {
   /**
-   * The name of the element, used to with `subjectURI` to construct the
+   * The predicateURI of the element, used to with `subjectURI` to construct the
    * parameter sent via the form submission.
    */
-  name: PropTypes.string,
+  predicateURI: PropTypes.string,
   /**
-   * Combined with the name (`<subjectURI>[<name>][]`) to construct the
-   * parameter sent via the form submission.
+   * Combined with the predicateURI (`<subjectURI>[<predicateURI>][]`) to
+   * construct the parameter sent via the form submission.
    */
   subjectURI: PropTypes.string,
   /**

--- a/app/javascript/components/LabeledThing.md
+++ b/app/javascript/components/LabeledThing.md
@@ -1,7 +1,7 @@
 ### Basic Example:
 
 ```js
-<LabeledThing paramPrefix='example' name='creator' />
+<LabeledThing subjectURI='example' name='creator' />
 ```
 
 ### Pre-populated example
@@ -9,7 +9,7 @@
 Default values can be pre-populated using the "value", "label", and "sameAs" properties:
 
 ```js
-<LabeledThing paramPrefix='example' name='title'
+<LabeledThing subjectURI='example' name='title'
  value={{
    'value': {'@id': 'http://example.com/id/foobar'},
    'label': {'@value': 'Foobar', '@language': 'en'},

--- a/app/javascript/components/LabeledThing.md
+++ b/app/javascript/components/LabeledThing.md
@@ -1,7 +1,7 @@
 ### Basic Example:
 
 ```js
-<LabeledThing subjectURI='example' name='creator' />
+<LabeledThing subjectURI='example' predicateURI='creator' />
 ```
 
 ### Pre-populated example
@@ -9,7 +9,7 @@
 Default values can be pre-populated using the "value", "label", and "sameAs" properties:
 
 ```js
-<LabeledThing subjectURI='example' name='title'
+<LabeledThing subjectURI='example' predicateURI='title'
  value={{
    'value': {'@id': 'http://example.com/id/foobar'},
    'label': {'@value': 'Foobar', '@language': 'en'},

--- a/app/javascript/components/PlainLiteral.jsx
+++ b/app/javascript/components/PlainLiteral.jsx
@@ -11,7 +11,7 @@ import PropTypes from "prop-types"
  *   :PlainLiteral,
  *   {
  *     subjectURI: 'example',
- *     name: 'title',
+ *     predicateURI: 'title',
  *     value: {
  *       '@id' => "Lorem ipsum",
  *       '@language' => "en"
@@ -51,8 +51,8 @@ class PlainLiteral extends React.Component {
   }
 
   render () {
-    let textbox_name = `${this.props.subjectURI}[${this.props.name}][][@value]`
-    let language_name = `${this.props.subjectURI}[${this.props.name}][][@language]`
+    let textbox_name = `${this.props.subjectURI}[${this.props.predicateURI}][][@value]`
+    let language_name = `${this.props.subjectURI}[${this.props.predicateURI}][][@language]`
 
     return (
       <React.Fragment>
@@ -70,13 +70,13 @@ class PlainLiteral extends React.Component {
 
 PlainLiteral.propTypes = {
   /**
-   * The name of the element, used to with `subjectURI` to construct the
+   * The predicateURI of the element, used to with `subjectURI` to construct the
    * parameter sent via the form submission.
    */
-  name: PropTypes.string,
+  predicateURI: PropTypes.string,
   /**
-   * Combined with the name (`<subjectURI>[<name>][]`) to construct the
-   * parameter sent via the form submission.
+   * Combined with the predicateURI (`<subjectURI>[<predicateURI>][]`) to
+   * construct the parameter sent via the form submission.
    */
   subjectURI: PropTypes.string,
   /**

--- a/app/javascript/components/PlainLiteral.jsx
+++ b/app/javascript/components/PlainLiteral.jsx
@@ -10,7 +10,7 @@ import PropTypes from "prop-types"
  * <%= react_component(
  *   :PlainLiteral,
  *   {
- *     paramPrefix: 'example',
+ *     subjectURI: 'example',
  *     name: 'title',
  *     value: {
  *       '@id' => "Lorem ipsum",
@@ -51,8 +51,8 @@ class PlainLiteral extends React.Component {
   }
 
   render () {
-    let textbox_name = `${this.props.paramPrefix}[${this.props.name}][][@value]`
-    let language_name = `${this.props.paramPrefix}[${this.props.name}][][@language]`
+    let textbox_name = `${this.props.subjectURI}[${this.props.name}][][@value]`
+    let language_name = `${this.props.subjectURI}[${this.props.name}][][@language]`
 
     return (
       <React.Fragment>
@@ -70,15 +70,15 @@ class PlainLiteral extends React.Component {
 
 PlainLiteral.propTypes = {
   /**
-   * The name of the element, used to with `paramPrefix` to construct the
+   * The name of the element, used to with `subjectURI` to construct the
    * parameter sent via the form submission.
    */
   name: PropTypes.string,
   /**
-   * Combined with the name (`<paramPrefix>[<name>][]`) to construct the
+   * Combined with the name (`<subjectURI>[<name>][]`) to construct the
    * parameter sent via the form submission.
    */
-  paramPrefix: PropTypes.string,
+  subjectURI: PropTypes.string,
   /**
    * The text and ISO-639 language code for the textbox, structured as
    * `{"@value": "...", "@language": "..." }`

--- a/app/javascript/components/PlainLiteral.md
+++ b/app/javascript/components/PlainLiteral.md
@@ -1,14 +1,14 @@
 ### Basic Example:
 
 ```js
-<PlainLiteral paramPrefix='example' name='title' />
+<PlainLiteral subjectURI='example' name='title' />
 ```
 
 ### Pre-populated example
 
-Default values can be pre-populated using the "value" property: 
+Default values can be pre-populated using the "value" property:
 
 ```js
-<PlainLiteral paramPrefix='example' name='title'
+<PlainLiteral subjectURI='example' name='title'
  value={{'@value': 'Lorem ipsum', '@language': 'en'}}/>
 ```

--- a/app/javascript/components/PlainLiteral.md
+++ b/app/javascript/components/PlainLiteral.md
@@ -1,7 +1,7 @@
 ### Basic Example:
 
 ```js
-<PlainLiteral subjectURI='example' name='title' />
+<PlainLiteral subjectURI='example' predicateURI='title' />
 ```
 
 ### Pre-populated example
@@ -9,6 +9,6 @@
 Default values can be pre-populated using the "value" property:
 
 ```js
-<PlainLiteral subjectURI='example' name='title'
+<PlainLiteral subjectURI='example' predicateURI='title'
  value={{'@value': 'Lorem ipsum', '@language': 'en'}}/>
 ```

--- a/app/javascript/components/Repeatable.jsx
+++ b/app/javascript/components/Repeatable.jsx
@@ -81,7 +81,7 @@ class Repeatable extends React.Component {
   // Creates the new element to add
   createNewElement(newValue) {
     const newProps = {
-      paramPrefix: this.props.paramPrefix,
+      subjectURI: this.props.subjectURI,
       name: this.props.name,
       value: newValue,
       vocab: this.props.vocab,

--- a/app/javascript/components/Repeatable.jsx
+++ b/app/javascript/components/Repeatable.jsx
@@ -82,7 +82,7 @@ class Repeatable extends React.Component {
   createNewElement(newValue) {
     const newProps = {
       subjectURI: this.props.subjectURI,
-      name: this.props.name,
+      predicateURI: this.props.predicateURI,
       value: newValue,
       vocab: this.props.vocab,
     }

--- a/app/javascript/components/Repeatable.md
+++ b/app/javascript/components/Repeatable.md
@@ -1,13 +1,13 @@
 ### Repeatable LabeledThing example
 
 ```js
-<Repeatable name="test" componentType="LabeledThing" subjectURI='example' name='creator' />
+<Repeatable name="test" componentType="LabeledThing" subjectURI='example' predicateURI='creator' />
 ```
 
 ### Repeatable LabeledThing with preset values
 
 ```js
-<Repeatable name="repeatableLabeledThingPredicate" componentType="LabeledThing" subjectURI='subjectURI'
+<Repeatable name="test" predicateURI="repeatableLabeledThingPredicate" componentType="LabeledThing" subjectURI='subjectURI'
             values={[
                { value: {'@id': 'http://example.com/id/foobar'},
                  label: {'@value': 'Foobar', '@language': 'en'},

--- a/app/javascript/components/Repeatable.md
+++ b/app/javascript/components/Repeatable.md
@@ -1,13 +1,13 @@
 ### Repeatable LabeledThing example
 
 ```js
-<Repeatable name="test" componentType="LabeledThing" paramPrefix='example' name='creator' />
+<Repeatable name="test" componentType="LabeledThing" subjectURI='example' name='creator' />
 ```
 
 ### Repeatable LabeledThing with preset values
 
 ```js
-<Repeatable name="repeatableLabeledThingPredicate" componentType="LabeledThing" paramPrefix='subjectURI'
+<Repeatable name="repeatableLabeledThingPredicate" componentType="LabeledThing" subjectURI='subjectURI'
             values={[
                { value: {'@id': 'http://example.com/id/foobar'},
                  label: {'@value': 'Foobar', '@language': 'en'},
@@ -68,7 +68,7 @@ let values = [
    componentType="TypedLiteral"
    maxValues={3}
    values={values}
-   paramPrefix="example"
+   subjectURI="example"
    defaultValue={{'@value': '', '@type': "http://id.loc.gov/datatypes/edtf"}}
 />
 ```

--- a/app/javascript/components/TypedLiteral.jsx
+++ b/app/javascript/components/TypedLiteral.jsx
@@ -11,7 +11,7 @@ import PropTypes from "prop-types"
  *   :TypedLiteralValue,
  *   {
  *     subjectURI: 'example',
- *     name: 'title',
+ *     predicateURI: 'title',
  *     value: {
  *       '@value': '2020-06-26',
  *       '@type': 'http://id.loc.gov/datatypes/edtf'
@@ -38,8 +38,8 @@ class TypedLiteral extends React.Component {
   }
 
   render () {
-    let textbox_name = `${this.props.subjectURI}[${this.props.name}][][@value]`
-    let datatype_name = `${this.props.subjectURI}[${this.props.name}][][@type]`
+    let textbox_name = `${this.props.subjectURI}[${this.props.predicateURI}][][@value]`
+    let datatype_name = `${this.props.subjectURI}[${this.props.predicateURI}][][@type]`
 
     return (
       <React.Fragment>
@@ -52,13 +52,13 @@ class TypedLiteral extends React.Component {
 
 TypedLiteral.propTypes = {
   /**
-   * The name of the element, used to with `subjectURI` to construct the
+   * The predicateURI of the element, used to with `subjectURI` to construct the
    * parameter sent via the form submission.
    */
-  name: PropTypes.string,
+  predicateURI: PropTypes.string,
   /**
-   * Combined with the name (`<subjectURI>[<name>][]`) to construct the
-   * parameter sent via the form submission.
+   * Combined with the predicateURI (`<subjectURI>[<predicateURI>][]`) to
+   * construct the parameter sent via the form submission.
    */
   subjectURI: PropTypes.string,
   /**

--- a/app/javascript/components/TypedLiteral.jsx
+++ b/app/javascript/components/TypedLiteral.jsx
@@ -10,7 +10,7 @@ import PropTypes from "prop-types"
  * <%= react_component(
  *   :TypedLiteralValue,
  *   {
- *     paramPrefix: 'example',
+ *     subjectURI: 'example',
  *     name: 'title',
  *     value: {
  *       '@value': '2020-06-26',
@@ -38,8 +38,8 @@ class TypedLiteral extends React.Component {
   }
 
   render () {
-    let textbox_name = `${this.props.paramPrefix}[${this.props.name}][][@value]`
-    let datatype_name = `${this.props.paramPrefix}[${this.props.name}][][@type]`
+    let textbox_name = `${this.props.subjectURI}[${this.props.name}][][@value]`
+    let datatype_name = `${this.props.subjectURI}[${this.props.name}][][@type]`
 
     return (
       <React.Fragment>
@@ -52,15 +52,15 @@ class TypedLiteral extends React.Component {
 
 TypedLiteral.propTypes = {
   /**
-   * The name of the element, used to with `paramPrefix` to construct the
+   * The name of the element, used to with `subjectURI` to construct the
    * parameter sent via the form submission.
    */
   name: PropTypes.string,
   /**
-   * Combined with the name (`<paramPrefix>[<name>][]`) to construct the
+   * Combined with the name (`<subjectURI>[<name>][]`) to construct the
    * parameter sent via the form submission.
    */
-  paramPrefix: PropTypes.string,
+  subjectURI: PropTypes.string,
   /**
    * The initial text and datatype for the component. in the form
    * `{"@value": "...", "@type": "http://..."}`

--- a/app/javascript/components/TypedLiteral.md
+++ b/app/javascript/components/TypedLiteral.md
@@ -1,12 +1,12 @@
 Basic Example:
 
 ```js
-<TypedLiteral subjectURI="example" name="title"/>
+<TypedLiteral subjectURI="example" predicateURI="title"/>
 ```
 
 Default values can be pre-populated using the "value" property:
 
 ```js
-<TypedLiteral subjectURI="example" name="title"
+<TypedLiteral subjectURI="example" predicateURI="title"
 value={{'@value': "2020-06-23", '@type': "http://id.loc.gov/datatypes/edtf"}} />
 ```

--- a/app/javascript/components/TypedLiteral.md
+++ b/app/javascript/components/TypedLiteral.md
@@ -1,12 +1,12 @@
 Basic Example:
 
 ```js
-<TypedLiteral paramPrefix="example" name="title"/>
+<TypedLiteral subjectURI="example" name="title"/>
 ```
 
 Default values can be pre-populated using the "value" property:
 
 ```js
-<TypedLiteral paramPrefix="example" name="title"
+<TypedLiteral subjectURI="example" name="title"
 value={{'@value': "2020-06-23", '@type': "http://id.loc.gov/datatypes/edtf"}} />
 ```

--- a/app/javascript/components/URIRef.jsx
+++ b/app/javascript/components/URIRef.jsx
@@ -7,7 +7,7 @@ import PropTypes, { string } from "prop-types"
  *  Sample Rails view usage:
  *
  * ```
- * <%= react_component(:URIRef, { paramPrefix: 'example', name: 'title', value: { "@id": "http://example.com/vocab#bar"} }) %>
+ * <%= react_component(:URIRef, { subjectURI: 'example', name: 'title', value: { "@id": "http://example.com/vocab#bar"} }) %>
  * ```
  *
  * When used in a form, this will submit the array `example[title][]`
@@ -29,7 +29,7 @@ class URIRef extends React.Component {
   }
 
   render () {
-    let textbox_name = `${this.props.paramPrefix}[${this.props.name}][][@id]`
+    let textbox_name = `${this.props.subjectURI}[${this.props.name}][][@id]`
 
     return (
       <React.Fragment>
@@ -41,15 +41,15 @@ class URIRef extends React.Component {
 
 URIRef.propTypes = {
   /**
-   * The name of the element, used to with `paramPrefix` to construct the
+   * The name of the element, used to with `subjectURI` to construct the
    * parameter sent via the form submission.
    */
   name: PropTypes.string,
   /**
-   * Combined with the name (`<paramPrefix>[<name>][]`) to construct the
+   * Combined with the name (`<subjectURI>[<name>][]`) to construct the
    * parameter sent via the form submission.
    */
-  paramPrefix: PropTypes.string,
+  subjectURI: PropTypes.string,
   /**
    * The default text for the textbox
    */

--- a/app/javascript/components/URIRef.jsx
+++ b/app/javascript/components/URIRef.jsx
@@ -7,7 +7,7 @@ import PropTypes, { string } from "prop-types"
  *  Sample Rails view usage:
  *
  * ```
- * <%= react_component(:URIRef, { subjectURI: 'example', name: 'title', value: { "@id": "http://example.com/vocab#bar"} }) %>
+ * <%= react_component(:URIRef, { subjectURI: 'example', predicateURI: 'title', value: { "@id": "http://example.com/vocab#bar"} }) %>
  * ```
  *
  * When used in a form, this will submit the array `example[title][]`
@@ -29,7 +29,7 @@ class URIRef extends React.Component {
   }
 
   render () {
-    let textbox_name = `${this.props.subjectURI}[${this.props.name}][][@id]`
+    let textbox_name = `${this.props.subjectURI}[${this.props.predicateURI}][][@id]`
 
     return (
       <React.Fragment>
@@ -41,13 +41,13 @@ class URIRef extends React.Component {
 
 URIRef.propTypes = {
   /**
-   * The name of the element, used to with `subjectURI` to construct the
+   * The predicateURI of the element, used to with `subjectURI` to construct the
    * parameter sent via the form submission.
    */
-  name: PropTypes.string,
+  predicateURI: PropTypes.string,
   /**
-   * Combined with the name (`<subjectURI>[<name>][]`) to construct the
-   * parameter sent via the form submission.
+   * Combined with the predicateURI (`<subjectURI>[<predicateURI>][]`) to
+   * construct the parameter sent via the form submission.
    */
   subjectURI: PropTypes.string,
   /**

--- a/app/javascript/components/URIRef.md
+++ b/app/javascript/components/URIRef.md
@@ -1,12 +1,12 @@
 Basic Example:
 
 ```js
-<URIRef paramPrefix="example" name="title" />
+<URIRef subjectURI="example" name="title" />
 ```
 
 Default values can be pre-populated using the "value" property:
 
 ```js
 let value = { "@id": "http://example.com/vocab#bar" };
-<URIRef paramPrefix="example" name="title" value={value} />
+<URIRef subjectURI="example" name="title" value={value} />
 ```

--- a/app/javascript/components/URIRef.md
+++ b/app/javascript/components/URIRef.md
@@ -1,12 +1,12 @@
 Basic Example:
 
 ```js
-<URIRef subjectURI="example" name="title" />
+<URIRef subjectURI="example" predicateURI="title" />
 ```
 
 Default values can be pre-populated using the "value" property:
 
 ```js
 let value = { "@id": "http://example.com/vocab#bar" };
-<URIRef subjectURI="example" name="title" value={value} />
+<URIRef subjectURI="example" predicateURI="title" value={value} />
 ```

--- a/app/views/react_components/react_components.html.erb
+++ b/app/views/react_components/react_components.html.erb
@@ -10,7 +10,7 @@
 
   <div class="form-group">
     <%= react_component(:LabeledThing, {
-      paramPrefix: 'labeled_thing',
+      subjectURI: 'labeled_thing',
       name: 'title',
       value: { value: { '@id': 'http://example.com/baz' },
               label: { '@value': 'Baz' },
@@ -24,7 +24,7 @@
   <div class="form-group">
     <%= react_component(
           "PlainLiteral", {
-          paramPrefix: 'plain_literal',
+          subjectURI: 'plain_literal',
           name: 'title',
           value: {
             '@value': "Lorem ipsum",
@@ -40,7 +40,7 @@
   <div class="form-group">
     <%= react_component(
           "TypedLiteral", {
-          paramPrefix: 'typed_literal',
+          subjectURI: 'typed_literal',
           name: 'title',
           value: {
             '@value': "2020-06-23",
@@ -60,7 +60,7 @@
       <%=
         react_component(
           "ControlledURIRef", {
-          paramPrefix: 'controlled_value',
+          subjectURI: 'controlled_value',
           name: vocab.identifier,
           vocab: vocab.as_hash,
           value: { '@id': vocab.terms[0].uri }
@@ -75,7 +75,7 @@
   <div>This component presents as a simple textbox</div>
 
   <div class="form-group">
-    <%= react_component(:URIRef, { paramPrefix: 'uri_ref', name: 'title', value: { "@id": "http://example.com/vocab#bar"} }) %>
+    <%= react_component(:URIRef, { subjectURI: 'uri_ref', name: 'title', value: { "@id": "http://example.com/vocab#bar"} }) %>
   </div>
 
   <h2>Repeatable</h2>
@@ -87,7 +87,7 @@
       :Repeatable,
       {
         componentType: :LabeledThing,
-        paramPrefix: "repeatable_labeled_thing",
+        subjectURI: "repeatable_labeled_thing",
         name: 'repeatableLabeledThingPredicate',
       }
     )%>
@@ -103,7 +103,7 @@
           {
             maxValues: 5,
             componentType: :PlainLiteral,
-            paramPrefix: "repeatable_plain_literal",
+            subjectURI: "repeatable_plain_literal",
             name: 'title',
             values: [
               {'@value': 'First Line', '@language': 'en'},
@@ -122,7 +122,7 @@
           :Repeatable,
           {
             componentType: :TypedLiteral,
-            paramPrefix: "repeatable_typed_literal",
+            subjectURI: "repeatable_typed_literal",
             defaultValue: { '@value': '', '@type': 'http://id.loc.gov/datatypes/edtf' },
             name: 'title',
             values: [
@@ -142,7 +142,7 @@
             :Repeatable,
             {
               componentType: :ControlledURIRef,
-              paramPrefix: 'repeated_controlled_value',
+              subjectURI: 'repeated_controlled_value',
               name: vocab.identifier,
               vocab: vocab.as_hash,
               values: [
@@ -162,7 +162,7 @@
             :Repeatable,
             {
               componentType: :URIRef,
-              paramPrefix: 'repeatable_uri_ref',
+              subjectURI: 'repeatable_uri_ref',
               name: 'title',
               values: [
                 { '@id': "http://example.com/vocab#bar" }

--- a/app/views/react_components/react_components.html.erb
+++ b/app/views/react_components/react_components.html.erb
@@ -11,7 +11,7 @@
   <div class="form-group">
     <%= react_component(:LabeledThing, {
       subjectURI: 'labeled_thing',
-      name: 'title',
+      predicateURI: 'title',
       value: { value: { '@id': 'http://example.com/baz' },
               label: { '@value': 'Baz' },
               sameAs: { '@id': 'http://example.com/id/baz' }
@@ -25,7 +25,7 @@
     <%= react_component(
           "PlainLiteral", {
           subjectURI: 'plain_literal',
-          name: 'title',
+          predicateURI: 'title',
           value: {
             '@value': "Lorem ipsum",
             '@language': "en"
@@ -41,7 +41,7 @@
     <%= react_component(
           "TypedLiteral", {
           subjectURI: 'typed_literal',
-          name: 'title',
+          predicateURI: 'title',
           value: {
             '@value': "2020-06-23",
             '@type': "http://id.loc.gov/datatypes/edtf"
@@ -61,7 +61,7 @@
         react_component(
           "ControlledURIRef", {
           subjectURI: 'controlled_value',
-          name: vocab.identifier,
+          predicateURI: vocab.identifier,
           vocab: vocab.as_hash,
           value: { '@id': vocab.terms[0].uri }
         }
@@ -75,7 +75,7 @@
   <div>This component presents as a simple textbox</div>
 
   <div class="form-group">
-    <%= react_component(:URIRef, { subjectURI: 'uri_ref', name: 'title', value: { "@id": "http://example.com/vocab#bar"} }) %>
+    <%= react_component(:URIRef, { subjectURI: 'uri_ref', predicateURI: 'title', value: { "@id": "http://example.com/vocab#bar"} }) %>
   </div>
 
   <h2>Repeatable</h2>
@@ -88,7 +88,7 @@
       {
         componentType: :LabeledThing,
         subjectURI: "repeatable_labeled_thing",
-        name: 'repeatableLabeledThingPredicate',
+        predicateURI: 'repeatableLabeledThingPredicate',
       }
     )%>
   </div>
@@ -104,7 +104,7 @@
             maxValues: 5,
             componentType: :PlainLiteral,
             subjectURI: "repeatable_plain_literal",
-            name: 'title',
+            predicateURI: 'title',
             values: [
               {'@value': 'First Line', '@language': 'en'},
               {'@value': '二行目', '@language': 'ja'},
@@ -123,8 +123,8 @@
           {
             componentType: :TypedLiteral,
             subjectURI: "repeatable_typed_literal",
+            predicateURI: 'title',
             defaultValue: { '@value': '', '@type': 'http://id.loc.gov/datatypes/edtf' },
-            name: 'title',
             values: [
               {'@value': '2020-06-23', '@type': 'http://id.loc.gov/datatypes/edtf'},
               {'@value': '1856-03-06', '@type': 'http://www.w3.org/2001/XMLSchema#date'}
@@ -143,7 +143,7 @@
             {
               componentType: :ControlledURIRef,
               subjectURI: 'repeated_controlled_value',
-              name: vocab.identifier,
+              predicateURI: vocab.identifier,
               vocab: vocab.as_hash,
               values: [
                 { '@id': vocab.terms[0].uri }
@@ -163,7 +163,7 @@
             {
               componentType: :URIRef,
               subjectURI: 'repeatable_uri_ref',
-              name: 'title',
+              predicateURI: 'title',
               values: [
                 { '@id': "http://example.com/vocab#bar" }
               ],


### PR DESCRIPTION

* Renamed "paramPrefix" to "subjectURI"
* Renamed "name" to "predicateURI"
* Fixed a small bug initializing "LabeledThing" in the "get_labeled_thing_value" method of "app/helpers/resource_helper.rb", where the "label" and "sameAs" properties were being initialized with a default empty string value. Modified to populate the properties only if an actual value was available.

https://issues.umd.edu/browse/LIBHYDRA-350