### PR TITLE
LIBHYDRA-353. Add synchronous message sending/receiving capability to the StompService

### DIFF
--- a/app/services/stomp_service.rb
+++ b/app/services/stomp_service.rb
@@ -13,4 +13,33 @@ class StompService
     Rails.logger.error('Unable to connect to STOMP server')
     false
   end
+
+  # Sends a message to Plastron and waits for a response
+  #
+  # Will wait up to "receive_timeout" (in seconds) for a response, which
+  # defaults to 2 minutes.
+  #
+  # Throws a Timeout::Error if the response timeout expires
+  def self.synchronous_message(destination, body, headers, receive_timeout = 120) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/LineLength
+    destination_queue = STOMP_CONFIG['destinations'][destination.to_s]
+    receive_queue = '/temp-queue/synchronous'
+
+    Rails.logger.info("Publishing message synchronously to #{destination_queue}")
+
+    connection = Stomp::Connection.new(hosts: [STOMP_SERVER], max_reconnect_attempts: 1)
+    connection.subscribe(receive_queue)
+    headers['reply-to'] = receive_queue
+    headers['PlastronJobId'] = "SYNCHRONOUS-#{SecureRandom.uuid}"
+    connection.publish(destination_queue, body, headers)
+
+    Timeout.timeout(receive_timeout) do
+      msg = connection.receive
+      return msg.body
+    end
+  rescue Stomp::Error::MaxReconnectAttempts
+    Rails.logger.error('Unable to connect to STOMP server')
+    'Unable to connect to STOMP server.'
+  ensure
+    connection&.disconnect
+  end
 end

--- a/app/views/resource/form_submit.html.erb
+++ b/app/views/resource/form_submit.html.erb
@@ -2,10 +2,7 @@
 
 <h2>Submitted Params</h2>
 <pre><%=
-    params_to_skip = %w[utf8 authenticity_token submit controller action]
-    submission = params.to_unsafe_h
-    params_to_skip.each { |key| submission.delete(key) }
-    JSON.pretty_generate(submission)
+    @submission
 %></pre>
 
 <hr />

--- a/config/stomp.yml
+++ b/config/stomp.yml
@@ -6,6 +6,7 @@ default: &default
     jobs: /queue/plastron.jobs
     job_status: /topic/plastron.jobs.status
     jobs_completed: /queue/plastron.jobs.completed
+    jobs_synchronous: /queue/plastron.jobs.synchronous
 
 development:
   <<: *default

--- a/docs/ArchelonDevelopmentEnvironment.md
+++ b/docs/ArchelonDevelopmentEnvironment.md
@@ -245,6 +245,7 @@ MESSAGE_BROKER:
     JOBS: /queue/plastron.jobs
     JOB_STATUS: /topic/plastron.jobs.status
     COMPLETED_JOBS: /queue/plastron.jobs.completed
+    SYNCHRONOUS_JOBS: /queue/plastron.jobs.synchronous
 COMMANDS:
   EXPORT:
     BINARIES_DIR: exports/


### PR DESCRIPTION
Added "synchronous_message" method to "StompServices" which sends a message to Plastron and then blocks until a reply is received, or the timeout expires.

Updated the "ResourceController" class with Simple demonstration of synchronous STOMP messages, using the Plastron "echo" command.

https://issues.umd.edu/browse/LIBHYDRA-353