### PR TITLE
LIBHYDRA-356. Generate a list of deletes and inserts on the edit form

### DIFF
--- a/app/controllers/resource_controller.rb
+++ b/app/controllers/resource_controller.rb
@@ -5,6 +5,7 @@ require 'json/ld'
 class ResourceController < ApplicationController
   def edit
     @id = params[:id]
+    @simulate = params[:simulate]
 
     # create a hash of resources by their URIs
     @items = Hash[resources(@id).map do |resource|
@@ -12,33 +13,17 @@ class ResourceController < ApplicationController
       [uri, resource]
     end]
 
-    @item = @items[@id]
-    @content_model = content_model_from_rdf_type
+    @content_model = content_model_from_rdf_type(@items[@id]['@type'])
   end
 
-  def update # rubocop:disable Metrics/MethodLength
-    params_to_skip = %w[utf8 authenticity_token submit controller action]
-    submission = params.to_unsafe_h
-    params_to_skip.each { |key| submission.delete(key) }
-    submission_json = JSON.generate(submission)
-    payload = submission_json
+  def update
+    @simulate = params[:simulate]
+    send_to_plastron if @simulate
 
-    headers = {
-      PlastronCommand: 'echo',
-      # Have Plastron delay the response by 2 seconds
-      'echo-delay': 2
-    }
-
-    begin
-      # Send STOMP message synchronously
-      msg_response = StompService.synchronous_message(:jobs_synchronous, payload, headers)
-
-      # Process response
-      @json = msg_response.undump
-      @submission = JSON.pretty_generate(JSON.parse(@json))
-    rescue Timeout::Error
-      # Handle timeout
-      @submission = 'Error: Message timeout expired.'
+    delete_statements = (params[:delete] || [])
+    insert_statements = (params[:insert] || [])
+    unless delete_statements.empty? && insert_statements.empty?
+      @sparql_update = "DELETE {\n#{delete_statements.join} } INSERT {\n#{insert_statements.join} } WHERE {}"
     end
 
     render 'form_submit'
@@ -46,12 +31,12 @@ class ResourceController < ApplicationController
 
   private
 
-    def content_model_from_rdf_type
-      if @item['@type'].include? 'http://purl.org/ontology/bibo/Issue'
+    def content_model_from_rdf_type(types)
+      if types.include? 'http://purl.org/ontology/bibo/Issue'
         ContentModels::NEWSPAPER
-      elsif @item['@type'].include? 'http://purl.org/ontology/bibo/Letter'
+      elsif types.include? 'http://purl.org/ontology/bibo/Letter'
         ContentModels::LETTER
-      elsif @item['@type'].include? 'http://purl.org/ontology/bibo/Image'
+      elsif types.include? 'http://purl.org/ontology/bibo/Image'
         ContentModels::POSTER
       else
         ContentModels::ITEM
@@ -62,5 +47,32 @@ class ResourceController < ApplicationController
       response = HTTP[accept: 'application/ld+json'].get(uri, ssl_context: SSL_CONTEXT)
       input = JSON.parse(response.body.to_s)
       JSON::LD::API.expand(input)
+    end
+
+    def send_to_plastron # rubocop:disable Metrics/MethodLength
+      params_to_skip = %w[utf8 authenticity_token submit controller action]
+      submission = params.to_unsafe_h
+      params_to_skip.each { |key| submission.delete(key) }
+      submission_json = JSON.generate(submission)
+      payload = submission_json
+
+      headers = {
+        PlastronCommand: 'echo',
+        # Have Plastron delay the response by 2 seconds
+        'echo-delay': 2
+      }
+
+      begin
+        # Send STOMP message synchronously
+        msg_response = StompService.synchronous_message(:jobs_synchronous, payload, headers)
+
+        # Process response
+        @json = msg_response.undump
+        @headers = JSON.pretty_generate(headers)
+        @submission = JSON.pretty_generate(JSON.parse(@json))
+      rescue Timeout::Error
+        # Handle timeout
+        @submission = 'Error: Message timeout expired.'
+      end
     end
 end

--- a/app/javascript/components/ControlledURIRef.jsx
+++ b/app/javascript/components/ControlledURIRef.jsx
@@ -1,6 +1,10 @@
 import React from "react"
 import PropTypes from "prop-types"
 
+const N3 = require('n3');
+const { DataFactory } = N3;
+const { namedNode, defaultGraph } = DataFactory;
+
 /**
  * Input component with a dropdown whose values come from a controlled vocabulary.
  *
@@ -27,27 +31,44 @@ import PropTypes from "prop-types"
 class ControlledURIRef extends React.Component {
   constructor(props) {
     super(props);
+    // save the initial value
+    this.initialStatement = this.getStatement(props.value['@id']);
     this.state = {
       uri: props.value['@id'] || ""
     }
+    this.noStartingValue = (this.state.uri === '');
 
     this.handleChange = this.handleChange.bind(this);
+    this.getStatement = this.getStatement.bind(this);
   };
 
   handleChange(event) {
     this.setState({ uri: event.target.value })
   };
 
-  render () {
-    let inputName = `${this.props.subjectURI}[${this.props.predicateURI}][][@id]`
-    let entries = Object.entries(this.props.vocab).map(([uri, label]) => ([uri, label]));
+  getStatement(uri) {
+    const writer = new N3.Writer({format: 'N-Triples'});
+    return writer.quadToString(
+        namedNode(this.props.subjectURI),
+        namedNode(this.props.predicateURI),
+        namedNode(uri),
+        defaultGraph(),
+    );
+  };
 
+  render () {
+    let statement = this.getStatement(this.state.uri);
+    let valueIsUnchanged = (this.initialStatement === statement);
+
+    let entries = Object.entries(this.props.vocab).map(([uri, label]) => ([uri, label]));
     const sortStringValues = (a, b) => (a[1] > b[1] && 1) || (a[1] === b[1] ? 0 : -1)
     entries.sort(sortStringValues); // Note: sort is "in-place"
 
     return (
       <React.Fragment>
-        <select name={inputName} value={this.state.uri} onChange={this.handleChange}>
+        <input type="hidden" name="delete[]" value={this.initialStatement} disabled={this.props.value.isNew || this.noStartingValue || valueIsUnchanged}/>
+        <input type="hidden" name="insert[]" value={statement} disabled={valueIsUnchanged}/>
+        <select value={this.state.uri} onChange={this.handleChange}>
           <option key="" value=""/>
           {entries.map(([uri, label]) => (
               <option key={uri} value={uri}>{label}</option>

--- a/app/javascript/components/PlainLiteral.jsx
+++ b/app/javascript/components/PlainLiteral.jsx
@@ -1,6 +1,10 @@
 import React from "react"
 import PropTypes from "prop-types"
 
+const N3 = require('n3');
+const { DataFactory } = N3;
+const { namedNode, literal, defaultGraph } = DataFactory;
+
 /**
  * Input component consisting of a textbox, and language dropdown list.
  *
@@ -34,31 +38,76 @@ class PlainLiteral extends React.Component {
 
   constructor(props) {
     super(props);
+    // save the initial value
+    this.initialStatement = this.getStatement(props.value['@value'], props.value['@language']);
     this.state = {
       value: props.value['@value'],
       language: props.value['@language']
     };
+
+    this.initialValue = props.value['@value'];
+    this.initialLanguage = props.value['@language'];
+
     this.handleTextChange = this.handleTextChange.bind(this);
     this.handleLanguageChange = this.handleLanguageChange.bind(this);
+    this.getStatement = this.getStatement.bind(this);
   };
 
   handleTextChange(event) {
-    this.setState({value: event.target.value})
+    let newValue = event.target.value;
+    let valueChanged = (newValue !== this.initialValue);
+    this.setState(function(state, props) {
+      if (props.onChange) {
+        props.onChange(valueChanged || state.languageChanged);
+      }
+      return {
+        value: newValue,
+        valueChanged: valueChanged,
+      };
+    });
   };
 
   handleLanguageChange(event) {
-    this.setState({language: event.target.value})
+    let newLanguage = event.target.value;
+    let languageChanged = (newLanguage !== this.initialLanguage)
+    this.setState(function(state, props) {
+      if (props.onChange) {
+        props.onChange(languageChanged || state.valueChanged);
+      }
+      return {
+        language: newLanguage,
+        languageChanged: languageChanged,
+      };
+    });
+  }
+
+  getStatement(value, language) {
+    const writer = new N3.Writer({format: 'N-Triples'});
+    return writer.quadToString(
+        namedNode(this.props.subjectURI),
+        namedNode(this.props.predicateURI),
+        literal(value, language || undefined),
+        defaultGraph(),
+    );
+  }
+
+  componentWillUnmount() {
+    if (this.props.notifyContainer && !this.props.value.isNew) {
+      this.props.notifyContainer(this.initialStatement)
+    }
   }
 
   render () {
-    let textbox_name = `${this.props.subjectURI}[${this.props.predicateURI}][][@value]`
-    let language_name = `${this.props.subjectURI}[${this.props.predicateURI}][][@language]`
+    let statement = this.getStatement(this.state.value, this.state.language);
+    let valueIsUnchanged = !(this.state.valueChanged || this.state.languageChanged)
 
     return (
       <React.Fragment>
-        <input name={textbox_name} value={this.state.value} onChange={this.handleTextChange} size="40"/>
+        <input type="hidden" name="delete[]" value={this.initialStatement} disabled={this.props.value.isNew || valueIsUnchanged}/>
+        <input type="hidden" name="insert[]" value={statement} disabled={valueIsUnchanged}/>
+        <input value={this.state.value} onChange={this.handleTextChange} size="40"/>
         &nbsp;Language:&nbsp;
-        <select name={language_name} value={this.state.language} onChange={this.handleLanguageChange}>
+        <select value={this.state.language} onChange={this.handleLanguageChange}>
           {Object.entries(this.LANGUAGES).map(([code, name]) => (
               <option key={code} value={code}>{name}</option>
           ))}
@@ -87,7 +136,8 @@ PlainLiteral.propTypes = {
 }
 
 PlainLiteral.defaultProps = {
-  value: { '@value': '', '@language': '' }
+  value: { '@value': '', '@language': '' },
+  notifyContainer: undefined,
 }
 
 export default PlainLiteral;

--- a/app/javascript/components/URIRef.jsx
+++ b/app/javascript/components/URIRef.jsx
@@ -1,6 +1,10 @@
 import React from "react"
 import PropTypes, { string } from "prop-types"
 
+const N3 = require('n3');
+const { DataFactory } = N3;
+const { namedNode, defaultGraph } = DataFactory;
+
 /**
  * Input component consisting of a simple textbox.
  *
@@ -17,23 +21,57 @@ class URIRef extends React.Component {
   constructor(props) {
     super(props);
 
+    // save the initial value
+    this.initialStatement = this.getStatement(props.value['@id']);
+    this.initialURI = props.value['@id'] || '';
     this.state = {
       uri: props.value['@id'] || "",
+      uriChanged: false,
     };
 
     this.handleTextChange = this.handleTextChange.bind(this);
+    this.getStatement = this.getStatement.bind(this);
   }
 
   handleTextChange(event) {
-    this.setState({ uri: event.target.value })
+    let newURI = event.target.value;
+    let uriChanged = (newURI !== this.initialURI);
+    this.setState(function (state, props){
+      if (props.onChange) {
+        props.onChange(uriChanged);
+      }
+      return {
+        uri: newURI,
+        uriChanged: uriChanged,
+      };
+    });
+  }
+
+  getStatement(uri) {
+    const writer = new N3.Writer({format: 'N-Triples'});
+    return writer.quadToString(
+        namedNode(this.props.subjectURI),
+        namedNode(this.props.predicateURI),
+        namedNode(uri),
+        defaultGraph(),
+    );
+  }
+
+  componentWillUnmount() {
+    if (this.props.notifyContainer && !this.props.value.isNew) {
+      this.props.notifyContainer(this.initialStatement)
+    }
   }
 
   render () {
-    let textbox_name = `${this.props.subjectURI}[${this.props.predicateURI}][][@id]`
+    let statement = this.getStatement(this.state.uri);
+    let valueIsUnchanged = (this.initialStatement === statement);
 
     return (
       <React.Fragment>
-        <input title={this.state.datatype} name={textbox_name} value={this.state.uri} onChange={this.handleTextChange} size="40"/>
+        <input type="hidden" name="delete[]" value={this.initialStatement} disabled={this.props.value.isNew || valueIsUnchanged}/>
+        <input type="hidden" name="insert[]" value={statement} disabled={valueIsUnchanged}/>
+        <input title={this.state.datatype} value={this.state.uri} onChange={this.handleTextChange} size="40"/>
       </React.Fragment>
     );
   }
@@ -60,6 +98,7 @@ URIRef.propTypes = {
 
 URIRef.defaultProps = {
   value: { '@id': '' },
+  notifyContainer: undefined,
 }
 
 export default URIRef;

--- a/app/views/resource/edit.html.erb
+++ b/app/views/resource/edit.html.erb
@@ -1,4 +1,5 @@
 <%= form_with do %>
+  <% if @simulate.present? %><input type="hidden" name="simulate" value="1"/><% end %>
 
   <% unless @content_model[:required].empty? %>
     <h2>Required Fields</h2>

--- a/app/views/resource/form_submit.html.erb
+++ b/app/views/resource/form_submit.html.erb
@@ -1,10 +1,12 @@
 <h1>Resource Form Submit</h1>
 
-<h2>Submitted Params</h2>
-<pre><%=
-    @submission
-%></pre>
+<pre><%= @sparql_update %></pre>
 
+<% if @simulate %>
+<h2>Submitted Message</h2>
+<pre><%= @headers %>
+<%= @submission %></pre>
+<% end %>
 <hr />
 
 <a href=<%= resource_edit_url(id: params[:id]) %>>Back to Form</a>

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "@babel/preset-react": "^7.10.1",
     "@rails/webpacker": "5.1.1",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
+    "n3": "^1.5.0",
     "prop-types": "^15.7.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5453,6 +5453,13 @@ mute-stream@0.0.8:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
+n3@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/n3/-/n3-1.5.0.tgz#98ba8c25bd90a24ff1fa1bc9957e065e89ae3239"
+  integrity sha512-k4R/EOMnnRYFt+hXgqyKOHjzmshaLuHUFgrz5nsp9nAojCZuAHrro/DsIM2tS0Bgx6ed7DM5Ks3q2teJ8n7HnQ==
+  dependencies:
+    queue-microtask "^1.1.2"
+
 nan@^2.12.1, nan@^2.13.2:
   version "2.14.1"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.1.tgz#d7be34dfa3105b91494c3147089315eff8874b01"
@@ -7017,6 +7024,11 @@ querystringify@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.1.1.tgz#60e5a5fd64a7f8bfa4d2ab2ed6fdf4c85bad154e"
   integrity sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==
+
+queue-microtask@^1.1.2:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.1.3.tgz#9188ce1b10f9350330c509982c8b1c640e0592a7"
+  integrity sha512-zC1ZDLKFhZSa8vAdFbkOGouHcOUMgUAI/2/3on/KktpY+BaVqABkzDSsCSvJfmLbICOnrEuF9VIMezZf+T0mBA==
 
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5, randombytes@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
- track deletes and inserts in the components themselves
- generate a list of N-Triple statements to delete and insert in javascript
- craft the sparql update query from that
- set a default for access type
- use the real rdf:type predicate URI for access type
- added simulate param to simulate submission to plastron
- record completely removed values using the Repeatable component
- place all values in a Repeatable component; for non-repeatable set maxValues to 1

https://issues.umd.edu/browse/LIBHYDRA-356