### PR TITLE
LIBHYDRA-360. Changed default language dropdown from "None" to ""

### DIFF
--- a/app/javascript/components/PlainLiteral.jsx
+++ b/app/javascript/components/PlainLiteral.jsx
@@ -30,7 +30,7 @@ const { namedNode, literal, defaultGraph } = DataFactory;
 class PlainLiteral extends React.Component {
   // The options for the dropdown, using ISO-639 language codes
   LANGUAGES = {
-    '': 'None',
+    '': '',
     'en': 'English',
     'ja': 'Japanese',
     'ja-latn': 'Japanese (Romanized)',


### PR DESCRIPTION
In PlainLiteral, changed the "no value"/default value in the "Language"
dropdown from "None" to "", based on feedback at the July 13, 2020
Fedora Implementation Team meeting.

https://issues.umd.edu/browse/LIBHYDRA-360