### PR TITLE
LIBHYDRA-364. Improve update error display

### DIFF
--- a/app/assets/javascripts/resource.js
+++ b/app/assets/javascripts/resource.js
@@ -22,8 +22,24 @@ $(document).on('turbolinks:load', function() {
     }
   }
 
-  function displayErrors(errorHtml) {
+  function displayErrors(errorHtml, errors) {
+    // Clear all error fields
+    errorClass = "validation_error";
+    let fields = document.getElementsByClassName(errorClass);
+    while (fields.length > 0) {
+      fields[0].classList.remove(errorClass);
+    }
+
     errorDiv.innerHTML = errorHtml;
+    errors.forEach( error => {
+      let field_name = error['name'];
+      if (field_name) {
+        let fields = document.getElementsByName(field_name);
+        fields.forEach(field => {
+          field.classList.add(errorClass);
+        });
+      }
+    });
     window.scrollTo(0, 0);
   }
 
@@ -47,9 +63,10 @@ $(document).on('turbolinks:load', function() {
       // ajax.success occurs even if a validation error occurrs, so
       // check for any errors
 
-      let errorDisplay = data.error_display;
-      if (errorDisplay) {
-        displayErrors(errorDisplay)
+      let errors = data.errors;
+      let errorHtml = data.error_display;
+      if (errorHtml) {
+        displayErrors(errorHtml, errors)
         return;
       }
 

--- a/app/assets/stylesheets/custom.css
+++ b/app/assets/stylesheets/custom.css
@@ -124,6 +124,11 @@ input {
   border: 2px solid #a94442;
 }
 
+.validation_error {
+  /* color is state-danger-text */
+  border: 2px solid #a94442;
+}
+
 #retrieve_url {
   text-align: center;
 }

--- a/app/helpers/resource_helper.rb
+++ b/app/helpers/resource_helper.rb
@@ -7,6 +7,7 @@ module ResourceHelper
       component_type = :Repeatable
       values = item[field[:uri]]
       component_args = {
+        name: field[:name],
         # this will group fields by their subject ...
         subjectURI: uri,
         # ... and key them by their predicate

--- a/app/javascript/components/ControlledURIRef.jsx
+++ b/app/javascript/components/ControlledURIRef.jsx
@@ -69,7 +69,7 @@ class ControlledURIRef extends React.Component {
       <React.Fragment>
         <input type="hidden" name="delete[]" value={this.initialStatement} disabled={this.props.value.isNew || this.noStartingValue || valueIsUnchanged}/>
         <input type="hidden" name="insert[]" value={statement} disabled={valueIsUnchanged}/>
-        <select value={this.state.uri} onChange={this.handleChange}>
+        <select name={this.props.name} value={this.state.uri} onChange={this.handleChange}>
           <option key="" value=""/>
           {entries.map(([uri, label]) => (
               <option key={uri} value={uri}>{label}</option>

--- a/app/javascript/components/LabeledThing.jsx
+++ b/app/javascript/components/LabeledThing.jsx
@@ -73,7 +73,7 @@ class LabeledThing extends React.Component {
     return (
         <React.Fragment>
           <input type="hidden" name="insert[]" value={this.initialStatement} disabled={!(this.state.labelChanged || this.state.sameAsChanged)}/>
-          <PlainLiteral subjectURI={this.subject} predicateURI={labelPredicate} value={this.state.label}
+          <PlainLiteral name={this.props.name} subjectURI={this.subject} predicateURI={labelPredicate} value={this.state.label}
           onChange={this.handleLabelChange} notifyContainer={this.props.notifyContainer}/>
           &nbsp;URI:&nbsp;
           <URIRef subjectURI={this.subject} predicateURI={sameAsPredicate} value={this.state.sameAs}

--- a/app/javascript/components/PlainLiteral.jsx
+++ b/app/javascript/components/PlainLiteral.jsx
@@ -105,7 +105,7 @@ class PlainLiteral extends React.Component {
       <React.Fragment>
         <input type="hidden" name="delete[]" value={this.initialStatement} disabled={this.props.value.isNew || valueIsUnchanged}/>
         <input type="hidden" name="insert[]" value={statement} disabled={valueIsUnchanged}/>
-        <input value={this.state.value} onChange={this.handleTextChange} size="40"/>
+        <input name={this.props.name} value={this.state.value} onChange={this.handleTextChange} size="40"/>
         &nbsp;Language:&nbsp;
         <select value={this.state.language} onChange={this.handleLanguageChange}>
           {Object.entries(this.LANGUAGES).map(([code, name]) => (

--- a/app/javascript/components/Repeatable.jsx
+++ b/app/javascript/components/Repeatable.jsx
@@ -73,7 +73,6 @@ class Repeatable extends React.Component {
   };
 
   onComponentRemove(deleteStatement) {
-    console.log(deleteStatement);
     this.setState(function (state, _props) {
       state.deletedStatements.push(deleteStatement);
       return { deletedStatements: state.deletedStatements };

--- a/app/javascript/components/Repeatable.jsx
+++ b/app/javascript/components/Repeatable.jsx
@@ -97,6 +97,7 @@ class Repeatable extends React.Component {
   // Creates the new element to add
   buildComponent(value) {
     const props = {
+      name: this.props.name,
       subjectURI: this.props.subjectURI,
       predicateURI: this.props.predicateURI,
       notifyContainer: this.onComponentRemove,

--- a/app/javascript/components/TypedLiteral.jsx
+++ b/app/javascript/components/TypedLiteral.jsx
@@ -77,7 +77,7 @@ class TypedLiteral extends React.Component {
       <React.Fragment>
         <input type="hidden" name="delete[]" value={this.initialStatement} disabled={this.props.value.isNew || valueIsUnchanged}/>
         <input type="hidden" name="insert[]" value={statement} disabled={valueIsUnchanged}/>
-        <input title={this.state.datatype} value={this.state.value} onChange={this.handleTextChange} size="40"/>
+        <input name={this.props.name} title={this.state.datatype} value={this.state.value} onChange={this.handleTextChange} size="40"/>
       </React.Fragment>
     );
   }

--- a/app/javascript/components/URIRef.jsx
+++ b/app/javascript/components/URIRef.jsx
@@ -71,7 +71,7 @@ class URIRef extends React.Component {
       <React.Fragment>
         <input type="hidden" name="delete[]" value={this.initialStatement} disabled={this.props.value.isNew || valueIsUnchanged}/>
         <input type="hidden" name="insert[]" value={statement} disabled={valueIsUnchanged}/>
-        <input title={this.state.datatype} value={this.state.uri} onChange={this.handleTextChange} size="40"/>
+        <input name={this.props.name} title={this.state.datatype} value={this.state.uri} onChange={this.handleTextChange} size="40"/>
       </React.Fragment>
     );
   }

--- a/app/views/resource/_error_display.html.erb
+++ b/app/views/resource/_error_display.html.erb
@@ -3,6 +3,7 @@
 
       <ul>
         <% @errors.each do |message| %>
+          <% message = message[:error] if message[:error] %>
           <li><%= message %></li>
         <% end %>
       </ul>


### PR DESCRIPTION
Modified the React components to include an HTML "name" attribute on the "primary" input field (generally, the textbox for user input). This "name" attribute is used by a CSS selector to find the field when its style needs to be changed due to a validation error.

Modified the "displayErrors" method in "app/assets/javascripts/resource.js" to set a CSS class of "validationError" on fields that have a validation error.

Modified "app/controllers/resource_controller.rb" to parse the errors coming back from Plastron into a map, and provide that map to JavaScript for use by the "displayErrors" method.

https://issues.umd.edu/browse/LIBHYDRA-364