### PR TITLE
LIBHYDRA-366. Override Blacklight helper methods to display Fedora title

### DIFF
--- a/app/controllers/resource_controller.rb
+++ b/app/controllers/resource_controller.rb
@@ -6,7 +6,7 @@ class ResourceController < ApplicationController
   def edit
     @id = params[:id]
     @resource = ResourceService.resource_with_model(@id)
-    @title = @resource[:items][@id]['http://purl.org/dc/terms/title']&.first&.fetch('@value', @id)
+    @title = ResourceService.display_title(@resource, @id)
     @page_title = "Editing: \"#{@title}\""
   end
 

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -6,4 +6,49 @@ module BlacklightHelper
   def application_name
     'Archelon'
   end
+
+  ##
+  # Get the document's "title" to display in the <title> element.
+  # (by default, use the #document_heading)
+  #
+  # @see #document_heading
+  # @param [SolrDocument] document
+  # @return [String]
+  def document_show_html_title(document = nil)
+    display_title = fedora_resource_title
+    return display_title if display_title
+
+    super(document)
+  end
+
+  ##
+  # Render the document "heading" (title) in a content tag
+  # @overload render_document_heading(document, options)
+  #   @param [SolrDocument] document
+  #   @param [Hash] options
+  #   @option options [Symbol] :tag
+  # @overload render_document_heading(options)
+  #   @param [Hash] options
+  #   @option options [Symbol] :tag
+  #
+  # Overridden to return the Fedora resource title, if available
+  def render_document_heading(*args)
+    display_title = fedora_resource_title
+    if display_title
+      options = args.extract_options!
+      tag = options.fetch(:tag, :h4)
+      content_tag(tag, display_title, itemprop: 'name')
+    else
+      super(*args)
+    end
+  end
+
+  # Retrieves the display title using Fedora resource data, or nil
+  # rubocop:disable Rails/HelperInstanceVariable:
+  def fedora_resource_title
+    return unless @resource && @id
+
+    ResourceService.display_title(@resource, @id)
+  end
+  # rubocop:enable Rails/HelperInstanceVariable:
 end

--- a/test/services/resource_service_test.rb
+++ b/test/services/resource_service_test.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ResourceServiceTest < ActionView::TestCase
+  def setup
+  end
+
+  def test_fedora_resource_title # rubocop:disable Metrics/MethodLength
+    @id = 'test_id'
+    @resource = create_title_resource(@id, nil)
+    display_title = ResourceService.display_title(@resource, @id)
+    assert_nil display_title
+
+    @resource = create_title_resource(@id, [{ '@value' => 'None Title' }])
+    display_title = ResourceService.display_title(@resource, @id)
+    assert_equal('None Title', display_title)
+
+    @resource = create_title_resource(
+      @id,
+      [
+        { '@value' => 'ja Title', '@language' => 'ja' },
+        { '@value' => 'ja-latn Title', '@language' => 'ja-latn' }
+      ]
+    )
+    display_title = ResourceService.display_title(@resource, @id)
+    assert_equal('ja-latn Title, ja Title', display_title)
+
+    @resource = create_title_resource(
+      @id,
+      [
+        { '@value' => 'en Title', '@language' => 'en' },
+        { '@value' => 'ja Title', '@language' => 'ja' },
+        { '@value' => 'ja-latn Title', '@language' => 'ja-latn' },
+        { '@value' => 'None Title' }
+      ]
+    )
+    display_title = ResourceService.display_title(@resource, @id)
+    assert_equal('None Title, en Title, ja-latn Title, ja Title', display_title)
+  end
+
+  def test_sort_titles_by_language
+    resource_titles = [
+      { '@value' => 'ja Title', '@language' => 'ja' },
+      { '@value' => 'ja-latn Title', '@language' => 'ja-latn' },
+      { '@value' => 'en Title', '@language' => 'en' },
+      { '@value' => 'None Title' }
+    ]
+
+    sorted_titles = ResourceService.sort_titles_by_language(resource_titles)
+    assert_equal(['None Title', 'en Title', 'ja-latn Title', 'ja Title'], sorted_titles)
+  end
+
+  # Test helper methods
+  def create_title_resource(id, titles)
+    return { items: { id => {} } } unless titles
+
+    { items: { id => { 'http://purl.org/dc/terms/title' => titles } } }
+  end
+end


### PR DESCRIPTION
Created utility methods "display_title" and "sort_titles_by_language" in
"app/services/resource_service.rb" to generate a display title from a
resource (the title is assumed to use the
"http://purl.org/dc/terms/title" predicate). The titles are sorted by
language, to ensure that a consistent order when there are multipl
 titles.

Used "app/helpers/blacklight_helper.rb" to override two Blacklight
helper methods to use the ResourceServices utility methods to generate
the title. If the title cannot be generated, the default Blacklight
methods (which use Solr) are used.

This causes the resource detail page to immediately display the correct
title after it has been editing, instead of waiting for Solr to process
the change.

https://issues.umd.edu/browse/LIBHYDRA-366