### PR TITLE
LIBHYDRA-402. Get development database info from environment.

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -37,3 +37,11 @@ AUDIT_DATABASE_HOST=localhost
 AUDIT_DATABASE_PORT=5432
 AUDIT_DATABASE_USERNAME=archelon
 AUDIT_DATABASE_PASSWORD=archelon
+
+# basic development mode defaults to SQLite
+# this should be overridden in a .env.local
+# if a PostgreSQL database is desired
+# --- config/database.yml
+ARCHELON_DATABASE_ADAPTER=sqlite3
+ARCHELON_DATABASE_NAME=db/development.sqlite3
+ARCHELON_DATABASE_POOL=5

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,30 +1,4 @@
-# SQLite version 3.x
-#   gem install sqlite3
-#
-#   Ensure the SQLite 3 gem is defined in your Gemfile
-#   gem 'sqlite3'
-#
 default: &default
-  adapter: sqlite3
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  timeout: 5000
-
-development:
-  <<: *default
-  database: db/development.sqlite3
-
-vagrant:
-  <<: *default
-  database: db/vagrant.sqlite3
-
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
-test:
-  <<: *default
-  database: db/test.sqlite3
-
-production:
   adapter: <%= ENV["ARCHELON_DATABASE_ADAPTER"] %>
   encoding: <%= ENV["ARCHELON_DATABASE_ENCODING"] %>
   database: <%= ENV["ARCHELON_DATABASE_NAME"] %>
@@ -33,3 +7,18 @@ production:
   host: <%= ENV["ARCHELON_DATABASE_HOST"] %>
   port: <%= ENV["ARCHELON_DATABASE_PORT"] %>
   pool: <%= ENV["ARCHELON_DATABASE_POOL"] %>
+
+development:
+  <<: *default
+
+# Warning: The database defined as "test" will be erased and
+# re-generated from your development database when you run "rake".
+# Do not set this db to the same as development or production.
+test:
+  adapter: sqlite3
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  timeout: 5000
+  database: db/test.sqlite3
+
+production:
+  <<: *default


### PR DESCRIPTION
Define a SQLite default in .env.development for the development environment. The test database is still configured to always use a SQLite database.

https://issues.umd.edu/browse/LIBHYDRA-402