### PR TITLE
LIBHYDRA-410. Enable Archelon to specify structure and relpath in import

### DIFF
--- a/app/models/import_job.rb
+++ b/app/models/import_job.rb
@@ -56,6 +56,9 @@ class ImportJob < ApplicationRecord
   validate :attachment_validation
   validate :include_binaries_options
 
+  # The relpath for "flat" structure collections
+  FLAT_LAYOUT_RELPATH = '/pcdm'
+
   def self.access_vocab
     @access_vocab ||= Vocabulary.find_by identifier: VOCAB_CONFIG['access_vocab_identifier']
   end
@@ -136,7 +139,8 @@ class ImportJob < ApplicationRecord
   end
 
   # Returns the relpath of the collection (the collection with the
-  # FCREPO_BASE_URL prefix removed). Will always start with a "/"
+  # FCREPO_BASE_URL prefix removed). Will always start with a "/", and
+  # returns FLAT_LAYOUT_RELPATH if the relpath starts with that value.
   def collection_relpath
     relpath = collection.sub(FCREPO_BASE_URL, '')
 
@@ -145,7 +149,7 @@ class ImportJob < ApplicationRecord
 
     # Any path starting with "/pcdm" uses the flat layout, which always has
     # a relpath of '/pcdm'
-    return '/pcdm' if relpath.starts_with?('/pcdm')
+    return FLAT_LAYOUT_RELPATH if relpath.starts_with?(FLAT_LAYOUT_RELPATH)
 
     relpath
   end
@@ -154,7 +158,7 @@ class ImportJob < ApplicationRecord
   def collection_structure
     relpath = collection_relpath
 
-    return :flat if relpath.starts_with?('/pcdm')
+    return :flat if relpath.starts_with?(FLAT_LAYOUT_RELPATH)
 
     :hierarchical
   end

--- a/app/models/import_job.rb
+++ b/app/models/import_job.rb
@@ -134,4 +134,24 @@ class ImportJob < ApplicationRecord
   def binaries?
     binaries_location.present?
   end
+
+  # Returns the relpath of the collection (the collection with the
+  # FCREPO_BASE_URL prefix removed). Will always start with a "/"
+  def collection_relpath
+    relpath = collection.sub(FCREPO_BASE_URL, '')
+
+    # Ensure that relpath starts with a "/"
+    relpath = '/' + relpath unless relpath.starts_with?('/')
+
+    relpath
+  end
+
+  # Returns ":flat" or ":hierarchical" based on the collections relpath
+  def collection_structure
+    relpath = collection_relpath
+
+    return :flat if relpath.starts_with?('/pcdm')
+
+    :hierarchical
+  end
 end

--- a/app/models/import_job.rb
+++ b/app/models/import_job.rb
@@ -143,6 +143,10 @@ class ImportJob < ApplicationRecord
     # Ensure that relpath starts with a "/"
     relpath = '/' + relpath unless relpath.starts_with?('/')
 
+    # Any path starting with "/pcdm" uses the flat layout, which always has
+    # a relpath of '/pcdm'
+    return '/pcdm' if relpath.starts_with?('/pcdm')
+
     relpath
   end
 

--- a/app/models/import_job.rb
+++ b/app/models/import_job.rb
@@ -107,10 +107,11 @@ class ImportJob < ApplicationRecord
 
     count = plastron_message.body_json['count'] || {}
     total_count = count['total']
+
     # Total could be nil for non-seekable files
     return if total_count.nil? || total_count.zero?
 
-    processed_count = count['updated'] + count['unchanged'] + count['errors']
+    processed_count = count['created'] + count['updated'] + count['unchanged'] + count['errors']
 
     self.progress = (processed_count.to_f / total_count * 100).round
     save!

--- a/app/services/import_job_request.rb
+++ b/app/services/import_job_request.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# Encapsulates a Plastron import job request message
+class ImportJobRequest
+  def initialize(job_id, import_job, validate_only)
+    @job_id = job_id
+    @job = import_job
+    @validate_only = validate_only
+  end
+
+  def headers # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+    {
+      PlastronCommand: 'import',
+      PlastronJobId: @job_id,
+      'PlastronArg-model': @job.model,
+      'PlastronArg-name': @job.name,
+      'PlastronArg-on-behalf-of': @job.cas_user.cas_directory_id,
+      'PlastronArg-member-of': @job.collection,
+      'PlastronArg-timestamp': @job.timestamp
+    }.tap do |headers|
+      headers['PlastronArg-access'] = "<#{access}>" if @job.access.present?
+      headers['PlastronArg-validate-only'] = 'True' if @validate_only
+      headers['PlastronArg-binaries-location'] = @job.binaries_location if @job.binaries_location.present?
+    end
+  end
+
+  def body
+    @job.metadata_file.download
+  end
+end

--- a/app/services/import_job_request.rb
+++ b/app/services/import_job_request.rb
@@ -17,7 +17,8 @@ class ImportJobRequest
       'PlastronArg-on-behalf-of': @job.cas_user.cas_directory_id,
       'PlastronArg-member-of': @job.collection,
       'PlastronArg-timestamp': @job.timestamp,
-      'PlastronArg-structure': @job.collection_structure.to_s
+      'PlastronArg-structure': @job.collection_structure.to_s,
+      'PlastronArg-relpath': @job.collection_relpath
     }.tap do |headers|
       headers['PlastronArg-access'] = "<#{access}>" if @job.access.present?
       headers['PlastronArg-validate-only'] = 'True' if @validate_only

--- a/app/services/import_job_request.rb
+++ b/app/services/import_job_request.rb
@@ -16,7 +16,8 @@ class ImportJobRequest
       'PlastronArg-name': @job.name,
       'PlastronArg-on-behalf-of': @job.cas_user.cas_directory_id,
       'PlastronArg-member-of': @job.collection,
-      'PlastronArg-timestamp': @job.timestamp
+      'PlastronArg-timestamp': @job.timestamp,
+      'PlastronArg-structure': @job.collection_structure.to_s
     }.tap do |headers|
       headers['PlastronArg-access'] = "<#{access}>" if @job.access.present?
       headers['PlastronArg-validate-only'] = 'True' if @validate_only

--- a/app/services/import_job_request.rb
+++ b/app/services/import_job_request.rb
@@ -20,7 +20,7 @@ class ImportJobRequest
       'PlastronArg-structure': @job.collection_structure.to_s,
       'PlastronArg-relpath': @job.collection_relpath
     }.tap do |headers|
-      headers['PlastronArg-access'] = "<#{access}>" if @job.access.present?
+      headers['PlastronArg-access'] = "<#{@job.access}>" if @job.access.present?
       headers['PlastronArg-validate-only'] = 'True' if @validate_only
       headers['PlastronArg-binaries-location'] = @job.binaries_location if @job.binaries_location.present?
     end

--- a/config/imports.yml
+++ b/config/imports.yml
@@ -1,6 +1,6 @@
 default: &default
   binaries_dir: <%= Rails.root.join('imports') %>
-  binaries_base_location: <%= Rails.root.join('imports') %>
+  binaries_base_location: <%= "zip:#{Rails.root.join('imports')}" %>
 
 development:
   <<: *default

--- a/docs/ArchelonDevelopmentEnvironment.md
+++ b/docs/ArchelonDevelopmentEnvironment.md
@@ -158,13 +158,15 @@ right sidebar.
 3.3. Add a "/dc/2016/1" container, using the "Create New Child Resource" panel
 in the right sidebar.
 
-3.4. Provide the name "Student Newspapers" to the "/dc/2016/1" container by
-entering the following in the "Update Properties" panel in the right sidebar
-and left-clicking the "Update" button:
+3.4. Provide the name "Student Newspapers" to the "/dc/2016/1" container (and
+identify it as a "pcdm:Collection") by entering the following in the
+"Update Properties" panel in the right sidebar and left-clicking the
+"Update" button:
 
 ```
 PREFIX dcterms: <http://purl.org/dc/terms/>
-DELETE {} INSERT { <> dcterms:title "Student Newspapers" } WHERE {}
+PREFIX pcdm: <http://pcdm.org/models#>
+DELETE {} INSERT { <> a pcdm:Collection; dcterms:title "Student Newspapers" } WHERE {}
 ```
 
 ## Step 4: Create auth tokens for plastron and archelon

--- a/test/models/import_job_test.rb
+++ b/test/models/import_job_test.rb
@@ -78,6 +78,7 @@ class ImportJobTest < ActiveSupport::TestCase
     test_collections = [
       # [Collection, Expected relative path]
       ['http://example.com/rest/pcdm', '/pcdm'],
+      ['http://example.com/rest/pcdm/51/a4/54/a8/51a454a8-7ad0-45dd-ba2b-85632fe1b618', '/pcdm'],
       ['http://example.com/rest/dc/2021/2', '/dc/2021/2']
     ]
 
@@ -86,7 +87,7 @@ class ImportJobTest < ActiveSupport::TestCase
         test_collections.each do |collection, expected_relpath|
           import_job = ImportJob.new
           import_job.collection = collection
-          assert_equal expected_relpath, import_job.collection_relpath, "Using base_url: #{base_url}"
+          assert_equal expected_relpath, import_job.collection_relpath, "Using base_url: '#{base_url}'"
         end
       end
     end

--- a/test/models/import_job_test.rb
+++ b/test/models/import_job_test.rb
@@ -77,8 +77,8 @@ class ImportJobTest < ActiveSupport::TestCase
 
     test_collections = [
       # [Collection, Expected relative path]
-      ['http://example.com/rest/pcdm', '/pcdm'],
-      ['http://example.com/rest/pcdm/51/a4/54/a8/51a454a8-7ad0-45dd-ba2b-85632fe1b618', '/pcdm'],
+      ["http://example.com/rest#{ImportJob::FLAT_LAYOUT_RELPATH}", ImportJob::FLAT_LAYOUT_RELPATH],
+      ["http://example.com/rest#{ImportJob::FLAT_LAYOUT_RELPATH}/51/a4/54/a8/51a454a8-7ad0-45dd-ba2b-85632fe1b618", ImportJob::FLAT_LAYOUT_RELPATH],
       ['http://example.com/rest/dc/2021/2', '/dc/2021/2']
     ]
 

--- a/test/models/import_job_test.rb
+++ b/test/models/import_job_test.rb
@@ -116,4 +116,33 @@ class ImportJobTest < ActiveSupport::TestCase
       assert_equal :flat, import_job.collection_structure
     end
   end
+
+  test 'update_progress should reflect progress in message' do
+    import_job = import_jobs(:one)
+    assert_nil import_job.progress
+
+    stomp_message = Stomp::Message.new('')
+    stomp_message.body = {
+      'time': {
+        'started': 1_612_895_677.028775,
+        'now': 1_612_895_784.956666,
+        'elapsed': 107.92789101600647
+      },
+      'count': {
+        'total': 25,
+        'rows': 25,
+        'errors': 1,
+        'valid': 5,
+        'invalid': 0,
+        'created': 2,
+        'updated': 1,
+        'unchanged': 1,
+        'files': 25
+      }
+    }.to_json
+
+    plastron_message = PlastronMessage.new(stomp_message)
+    import_job.update_progress(plastron_message)
+    assert_equal 20, import_job.progress # (errors + created + updated + unchanged) = 5, 5/25 = 20%
+  end
 end

--- a/test/services/import_job_request_test.rb
+++ b/test/services/import_job_request_test.rb
@@ -9,13 +9,13 @@ class ImportJobRequestTest < ActiveSupport::TestCase
   test 'headers for "flat" collections' do
     with_constant('FCREPO_BASE_URL', 'http://example.com/rest') do
       import_job = import_jobs(:one)
-      import_job.collection = 'http://example.com/rest/pcdm'
+      import_job.collection = 'http://example.com/rest/pcdm/51/a4/54/a8/51a454a8-7ad0-45dd-ba2b-85632fe1b618'
       assert_equal :flat, import_job.collection_structure
 
       import_job_request = ImportJobRequest.new('test', import_job, false)
       headers = import_job_request.headers
       assert_equal('flat', headers[:'PlastronArg-structure'])
-      assert_equal('/pcdm', headers[:'PlastronArg-relpath'])
+      assert_equal(ImportJob::FLAT_LAYOUT_RELPATH, headers[:'PlastronArg-relpath'])
     end
   end
 

--- a/test/services/import_job_request_test.rb
+++ b/test/services/import_job_request_test.rb
@@ -15,6 +15,7 @@ class ImportJobRequestTest < ActiveSupport::TestCase
       import_job_request = ImportJobRequest.new('test', import_job, false)
       headers = import_job_request.headers
       assert_equal('flat', headers[:'PlastronArg-structure'])
+      assert_equal('/pcdm', headers[:'PlastronArg-relpath'])
     end
   end
 
@@ -27,6 +28,7 @@ class ImportJobRequestTest < ActiveSupport::TestCase
       import_job_request = ImportJobRequest.new('test', import_job, false)
       headers = import_job_request.headers
       assert_equal('hierarchical', headers[:'PlastronArg-structure'])
+      assert_equal('/dc/2021/2', headers[:'PlastronArg-relpath'])
     end
   end
 end

--- a/test/services/import_job_request_test.rb
+++ b/test/services/import_job_request_test.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ImportJobRequestTest < ActiveSupport::TestCase
+  def setup
+  end
+
+  test 'headers for "flat" collections' do
+    with_constant('FCREPO_BASE_URL', 'http://example.com/rest') do
+      import_job = import_jobs(:one)
+      import_job.collection = 'http://example.com/rest/pcdm'
+      assert_equal :flat, import_job.collection_structure
+
+      import_job_request = ImportJobRequest.new('test', import_job, false)
+      headers = import_job_request.headers
+      assert_equal('flat', headers[:'PlastronArg-structure'])
+    end
+  end
+
+  test 'headers for "hierarchical" collections' do
+    with_constant('FCREPO_BASE_URL', 'http://example.com/rest') do
+      import_job = import_jobs(:one)
+      import_job.collection = 'http://example.com/rest/dc/2021/2'
+      assert_equal :hierarchical, import_job.collection_structure
+
+      import_job_request = ImportJobRequest.new('test', import_job, false)
+      headers = import_job_request.headers
+      assert_equal('hierarchical', headers[:'PlastronArg-structure'])
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -119,3 +119,18 @@ def stub_repository_collections_solr_response(fixture_filename)
   response = Blacklight::Solr::Response.new(data_hash, nil)
   Blacklight::Solr::Repository.any_instance.stub(:search).and_return(response)
 end
+
+# Allows a constant defined in config/initializers to be be overridden for
+# a single test, and then restored
+def with_constant(constant_name, value)
+  old_value = Rails.const_get(constant_name)
+  silence_warnings do # Silence warning about redefining constant
+    Object.const_set(constant_name, value)
+  end
+
+  yield
+
+  silence_warnings do
+    Object.const_set(constant_name, old_value)
+  end
+end


### PR DESCRIPTION
Modified Archelon to provide "structure" and "relpath" arguments the import request message sent to Plastron.

This enables collections with "hierarchical" layouts to be loaded via Archelon.

https://issues.umd.edu/browse/LIBHYDRA-410