### PR TITLE
LIBFCREPO-969. Update development env instructions for Python v3.6.12

### DIFF
--- a/docs/ArchelonDevelopmentEnvironment.md
+++ b/docs/ArchelonDevelopmentEnvironment.md
@@ -237,8 +237,8 @@ COMMANDS:
 5.4. Set up the Python environment to run Plastron using pyenv:
 
 ```bash
-pyenv install 3.6.2
-pyenv virtualenv 3.6.2 plastron
+pyenv install 3.6.12
+pyenv virtualenv 3.6.12 plastron
 pyenv local plastron
 pip install -e .
 ```


### PR DESCRIPTION
Updated the "docs/ArchelonDevelopmentEnvironment.md" instructions to
use Python v3.6.12 instead of v3.6.2.

https://issues.umd.edu/browse/LIBFCREPO-969