### PR TITLE
LIBHYDRA-420. Reverse the exportable type check logic.

### DIFF
--- a/app/models/export_job.rb
+++ b/app/models/export_job.rb
@@ -23,8 +23,16 @@ class ExportJob < ApplicationRecord
                                          50.gigabytes
                                        end
 
-  def self.exportable_types
-    %w[Image Issue Letter]
+  def self.exportable?(document)
+    return false if document[:component].nil?
+
+    # non-exportable types
+    return false if %w[Collection Page Article].include? document[:component]
+
+    # binaries are not directly exportable
+    return false if document[:rdf_type].include? 'fedora:Binary'
+
+    true
   end
 
   def filename

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -15,6 +15,6 @@ class SearchBuilder < Blacklight::SearchBuilder
   def exportable_only(solr_parameters)
     return unless blacklight_params[:exportable_only]
 
-    solr_parameters[:fq] << ExportJob.exportable_types.map { |type| "component:#{type}" }.join(' OR ')
+    solr_parameters[:fq] << '!component:Page AND !component:Article AND !component:Collection AND !rdf_type:fedora\:Binary'
   end
 end

--- a/app/views/catalog/_select_box.erb
+++ b/app/views/catalog/_select_box.erb
@@ -2,23 +2,19 @@
 <% if current_or_guest_user %>
   <%-
   # Note these two forms are pretty similar but for different :methods, classes, and labels.
-  # but it was simpler to leave them seperate instead of DRYing them, got confusing trying that.
+  # but it was simpler to leave them separate instead of DRYing them, got confusing trying that.
   # the data-doc-id attribute is used by our JS that converts to a checkbox/label.
   -%>
-  <% if ExportJob.exportable_types.include? document._source[:component] %>
+  <% if ExportJob.exportable? document %>
     <div class="select-box">
-      <% unless bookmarked? document %>
-
-        <%= form_tag( bookmark_path( document ), :method => :put, :class => "bookmark_toggle", "data-doc-id" => document.id) do %>
-          <%= submit_tag(t('blacklight.bookmarks.add.button'), :id => "bookmark_toggle_#{document.id.to_s.parameterize}", :class => "compact-checkbox") %>
-        <% end %>
-
-      <% else %>
-
+      <% if bookmarked? document %>
         <%= form_tag( bookmark_path( document ), :method => :delete, :class => "bookmark_toggle", "data-doc-id" => document.id) do %>
           <%= submit_tag(t('blacklight.bookmarks.remove.button'), :id => "bookmark_toggle_#{document.id.to_s.parameterize}", :class => "compact-checkbox") %>
         <% end %>
-
+      <% else %>
+        <%= form_tag( bookmark_path( document ), :method => :put, :class => "bookmark_toggle", "data-doc-id" => document.id) do %>
+          <%= submit_tag(t('blacklight.bookmarks.add.button'), :id => "bookmark_toggle_#{document.id.to_s.parameterize}", :class => "compact-checkbox") %>
+        <% end %>
       <% end %>
     </div>
   <% end %>


### PR DESCRIPTION
Assume an object is exportable unless it is a Page, Article, Collection, or binary.

https://issues.umd.edu/browse/LIBHYDRA-420