### PR TITLE
LIBHYDRA-415. Switch ActionCable adapter to "async"

### DIFF
--- a/config/cable.yml
+++ b/config/cable.yml
@@ -5,4 +5,4 @@ test:
   adapter: async
 
 production:
-  adapter: postgresql
+  adapter: async


### PR DESCRIPTION
As the "postgres" ActionCable adapter cannot gracefully handle
Postgres terminating the database connection, switching to using
the in-memory "async" adapter.

While the documentation indicates that the "async" adapter is only for
development/testing (because it does not persist, doesn't scale, and may
not be reliable), it is likely sufficient for our current use case of
using it to process status updates.

https://issues.umd.edu/browse/LIBHYDRA-415