### PR TITLE
LIBHYDRA-428. Added MIME types for files in "public" directory

### DIFF
--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -5,3 +5,9 @@
 
 Mime::Type.register 'text/turtle', :ttl
 Mime::Type.register 'application/n-triples', :nt
+
+# Add new mime types for files in "public" directory
+# See https://stackoverflow.com/a/45470372
+Rack::Mime::MIME_TYPES[".ttl"]="text/turtle"
+Rack::Mime::MIME_TYPES[".nt"]="application/n-triples"
+Rack::Mime::MIME_TYPES[".json"]="application/json-ld"


### PR DESCRIPTION
The vocabulary files are served from a "public" directory. Configured
Rails to return files using the expected MIME type, based on the
extension.

https://issues.umd.edu/browse/LIBHYDRA-428