### PR TITLE
LIBHYDRA-433. Refactored environment banner for Kubernetes

### DIFF
--- a/app/assets/stylesheets/umd_lib_environment_banner.scss
+++ b/app/assets/stylesheets/umd_lib_environment_banner.scss
@@ -7,14 +7,4 @@
         background: #008000;
         color: #fff;
     }
-
-    &#environment-development {
-        background: #fff100;
-        color: #000;
-    }
-    
-    &#environment-staging {
-        background: #0000ff;
-        color: #fff;
-    }
 }

--- a/app/helpers/umd_lib_environment_banner_helper.rb
+++ b/app/helpers/umd_lib_environment_banner_helper.rb
@@ -1,21 +1,173 @@
 # frozen_string_literal: true
 
 module UMDLibEnvironmentBannerHelper
+  # True if the banner has been initialized, false otherwise
+  @@banner_initialized = false
+  # Holds the banner ibject
+  @@banner = nil
+  # Holds the HTML for the banner (if any)
+  @@banner_html = nil
+
+  # Initializes the banner
+  def self.initialize
+    # Uses @@banner_initialized to skip regenerating banner each time the
+    # module is called.
+    if !@@banner_initialized
+      @@banner_initialized = true
+      return if ENV['ENVIRONMENT_BANNER_ENABLED'] == 'false'
+
+      # The EnvVarsEnvironmentBanner banner is used, if enabled, otherwise
+      # defaults to the DevelopmentEnvironmentBanner implementation
+      banner = EnvVarsEnvironmentBanner.new
+      if !banner.enabled?
+        banner = DevelopmentEnvironmentBanner.new
+      end
+
+      @@banner = banner
+
+      if @@banner.enabled?
+        # Configure banner HTML
+        css_options = @@banner.css_options
+        # Sort to get consistent ordering of keys
+        css_string = css_options.sort.to_h.map { |key,value| "#{key}='#{value}'" }.join(" ")
+        banner_text = @@banner.text
+        @@banner_html = "<div #{css_string}>#{banner_text}</div>".html_safe
+        return @@banner_html
+      else
+        @@banner_html = nil
+      end
+    end
+
+    @@banner
+  end
+
+  # Resets the banner -- intended be used only for testing
+  def self.reset
+    @@banner_initialized = false
+    @@banner = nil
+    @@banner_html = nil
+  end
+
   # https://confluence.umd.edu/display/LIB/Create+Environment+Banners
+  #
   def umd_lib_environment_banner
-    current_env = environment_name
-    return unless current_env
-
-    text = "#{current_env} Environment"
-    id = "environment-#{current_env.downcase}"
-    content_tag :div, text, class: 'environment-banner', id: id
+    UMDLibEnvironmentBannerHelper.initialize if !@@banner_initialized
+    @@banner_html
   end
 
-  def environment_name
-    return 'Local' if Rails.env.development? || Rails.env.vagrant?
+  # Banner implementation classes -- these are not intended to be called
+  # directly
 
-    hostname = `hostname -s`
-    return 'Development' if hostname =~ /dev$/
-    return 'Staging' if hostname =~ /stage$/
+    # Returns an environment banner based on ENV config properties
+    class EnvVarsEnvironmentBanner
+      attr_accessor :text
+      attr_accessor :css_options
+
+      def initialize
+        @text = banner_text
+        @css_options = banner_css_options
+        @enabled = banner_enabled(@text)
+      end
+
+      # Returns the text to display in the environment banner.
+      #
+      # Implementation: Returns the value of the ENVIRONMENT_BANNER property, if
+      # non-empty.
+      #
+      # This method may return nil, if there is no ENVIRONMENT_BANNER
+      def banner_text
+        banner_text = ENV.has_key?('ENVIRONMENT_BANNER') ? ENV['ENVIRONMENT_BANNER'] : ''
+        if !banner_text.empty?
+           ENV['ENVIRONMENT_BANNER'].freeze
+        end
+      end
+
+      # Returns the CSS options to use with the environment banner.
+      #
+      # Implementation: Uses the ENVIRONMENT_BANNER_BACKGROUND and
+      # ENVIRONMENT_BANNER_FOREGROUND properties, if provided.
+      def banner_css_options
+        css_options = {}
+        css_style = ''
+
+        background_color = ENV.has_key?('ENVIRONMENT_BANNER_BACKGROUND') ? ENV['ENVIRONMENT_BANNER_BACKGROUND'] : ''
+        foreground_color = ENV.has_key?('ENVIRONMENT_BANNER_FOREGROUND') ? ENV['ENVIRONMENT_BANNER_FOREGROUND'] : ''
+
+        if !background_color.empty?
+          css_style = "background-color: #{background_color};"
+        end
+
+        if !foreground_color.empty?
+          css_style += " color: #{foreground_color};"
+          css_style.strip!
+        end
+
+        if !css_style.empty?
+          css_options[:style] = css_style
+        end
+
+        css_options[:class] = 'environment-banner'
+        css_options
+      end
+
+      # Returns true if the banner should be displayed, false otherwise.
+      #
+      # text - the text (if any) being displayed in the banner
+      def banner_enabled(text)
+        env_var_enabled = ENV['ENVIRONMENT_BANNER_ENABLED']
+        env_var_enabled = ENV.has_key?('ENVIRONMENT_BANNER_ENABLED') ? ENV['ENVIRONMENT_BANNER_ENABLED'] : ''
+
+        # Don't display the banner if there is no text
+        has_display_text = !text.nil? && !text.empty?
+        return false unless has_display_text
+
+        # Display if ENVIRONMENT_BANNER_ENABLED is not provided or empty
+        return true if env_var_enabled.nil? || env_var_enabled.empty?
+
+        # Any value other than "true" is false
+        env_var_enabled.strip.downcase == 'true'
+      end
+
+      def enabled?
+        @enabled
+      end
+    end
+
+  # Returns a default environment banner for Rails development environment
+  class DevelopmentEnvironmentBanner
+    attr_accessor :text
+    attr_accessor :css_options
+
+    def initialize
+      environment_name = environment_name()
+      if environment_name.nil?
+        @enabled = false
+        return
+      end
+      @text = "#{environment_name} Environment"
+      @css_options = {}
+      @css_options[:id] = "environment-#{environment_name.downcase}"
+      @css_options[:class] = "environment-banner"
+      @enabled = !environment_name.empty?
+    end
+
+    def enabled?
+      @enabled
+    end
+
+    private
+
+      def environment_name
+        ( Rails.env.development? || Rails.env.vagrant? ) ? "Local" : nil
+      end
   end
+end
+
+# here we reopen the ApplicationController (after Rails has started)
+# and stick in our helper module.
+Rails.application.config.after_initialize do
+    ApplicationController.class_eval do
+      include UMDLibEnvironmentBannerHelper
+      helper_method :umd_lib_environment_banner
+    end
 end

--- a/app/helpers/umd_lib_environment_banner_helper.rb
+++ b/app/helpers/umd_lib_environment_banner_helper.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Rails/HelperInstanceVariable, Style/ClassVars
 module UMDLibEnvironmentBannerHelper
   # True if the banner has been initialized, false otherwise
   @@banner_initialized = false
@@ -9,19 +10,18 @@ module UMDLibEnvironmentBannerHelper
   @@banner_html = nil
 
   # Initializes the banner
-  def self.initialize
+  def self.initialize # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
     # Uses @@banner_initialized to skip regenerating banner each time the
     # module is called.
-    if !@@banner_initialized
+    unless @@banner_initialized
       @@banner_initialized = true
       return if ENV['ENVIRONMENT_BANNER_ENABLED'] == 'false'
 
       # The EnvVarsEnvironmentBanner banner is used, if enabled, otherwise
       # defaults to the DevelopmentEnvironmentBanner implementation
       banner = EnvVarsEnvironmentBanner.new
-      if !banner.enabled?
-        banner = DevelopmentEnvironmentBanner.new
-      end
+
+      banner = DevelopmentEnvironmentBanner.new unless banner.enabled?
 
       @@banner = banner
 
@@ -29,9 +29,9 @@ module UMDLibEnvironmentBannerHelper
         # Configure banner HTML
         css_options = @@banner.css_options
         # Sort to get consistent ordering of keys
-        css_string = css_options.sort.to_h.map { |key,value| "#{key}='#{value}'" }.join(" ")
+        css_string = css_options.sort.to_h.map { |key, value| "#{key}='#{value}'" }.join(' ')
         banner_text = @@banner.text
-        @@banner_html = "<div #{css_string}>#{banner_text}</div>".html_safe
+        @@banner_html = "<div #{css_string}>#{banner_text}</div>".html_safe # rubocop:disable Rails/OutputSafety
         return @@banner_html
       else
         @@banner_html = nil
@@ -51,87 +51,80 @@ module UMDLibEnvironmentBannerHelper
   # https://confluence.umd.edu/display/LIB/Create+Environment+Banners
   #
   def umd_lib_environment_banner
-    UMDLibEnvironmentBannerHelper.initialize if !@@banner_initialized
+    UMDLibEnvironmentBannerHelper.initialize unless @@banner_initialized
     @@banner_html
   end
 
   # Banner implementation classes -- these are not intended to be called
   # directly
 
-    # Returns an environment banner based on ENV config properties
-    class EnvVarsEnvironmentBanner
-      attr_accessor :text
-      attr_accessor :css_options
+  # Returns an environment banner based on ENV config properties
+  class EnvVarsEnvironmentBanner
+    attr_accessor :text
+    attr_accessor :css_options
 
-      def initialize
-        @text = banner_text
-        @css_options = banner_css_options
-        @enabled = banner_enabled(@text)
-      end
-
-      # Returns the text to display in the environment banner.
-      #
-      # Implementation: Returns the value of the ENVIRONMENT_BANNER property, if
-      # non-empty.
-      #
-      # This method may return nil, if there is no ENVIRONMENT_BANNER
-      def banner_text
-        banner_text = ENV.has_key?('ENVIRONMENT_BANNER') ? ENV['ENVIRONMENT_BANNER'] : ''
-        if !banner_text.empty?
-           ENV['ENVIRONMENT_BANNER'].freeze
-        end
-      end
-
-      # Returns the CSS options to use with the environment banner.
-      #
-      # Implementation: Uses the ENVIRONMENT_BANNER_BACKGROUND and
-      # ENVIRONMENT_BANNER_FOREGROUND properties, if provided.
-      def banner_css_options
-        css_options = {}
-        css_style = ''
-
-        background_color = ENV.has_key?('ENVIRONMENT_BANNER_BACKGROUND') ? ENV['ENVIRONMENT_BANNER_BACKGROUND'] : ''
-        foreground_color = ENV.has_key?('ENVIRONMENT_BANNER_FOREGROUND') ? ENV['ENVIRONMENT_BANNER_FOREGROUND'] : ''
-
-        if !background_color.empty?
-          css_style = "background-color: #{background_color};"
-        end
-
-        if !foreground_color.empty?
-          css_style += " color: #{foreground_color};"
-          css_style.strip!
-        end
-
-        if !css_style.empty?
-          css_options[:style] = css_style
-        end
-
-        css_options[:class] = 'environment-banner'
-        css_options
-      end
-
-      # Returns true if the banner should be displayed, false otherwise.
-      #
-      # text - the text (if any) being displayed in the banner
-      def banner_enabled(text)
-        env_var_enabled = ENV['ENVIRONMENT_BANNER_ENABLED']
-        env_var_enabled = ENV.has_key?('ENVIRONMENT_BANNER_ENABLED') ? ENV['ENVIRONMENT_BANNER_ENABLED'] : ''
-
-        # Don't display the banner if there is no text
-        has_display_text = !text.nil? && !text.empty?
-        return false unless has_display_text
-
-        # Display if ENVIRONMENT_BANNER_ENABLED is not provided or empty
-        return true if env_var_enabled.nil? || env_var_enabled.empty?
-
-        # Any value other than "true" is false
-        env_var_enabled.strip.downcase == 'true'
-      end
-
-      def enabled?
-        @enabled
-      end
+    def initialize
+      @text = banner_text
+      @css_options = banner_css_options
+      @enabled = banner_enabled(@text)
     end
+
+    # Returns the text to display in the environment banner.
+    #
+    # Implementation: Returns the value of the ENVIRONMENT_BANNER property, if
+    # non-empty.
+    #
+    # This method may return nil, if there is no ENVIRONMENT_BANNER
+    def banner_text
+      banner_text = ENV.key?('ENVIRONMENT_BANNER') ? ENV['ENVIRONMENT_BANNER'] : ''
+      ENV['ENVIRONMENT_BANNER'] unless banner_text.empty?
+    end
+
+    # Returns the CSS options to use with the environment banner.
+    #
+    # Implementation: Uses the ENVIRONMENT_BANNER_BACKGROUND and
+    # ENVIRONMENT_BANNER_FOREGROUND properties, if provided.
+    def banner_css_options # rubocop:disable Metrics/MethodLength
+      css_options = {}
+      css_style = ''
+
+      background_color = ENV.key?('ENVIRONMENT_BANNER_BACKGROUND') ? ENV['ENVIRONMENT_BANNER_BACKGROUND'] : ''
+      foreground_color = ENV.key?('ENVIRONMENT_BANNER_FOREGROUND') ? ENV['ENVIRONMENT_BANNER_FOREGROUND'] : ''
+
+      css_style = "background-color: #{background_color};" unless background_color.empty?
+
+      unless foreground_color.empty?
+        css_style += " color: #{foreground_color};"
+        css_style.strip!
+      end
+
+      css_options[:style] = css_style unless css_style.empty?
+
+      css_options[:class] = 'environment-banner'
+      css_options
+    end
+
+    # Returns true if the banner should be displayed, false otherwise.
+    #
+    # text - the text (if any) being displayed in the banner
+    def banner_enabled(text)
+      env_var_enabled = ENV.key?('ENVIRONMENT_BANNER_ENABLED') ? ENV['ENVIRONMENT_BANNER_ENABLED'] : ''
+
+      # Don't display the banner if there is no text
+      has_display_text = text.present?
+      return false unless has_display_text
+
+      # Display if ENVIRONMENT_BANNER_ENABLED is not provided or empty
+      return true if env_var_enabled.blank?
+
+      # Any value other than "true" is false
+      env_var_enabled.strip.downcase == 'true'
+    end
+
+    def enabled?
+      @enabled
+    end
+  end
 
   # Returns a default environment banner for Rails development environment
   class DevelopmentEnvironmentBanner
@@ -147,7 +140,7 @@ module UMDLibEnvironmentBannerHelper
       @text = "#{environment_name} Environment"
       @css_options = {}
       @css_options[:id] = "environment-#{environment_name.downcase}"
-      @css_options[:class] = "environment-banner"
+      @css_options[:class] = 'environment-banner'
       @enabled = !environment_name.empty?
     end
 
@@ -158,16 +151,17 @@ module UMDLibEnvironmentBannerHelper
     private
 
       def environment_name
-        ( Rails.env.development? || Rails.env.vagrant? ) ? "Local" : nil
+        (Rails.env.development? || Rails.env.vagrant?) ? 'Local' : nil # rubocop: disable Style/TernaryParentheses
       end
   end
 end
+# rubocop:enable Rails/HelperInstanceVariable, Style/ClassVars
 
 # here we reopen the ApplicationController (after Rails has started)
 # and stick in our helper module.
 Rails.application.config.after_initialize do
-    ApplicationController.class_eval do
-      include UMDLibEnvironmentBannerHelper
-      helper_method :umd_lib_environment_banner
-    end
+  ApplicationController.class_eval do
+    include UMDLibEnvironmentBannerHelper
+    helper_method :umd_lib_environment_banner
+  end
 end

--- a/test/helpers/umd_lib_environment_banner_helper_test.rb
+++ b/test/helpers/umd_lib_environment_banner_helper_test.rb
@@ -1,9 +1,15 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class UMDLibEnvironmentBannerHelperTest < ActiveSupport::TestCase
   def setup
     @banner = Object.new
     @banner.extend(UMDLibEnvironmentBannerHelper)
+
+    # Reset the module - need to do this here, because other tests may have
+    # already set the UMDLibEnvironmentBannerHelper
+    UMDLibEnvironmentBannerHelper.reset
   end
 
   test 'Development environment returns local banner by default' do
@@ -44,7 +50,8 @@ class UMDLibEnvironmentBannerHelperTest < ActiveSupport::TestCase
     ENV['ENVIRONMENT_BANNER_BACKGROUND'] = '#777777'
     assert_equal(
       "<div class='environment-banner' style='background-color: #777777; color: #ff0000;'>TestingForeBack</div>",
-      @banner.umd_lib_environment_banner)
+      @banner.umd_lib_environment_banner
+    )
   end
 
   test 'A ENVIRONMENT_BANNER_ENABLED of "true" enables banner display' do
@@ -54,7 +61,8 @@ class UMDLibEnvironmentBannerHelperTest < ActiveSupport::TestCase
     ENV['ENVIRONMENT_BANNER_ENABLED'] = 'true'
     assert_equal(
       "<div class='environment-banner' style='background-color: #777777; color: #ff0000;'>BannerEnabledTrue</div>",
-      @banner.umd_lib_environment_banner)
+      @banner.umd_lib_environment_banner
+    )
   end
 
   test 'A blank ENVIRONMENT_BANNER_ENABLED enables banner display' do
@@ -64,7 +72,8 @@ class UMDLibEnvironmentBannerHelperTest < ActiveSupport::TestCase
     ENV['ENVIRONMENT_BANNER_ENABLED'] = ''
     assert_equal(
       "<div class='environment-banner' style='background-color: #777777; color: #ff0000;'>BannerEnabledBlank</div>",
-      @banner.umd_lib_environment_banner)
+      @banner.umd_lib_environment_banner
+    )
   end
 
   test 'ENVIRONMENT_BANNER_ENABLED of "false" prevents banner display' do
@@ -96,7 +105,8 @@ class UMDLibEnvironmentBannerHelperTest < ActiveSupport::TestCase
     ENV['ENVIRONMENT_BANNER_BACKGROUND'] = '#777777'
     assert_equal(
       "<div class='environment-banner' style='background-color: #777777; color: #ff0000;'>TestingProdWithEnv</div>",
-      @banner.umd_lib_environment_banner)
+      @banner.umd_lib_environment_banner
+    )
   end
 
   def teardown
@@ -104,7 +114,6 @@ class UMDLibEnvironmentBannerHelperTest < ActiveSupport::TestCase
     Rails.env = 'test'
     ENV.clear
 
-    # Reset the module
     UMDLibEnvironmentBannerHelper.reset
   end
 end

--- a/test/helpers/umd_lib_environment_banner_helper_test.rb
+++ b/test/helpers/umd_lib_environment_banner_helper_test.rb
@@ -1,0 +1,110 @@
+require 'test_helper'
+
+class UMDLibEnvironmentBannerHelperTest < ActiveSupport::TestCase
+  def setup
+    @banner = Object.new
+    @banner.extend(UMDLibEnvironmentBannerHelper)
+  end
+
+  test 'Development environment returns local banner by default' do
+    Rails.env = 'development'
+    assert_equal("<div class='environment-banner' id='environment-local'>Local Environment</div>",
+                 @banner.umd_lib_environment_banner)
+  end
+
+  test 'Vagrant environment returns local banner by default' do
+    Rails.env = 'vagrant'
+    assert_equal("<div class='environment-banner' id='environment-local'>Local Environment</div>",
+                 @banner.umd_lib_environment_banner)
+  end
+
+  test 'Banner text can be controlled by ENVIRONMENT_BANNER' do
+    ENV['ENVIRONMENT_BANNER'] = 'Testing123'
+    assert_equal("<div class='environment-banner'>Testing123</div>",
+                 @banner.umd_lib_environment_banner)
+  end
+
+  test 'Banner foreground color can be controlled by ENVIRONMENT_BANNER_FOREGROUND' do
+    ENV['ENVIRONMENT_BANNER'] = 'TestingForeground'
+    ENV['ENVIRONMENT_BANNER_FOREGROUND'] = '#ff0000'
+    assert_equal("<div class='environment-banner' style='color: #ff0000;'>TestingForeground</div>",
+                 @banner.umd_lib_environment_banner)
+  end
+
+  test 'Banner background color can be controlled by ENVIRONMENT_BANNER_BACKGROUND' do
+    ENV['ENVIRONMENT_BANNER'] = 'TestingBackground'
+    ENV['ENVIRONMENT_BANNER_BACKGROUND'] = '#ff00ff'
+    assert_equal("<div class='environment-banner' style='background-color: #ff00ff;'>TestingBackground</div>",
+                 @banner.umd_lib_environment_banner)
+  end
+
+  test 'Banner foreground and background color can be controlled by environment variables' do
+    ENV['ENVIRONMENT_BANNER'] = 'TestingForeBack'
+    ENV['ENVIRONMENT_BANNER_FOREGROUND'] = '#ff0000'
+    ENV['ENVIRONMENT_BANNER_BACKGROUND'] = '#777777'
+    assert_equal(
+      "<div class='environment-banner' style='background-color: #777777; color: #ff0000;'>TestingForeBack</div>",
+      @banner.umd_lib_environment_banner)
+  end
+
+  test 'A ENVIRONMENT_BANNER_ENABLED of "true" enables banner display' do
+    ENV['ENVIRONMENT_BANNER'] = 'BannerEnabledTrue'
+    ENV['ENVIRONMENT_BANNER_FOREGROUND'] = '#ff0000'
+    ENV['ENVIRONMENT_BANNER_BACKGROUND'] = '#777777'
+    ENV['ENVIRONMENT_BANNER_ENABLED'] = 'true'
+    assert_equal(
+      "<div class='environment-banner' style='background-color: #777777; color: #ff0000;'>BannerEnabledTrue</div>",
+      @banner.umd_lib_environment_banner)
+  end
+
+  test 'A blank ENVIRONMENT_BANNER_ENABLED enables banner display' do
+    ENV['ENVIRONMENT_BANNER'] = 'BannerEnabledBlank'
+    ENV['ENVIRONMENT_BANNER_FOREGROUND'] = '#ff0000'
+    ENV['ENVIRONMENT_BANNER_BACKGROUND'] = '#777777'
+    ENV['ENVIRONMENT_BANNER_ENABLED'] = ''
+    assert_equal(
+      "<div class='environment-banner' style='background-color: #777777; color: #ff0000;'>BannerEnabledBlank</div>",
+      @banner.umd_lib_environment_banner)
+  end
+
+  test 'ENVIRONMENT_BANNER_ENABLED of "false" prevents banner display' do
+    ENV['ENVIRONMENT_BANNER'] = 'BannerEnabledFalse'
+    ENV['ENVIRONMENT_BANNER_FOREGROUND'] = '#ff0000'
+    ENV['ENVIRONMENT_BANNER_BACKGROUND'] = '#777777'
+    ENV['ENVIRONMENT_BANNER_ENABLED'] = 'false'
+    assert_nil(@banner.umd_lib_environment_banner)
+  end
+
+  test 'Non-blank ENVIRONMENT_BANNER_ENABLED other than "true" prevents banner display' do
+    ENV['ENVIRONMENT_BANNER'] = 'BannerEnabledFoobar'
+    ENV['ENVIRONMENT_BANNER_FOREGROUND'] = '#ff0000'
+    ENV['ENVIRONMENT_BANNER_BACKGROUND'] = '#777777'
+    ENV['ENVIRONMENT_BANNER_ENABLED'] = 'foobar'
+    assert_nil(@banner.umd_lib_environment_banner)
+  end
+
+  test 'Banner is not displayed by default in production' do
+    Rails.env = 'production'
+    assert_nil(@banner.umd_lib_environment_banner)
+  end
+
+  test 'Banner can be displayed in production using environment variables' do
+    Rails.env = 'production'
+
+    ENV['ENVIRONMENT_BANNER'] = 'TestingProdWithEnv'
+    ENV['ENVIRONMENT_BANNER_FOREGROUND'] = '#ff0000'
+    ENV['ENVIRONMENT_BANNER_BACKGROUND'] = '#777777'
+    assert_equal(
+      "<div class='environment-banner' style='background-color: #777777; color: #ff0000;'>TestingProdWithEnv</div>",
+      @banner.umd_lib_environment_banner)
+  end
+
+  def teardown
+    # Unset environment variables
+    Rails.env = 'test'
+    ENV.clear
+
+    # Reset the module
+    UMDLibEnvironmentBannerHelper.reset
+  end
+end


### PR DESCRIPTION
Refactored the "environment banner" implementation to better support use
in Kubernetes. Largely followed the approach taken in umd_lib_style
PR #14 (https://github.com/umd-lib/umd_lib_style/pull/14), where the
following variables are available for setting the banner:

* ENVIRONMENT_BANNER - the text for the banner
* ENVIRONMENT_BANNER_BACKGROUND - The background color of the banner
   (in CSS notation)
* ENVIRONMENT_BANNER_FOREGROUND - The foreground color of the banner
   (in CSS notation)
* ENVIRONMENT_BANNER_ENABLED - "true" (or present, but blank) if the
   banner should be enabled. Any other (non-empty) value is treated as
  false

Automatic configuration of the banner based on the hostname (i.e., the
autodiscovery of "dev" and "stage" servers), is no longer provided).

The local development environment is still auto-detected (and displays
a "Local Development" banner) when the "Rails.env.development?" or
"Rails.env.vargant?" methods return true. Setting the environment
variables above overrides this behavior.

*Note:* This change does NOT preserve the existing banner functionality
for the "archelondev" and "archelonstage" servers.

https://issues.umd.edu/browse/LIBHYDRA-433