### PR TITLE
LIBHYDRA-377. Updated ControlledURIRef to display non-vocabulary terms

### DIFF
--- a/app/javascript/components/ControlledURIRef.jsx
+++ b/app/javascript/components/ControlledURIRef.jsx
@@ -39,6 +39,21 @@ class ControlledURIRef extends React.Component {
     }
     this.noStartingValue = (this.state.uri === '');
 
+    // Determine if the "uri" value is in the vocabulary
+    let isUriInVocabulary = false;
+    for (const [uri, label] of Object.entries(this.props.vocab)) {
+      if (uri === this.state.uri) {
+        isUriInVocabulary = true;
+        break;
+      }
+    }
+
+    // If uri is not in vocabulary, append it to the vocabulary so that it
+    // shows up in the dropdown
+    if (!isUriInVocabulary) {
+      props.vocab[this.state.uri] = this.state.uri;
+    }
+
     this.handleChange = this.handleChange.bind(this);
     this.getStatement = this.getStatement.bind(this);
   };

--- a/app/javascript/components/ControlledURIRef.md
+++ b/app/javascript/components/ControlledURIRef.md
@@ -13,3 +13,12 @@ Default values can be pre-populated using the "value" property:
 <ControlledURIRef subjectURI='example' predicateURI='title' value={{'@id': 'http://example.com/vocab#bar'}}
  vocab={{'http://example.com/vocab#foo': 'Foo', 'http://example.com/vocab#bar': 'Bar'}}/>
 ```
+
+### Value not in vocabulary example
+
+When the value returned is not in the allowed vocabulary, simply display the value:
+
+```js
+<ControlledURIRef subjectURI='example' predicateURI='title' value={{'@id': 'http://example.com/not-in-vocabulary'}}
+ vocab={{'http://example.com/vocab#foo': 'Foo', 'http://example.com/vocab#bar': 'Bar'}}/>
+```

--- a/app/views/react_components/react_components.html.erb
+++ b/app/views/react_components/react_components.html.erb
@@ -51,11 +51,13 @@
 
   <h2>ControlledURIRef</h2>
 
-  <div>This component presents a dropdown using the values defined in the
+  <h3>Typical Usage</h3>
+
+  <div>This component presents dropdowns using the values defined in the
     <%= link_to 'controlled vocabularies', vocabularies_url %>.</div>
 
   <% Vocabulary.all.each do |vocab| %>
-    <h3><%= vocab.identifier %></h3>
+    <h4><%= vocab.identifier %></h4>
     <div class="form-group">
       <%=
         react_component(
@@ -69,6 +71,26 @@
       %>
     </div>
   <% end %>
+
+  <h3>Value not in vocabulary</h3>
+
+  <div>This example presents a dropdown where the provided value is not
+       present in the controlled vocabulary list.</div>
+
+  <% vocab = Vocabulary.find_by(identifier:'access') %>
+  <h4><%= vocab.identifier %></h4>
+  <div class="form-group">
+    <%=
+      react_component(
+        "ControlledURIRef", {
+        subjectURI: 'controlled_value',
+        predicateURI: vocab.identifier,
+        vocab: vocab.as_hash,
+        value: { '@id': 'not-in-vocabulary' }
+      }
+      )
+    %>
+  </div>
 
   <h2>URIRef</h2>
 


### PR DESCRIPTION
Modified the ControlledURIRef React component to display a URI that is
not in the vocabulary simply as the URI, instead of showing a blank
value.

The non-vocabulary term is added to the drop-down list, as so will be
available to the user, at least until the field is submitted with a
different value.

https://issues.umd.edu/browse/LIBHYDRA-377