### PR TITLE
LIBFCREPO-1041. Configured docker-archelon-template.env for /fcrepo/rest

### DIFF
--- a/docker-archelon-template.env
+++ b/docker-archelon-template.env
@@ -1,7 +1,7 @@
 SOLR_URL=http://solr-fedora4:8983/solr/fedora4
 
-FCREPO_BASE_URL=http://repository:8080/rest
-REPO_EXTERNAL_URL=http://fcrepo-local:8080/rest
+FCREPO_BASE_URL=http://repository:8080/fcrepo/rest
+REPO_EXTERNAL_URL=http://fcrepo-local:8080/fcrepo/rest
 FCREPO_AUTH_TOKEN=<REPLACE WITH FCREPO GENERATED AUTH_TOKEN>
 
 IIIF_BASE_URL=https://iiiflocal/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,17 @@ services:
       - 3000:3000
     env_file:
       - docker-archelon.env
+  archelon-db:
+    image: postgres:9.5.16
+    environment:
+      POSTGRES_USER: archelon
+      POSTGRES_PASSWORD: archelon
+      POSTGRES_DB: archelon
+    volumes:
+      - "dbdata:/var/lib/postgresql/data"
 volumes:
   archelon:
+  dbdata:
 networks:
   default:
     external: true


### PR DESCRIPTION
Configured the "docker-archelon-template.env" file to use the
"/fcrepo/rest" endpoint that is now used for the Docker setup.

https://issues.umd.edu/browse/LIBFCREPO-1041