### PR TITLE
LIBFCREPO-1037. Updated Docker config to support SFTP

### DIFF
--- a/docker-archelon-template.env
+++ b/docker-archelon-template.env
@@ -39,10 +39,10 @@ VOCAB_PUBLICATION_BASE_URI=http://localhost:3000/published_vocabularies/
 
 MAX_ALLOWED_BINARIES_DOWNLOAD_SIZE=53687091200
 
-IMPORT_BINARIES_DIR=/data/imports
-IMPORT_BINARIES_BASE_LOCATION=zip+sftp://plastron@archelon/imports
+IMPORT_BINARIES_DIR=/var/opt/archelon/imports
+IMPORT_BINARIES_BASE_LOCATION=zip+sftp://plastron@archelon-sftp/imports
 
-EXPORT_DIR=/data/exports
-EXPORT_BASE_DESTINATION=sftp://plastron@archelon/exports
+EXPORT_DIR=/var/opt/archelon/exports
+EXPORT_BASE_DESTINATION=sftp://plastron@archelon-sftp/exports
 
 PLASTRON_PUBLIC_KEY=<REPLACE WITH CONTENTS of PLASTRON "archelon_id.pub" FILE>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,14 @@ services:
       - 3000:3000
     env_file:
       - docker-archelon.env
+    volumes:
+      - archelon-import-export-data:/var/opt/archelon:ro
+  archelon-sftp:
+    image: docker.lib.umd.edu/archelon-sftp:latest
+    ports:
+      - 2200:22
+    volumes:
+      - archelon-import-export-data:/data
   archelon-db:
     image: postgres:9.5.16
     environment:
@@ -20,7 +28,7 @@ services:
     volumes:
       - "dbdata:/var/lib/postgresql/data"
 volumes:
-  archelon:
+  archelon-import-export-data:
   dbdata:
 networks:
   default:


### PR DESCRIPTION
Addd "archelon-sftp" container to "docker-compose.yml". Added
"archelon-import-export-data" volume, used by both the "archelon" and
"archelon-sftp" containers to manage SFTP imports.

Updated the import/export environment variables to reflect their
actual location in the Docker environment.

https://issues.umd.edu/browse/LIBFCREPO-1037