### PR TITLE
LIBHYDRA-448. Added default "VOCAB" values to "env_example"

### DIFF
--- a/env_example
+++ b/env_example
@@ -85,10 +85,10 @@ FCREPO_CLIENT_KEY=
 
 # --- config/vocabularies.yml
 # Base URI for the controlled vocabulary terms
-VOCAB_LOCAL_AUTHORITY_BASE_URI=
+VOCAB_LOCAL_AUTHORITY_BASE_URI=http://vocab.lib.umd.edu/
 
 # Base URI for the location where the vocabularies are published
-VOCAB_PUBLICATION_BASE_URI=
+VOCAB_PUBLICATION_BASE_URI=http://localhost:3000/published_vocabularies/
 
 # The maximum allowed binaries export download size, in bytes
 MAX_ALLOWED_BINARIES_DOWNLOAD_SIZE=53687091200


### PR DESCRIPTION
Updated the "env_example" file with default
"VOCAB_LOCAL_AUTHORITY_BASE_URI" and "VOCAB_PUBLICATION_BASE_URI"
values, so that they do not need to be added by the user.

This simplifies the installation when setting up Archelon locally.

https://issues.umd.edu/browse/LIBHYDRA-448