### PR TITLE
LIBHYDRA-449. Update export job status dynamically without page reload

### DIFF
--- a/app/assets/javascripts/channels/export_jobs.js
+++ b/app/assets/javascripts/channels/export_jobs.js
@@ -8,8 +8,12 @@
       return this.installPageChangeCallback();
     },
     received: function(data) {
-      // Trigger a page reload
-      return location.reload();
+      // Update the display for the export job
+      const {job, htmlUpdate} = data.export_job
+      let currentHtml = $('[data-job-id="' + job.id + '"]')
+      if (currentHtml && htmlUpdate) {
+        currentHtml.replaceWith(htmlUpdate)
+      }
     },
     followExportJobs: function() {
       // Calls "follow" or "unfollow" on ExportJobsChannel, based on whether

--- a/app/channels/export_jobs_channel.rb
+++ b/app/channels/export_jobs_channel.rb
@@ -19,15 +19,17 @@ class ExportJobsChannel < ApplicationCable::Channel
   def self.broadcast(export_job)
     user = export_job.cas_user
 
+    message = { job: export_job, htmlUpdate: html_update(export_job) }
+
     unless user.admin?
       # Don't broadcast on per-user stream if user is an admin, as they
       # will get the message on the "admins" stream
       user_stream = ExportJobsChannel.stream(user)
-      ActionCable.server.broadcast user_stream, export_job: export_job
+      ActionCable.server.broadcast user_stream, export_job: message
     end
 
     admins_stream = ExportJobsChannel.admins_stream
-    ActionCable.server.broadcast admins_stream, export_job: export_job
+    ActionCable.server.broadcast admins_stream, export_job: message
   end
 
   # Stream that sends status message to the user that created the export job
@@ -39,5 +41,11 @@ class ExportJobsChannel < ApplicationCable::Channel
   # the export job.
   def self.admins_stream
     'export_jobs:admins:status'
+  end
+
+  # Returns the updated HTML to render
+  def self.html_update(export_job)
+    ActionController::Renderer.for(ExportJobsController).render partial: 'export_job_table_row',
+                                                                locals: { export_job: export_job }
   end
 end

--- a/app/views/export_jobs/_export_job_status.erb
+++ b/app/views/export_jobs/_export_job_status.erb
@@ -1,5 +1,5 @@
 <td>
-  <span class="export_job_status_<%= export_job.state %>" data-channel="export_jobs" data-job-id="<%= export_job.id %>"<% unless export_job.done? %> colspan="3"<% end %>>
+  <span class="export_job_status_<%= export_job.state %>" <% unless export_job.done? %> colspan="3"<% end %>>
     <%= t("activerecord.attributes.export_job.status.#{export_job.state}") %>
     <% if export_job.in_progress? %>(<%= export_job.progress %>%)<% end %>
   </span>

--- a/app/views/export_jobs/_export_job_table_row.erb
+++ b/app/views/export_jobs/_export_job_table_row.erb
@@ -1,0 +1,14 @@
+  <%
+    format_label = ExportJob::FORMATS[export_job.format] || export_job.format
+  %>
+<tr data-channel="export_jobs" data-job-id="<%= export_job.id %>">
+  <td><%= export_job.id %></td>
+  <td><%= export_job.name %></td>
+  <td><%= export_job.cas_user&.name%></td>
+  <td><%= export_job.timestamp %></td>
+  <td><%= export_job.item_count %></td>
+  <td><%= export_job.binaries_count %></td>
+  <td><%= number_to_human_size export_job.binaries_size %></td>
+  <td><span title="<%= export_job.format %>"><%= format_label %></span></td>
+  <%= render partial: 'export_job_status', locals: { export_job: export_job } %>
+</tr>

--- a/app/views/export_jobs/index.html.erb
+++ b/app/views/export_jobs/index.html.erb
@@ -17,20 +17,7 @@
     </thead>
     <tbody>
     <% @jobs.each do |job| %>
-        <%
-          format_label = ExportJob::FORMATS[job.format] || job.format
-        %>
-      <tr>
-        <td><%= job.id %></td>
-        <td><%= job.name %></td>
-        <td><%= job.cas_user&.name%></td>
-        <td><%= job.timestamp %></td>
-        <td><%= job.item_count %></td>
-        <td><%= job.binaries_count %></td>
-        <td><%= number_to_human_size job.binaries_size %></td>
-        <td><span title="<%= job.format %>"><%= format_label %></span></td>
-        <%= render partial: 'export_job_status', locals: { export_job: job } %>
-      </tr>
+      <%= render partial: 'export_job_table_row', locals: { export_job: job } %>
     <% end %>
     </tbody>
   </table>


### PR DESCRIPTION
Largely followed the import status example in LIBHYDRA-446.

One issue was that the "status" field in the "_export_job_status.erb"
helper actually consists of two "td" elements – one for the status,
the other for the "Download" button. This made it problematic to update
the status because targeting the "td" element for the "status" field for
updates resulted in nesting both "td" elements from the helper in a
single "td" element in the table (because the HTML attribute being used
to locate the element in JavaScript was inside the first "td" element).

Ideally, it would have been nice to be able to group the two "td"
elements within a single HTML element that had an attribute that could
be targeted by JavaScript so that they could be replaced together, but
I could not find a way to do this. Instead, added a
"_export_job_table_row.erb" helper that replaces the entire row in the
table when the status is updated.

https://issues.umd.edu/browse/LIBHYDRA-449