### PR TITLE
LIBHYDRA-447. Add invalid items tab panel to import job view.

### DIFF
--- a/app/assets/javascripts/channels/import_jobs.js
+++ b/app/assets/javascripts/channels/import_jobs.js
@@ -13,10 +13,15 @@
       // Update the status widget for each job in the received message
       data.import_jobs.forEach(function(msg){
         const {job, statusWidget} = msg;
-        let oldWidget = $('[data-job-id="' + job.id + '"]')
+        const {binaries_count, item_count} = job;
+        let oldWidget = $('[data-job-id="' + job.id + '"]');
         if (oldWidget && statusWidget) {
           oldWidget.replaceWith(statusWidget)
         }
+        // update count columns
+        let td = document.querySelector('[data-job-id="' + job.id + '"]');
+        td.parentElement.querySelector('.binaries-count').innerHTML = binaries_count;
+        td.parentElement.querySelector('.item-count').innerHTML = item_count;
       });
     },
 

--- a/app/controllers/import_jobs_controller.rb
+++ b/app/controllers/import_jobs_controller.rb
@@ -198,16 +198,10 @@ class ImportJobsController < ApplicationController # rubocop:disable Metrics/Cla
     def valid_update
       @import_job.update(import_job_params)
 
-      # Need special handing of "metadata_file", because if we're gotten this
-      # far, the @import_job already has a file attached, so the
-      # "attachment_validation" method on the model won't catch that the
-      # update form submission doesn't have new file attached.
-      #
-      # Need to have the method after the call to @import_job.update, as
-      # update clears the "errors" array
-      if import_job_params['metadata_file'].nil?
-        @import_job.errors.add(:metadata_file, :required)
-        return false
+      if import_job_params['metadata_file'].present?
+        # delete existing attachment and attach new metadata file
+        @import_job.metadata_file.purge
+        @import_job.metadata_file.attach(import_job_params[:metadata_file])
       end
 
       true

--- a/app/services/import_job_info.rb
+++ b/app/services/import_job_info.rb
@@ -5,22 +5,17 @@
 # If an error has occurred, the "error_occurred?" method returns true,
 # and the error message is available in the "error_message" attribute.
 class ImportJobInfo
-  attr_reader :completed, :failed, :total, :error_message
+  attr_reader :completed, :failed, :invalid, :total, :error_message
 
   def initialize(json_rest_result)
     # Constructed from a JsonRestResult object
     @json_rest_result = json_rest_result
     parsed_json = json_rest_result.parsed_json
 
-    if parsed_json.present?
-      @completed = parsed_json.dig('completed', 'items')
-      @failed = parsed_json.dig('dropped', 'failed', 'items')
-      @total = parsed_json.dig('total')
-    end
-
-    @completed = [] if @completed.blank?
-    @failed = [] if @failed.blank?
-    @total = 0 if @total.blank?
+    @completed = parsed_json&.dig('completed', 'items') || []
+    @failed = parsed_json&.dig('dropped', 'failed', 'items') || []
+    @invalid = parsed_json&.dig('dropped', 'invalid', 'items') || []
+    @total = parsed_json&.dig('total') || 0
   end
 
   delegate :error_message, to: :json_rest_result

--- a/app/views/import_jobs/_form.html.erb
+++ b/app/views/import_jobs/_form.html.erb
@@ -57,6 +57,9 @@
       <%= form.label :metadata_file, 'Metadata File to Upload (CSV)', class: "col-form-label-lg" %>
     </div>
     <div class="p-3 ml-5">
+      <% if import_job.metadata_file.attachment.present? %>
+        <div class="current-file"><strong>Current file:</strong> <%= import_job.metadata_file.filename %></div>
+      <% end %>
       <%= form.file_field :metadata_file, class: "form-control" %>
     </div>
   </div>
@@ -71,11 +74,12 @@
           <h3 class="panel-title">Select the zip file containing the binaries for this import job</h3>
         </div>
         <div class="panel-body">
+          <% current_filename = import_job.binaries_location&.gsub(IMPORT_CONFIG[:binaries_base_location], '') %>
           <ul style="list-style-type: none">
             <li><label><%= form.radio_button :binaries_zip_filename, '' %> No binaries</label></li>
             <% @binaries_files&.each do |filename| %>
               <li>
-                <%= form.radio_button :binaries_zip_filename, filename %>
+                <%= form.radio_button :binaries_zip_filename, filename, checked: current_filename == filename %>
                 <%= form.label :binaries_zip_filename, filename %>
                 (<%= number_to_human_size File.size(File.join(IMPORT_CONFIG[:binaries_dir], filename)) %>)
               </li>

--- a/app/views/import_jobs/_import_job_info_panel.erb
+++ b/app/views/import_jobs/_import_job_info_panel.erb
@@ -14,7 +14,7 @@
       </li>
       <li role="presentation">
         <a href="#invalid" aria-controls="invalid" role="tab" data-toggle="tab">
-          Invalid
+          Invalid <span class="badge"><%= import_job_info.invalid.count %></span>
         </a>
       </li>
     </ul>
@@ -33,7 +33,9 @@
         %>
       </div>
       <div role="tabpanel" class="tab-pane" id="invalid">
-        <p>TODO - Invalid</p>
+        <%= render "import_jobs/import_job_info_panel/invalid",
+                   import_job_info: @import_job_info
+        %>
       </div>
     </div>
   </div>

--- a/app/views/import_jobs/_import_job_status.erb
+++ b/app/views/import_jobs/_import_job_status.erb
@@ -6,6 +6,6 @@
       <%= form.submit 'Import', class: 'btn-xs btn-success' %>
     <% end %>
   <% elsif import_job.validate_failed? or import_job.validate_error? %>
-    <%= link_to 'Edit', edit_import_job_path(import_job), class: 'btn-xs btn-danger' %>
+    <%= link_to 'Resubmit', edit_import_job_path(import_job), class: 'btn-xs btn-danger' %>
   <% end %>
 </td>

--- a/app/views/import_jobs/import_job_info_panel/_invalid.erb
+++ b/app/views/import_jobs/import_job_info_panel/_invalid.erb
@@ -1,0 +1,27 @@
+<% if !import_job_info.invalid.empty? %>
+  <strong>Invalid Items (<%= import_job_info.invalid.count %>)</strong>
+  <table class="table table-striped">
+    <thead>
+    <tr>
+      <th>#</th>
+      <th>ID</th>
+      <th>Timestamp</th>
+      <th>Title</th>
+      <th>Error</th>
+    </tr>
+    </thead>
+    <tbody>
+    <% import_job_info.invalid.each_with_index do |item, index| %>
+      <tr>
+        <td><%= (index+1) %></td>
+        <td><%= item['id'] %></td>
+        <td><%= item['timestamp'] %></td>
+        <td><%= item['title'] %></td>
+        <td><%= item['reason'] %></td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <p>There are no invalid items for this import job.</p>
+<% end %>

--- a/app/views/import_jobs/index.html.erb
+++ b/app/views/import_jobs/index.html.erb
@@ -38,8 +38,8 @@
           <td><%= job.timestamp %></td>
           <td><%= job.metadata_file.filename if job.metadata_file.attached? %></td>
           <td><%= job.binaries? ? t('activerecord.attributes.import_job.binaries.true') : t('activerecord.attributes.import_job.binaries.false') %></td>
-          <td><%= job.item_count %></td>
-          <td><%= job.binaries_count if job.binaries? %></td>
+          <td class="item-count"><%= job.item_count %></td>
+          <td class="binaries-count"><%= job.binaries_count if job.binaries? %></td>
           <td><%= job.model %></td>
           <%= render partial: 'import_job_status', locals: { import_job: job } %>
         </tr>

--- a/app/views/import_jobs/show.html.erb
+++ b/app/views/import_jobs/show.html.erb
@@ -4,8 +4,32 @@
 
 <%= render "import_job_panel", import_job: @import_job %>
 
-<%= render "import_job_info_panel",
-           import_job_info: @import_job_info
-%>
+<% if @import_job.validate_failed? || @import_job.validate_error? || @import_job.validate_success? %>
+  <% if @import_job.validate_failed? %>
+    <div class="panel panel-danger">
+      <div class="panel-heading">
+        <h3 class="panel-title">Validation Errors</h3>
+      </div>
+      <div class="panel-body">
+        <p><strong>To continue this import job, please edit your metadata file to correct the
+          validation errors listed below. Then, resubmit this import job to re-upload
+          the metadata file.</strong></p>
+      </div>
+    </div>
+  <% end %>
+  <div class="panel panel-default">
+    <div class="panel-heading">
+      <h3 class="panel-title">Validation Report</h3>
+    </div>
+    <div class="panel-body">
+      <%= render "import_jobs/import_job_info_panel/invalid", import_job_info: @import_job_info %>
+    </div>
+  </div>
+<% else %>
+  <%= render "import_job_info_panel", import_job_info: @import_job_info %>
+<% end %>
 
 <%= link_to 'Back', import_jobs_path, class: 'btn btn-danger' %>
+<% if @import_job.validate_failed? %>
+  <%= link_to 'Resubmit', edit_import_job_path(@import_job), class: 'btn btn-success' %>
+<% end %>

--- a/test/controllers/import_jobs_controller_test.rb
+++ b/test/controllers/import_jobs_controller_test.rb
@@ -126,15 +126,6 @@ class ImportJobsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
-  test 'file attachment is required when updating import_job' do
-    import_job = ImportJob.first
-    patch :update, params: { id: import_job.id, import_job: { name: import_job.name } }
-    result = assigns(:import_job)
-    assert_includes(result.errors.messages[:metadata_file],
-                    I18n.t('activerecord.errors.models.import_job.attributes.metadata_file.required'))
-    assert_template :edit
-  end
-
   test 'name cannot be blank when updating import_job' do
     import_job = ImportJob.first
     patch :update, params: { id: import_job.id, import_job: { name: '' } }


### PR DESCRIPTION
- reuse the invalid items panel as the validation report before import
- ensure that the currently selected binaries location is selected when editing an import job
- when a metadata file is uploaded, purge and reattach to ensure the file in ActiveStorage is the one the user uploaded
- dynamically update the item and binaries counts
- display the name of the current metadata file attachment on the resubmit page; use this file if no other file is selected

https://issues.umd.edu/browse/LIBHYDRA-447