### PR TITLE
LIBHYDRA-467. Added Archelon delayed jobs worker process to Docker Compose stack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,11 +28,11 @@ ENV SCRIPT_NAME=
 # "assets:precompile" command will run run without throwing an error.
 # It will have no effect on the application when it is actually run.
 #
-# Similarly, the PROD_DATABASE_ADAPTER variable is needed for the
+# Similarly, the ARCHELON_DATABASE_ADAPTER variable is needed for the
 # "assets:precompile" Rake task to complete, but will have no effect
 # on the application when it is actually run.
 ENV SECRET_KEY_BASE=IGNORE_ME
-RUN PROD_DATABASE_ADAPTER=postgresql bundle exec rails assets:precompile
+RUN ARCHELON_DATABASE_ADAPTER=postgresql bundle exec rails assets:precompile
 
 EXPOSE 3000
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,11 @@ services:
       - docker-archelon.env
     volumes:
       - archelon-import-export-data:/var/opt/archelon:ro
+  archelon-delayed-job-worker:
+    image: docker.lib.umd.edu/archelon
+    env_file:
+      - docker-archelon.env
+    command: [ "bundle", "exec", "rails", "jobs:work" ]
   archelon-sftp:
     image: docker.lib.umd.edu/archelon-sftp:latest
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,11 +13,14 @@ services:
       - docker-archelon.env
     volumes:
       - archelon-import-export-data:/var/opt/archelon:ro
+      - archelon-storage:/opt/archelon/storage
   archelon-delayed-job-worker:
     image: docker.lib.umd.edu/archelon
     env_file:
       - docker-archelon.env
     command: [ "bundle", "exec", "rails", "jobs:work" ]
+    volumes:
+      - archelon-storage:/opt/archelon/storage:ro
   archelon-sftp:
     image: docker.lib.umd.edu/archelon-sftp:latest
     ports:
@@ -35,6 +38,7 @@ services:
     ports:
       - 5434:5432
 volumes:
+  archelon-storage:
   archelon-import-export-data:
   dbdata:
 networks:


### PR DESCRIPTION
###  Archelon Dockerfile "assets:precompiler" fix

The Archelon Dockerfile had the following line to run the "assets:precompile" task:

```
RUN PROD_DATABASE_ADAPTER=postgresql bundle exec rails assets:precompile
```

The "PROD_DATABASE_ADAPTER" environment variable was believed to be needed for the "assets:precompile" task to successfully run, but there is no other reference to the "PROD_DATABASE_ADAPTER" variable anywhere else in the codebase. This was likely copy-and-pasted from some other Rails application (such as "student-applications").

The environment variable has been in the codebase for quite some time,
but was apparently unused. When the "delayed_job" gem was added in
LIBHYDRA-462, the "assets:precompile" task started causing the following
error when building the Docker image:

```
 > [8/8] RUN bundle exec rails assets:precompile:
#12 5.531 rails aborted!
#12 5.531 LoadError: Could not load the '' Active Record adapter. Ensure that the adapter is spelled correctly in config/database.yml and that you've added the necessary adapter gem to your Gemfile.
#12 5.531 /opt/archelon/vendor/bundle/ruby/2.6.0/gems/bootsnap-1.4.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `require'
...
```

Changed the "PROD_DATA_ADAPTER" environment variable to "ARCHELON_DATABASE_ADAPTER" to match the environment variable expected by the "config/database.yml" file, which corrected the error.

### "archelon-delayed-job-worker" Container

Added an "archelon-delayed-job-worker" container to the Docker Compose stack in "docker-compose.yml".

This container uses the same Docker image as the "archelon" container, so no additional Docker build steps are necessary.

### Share "/opt/archelon/storage" between containers

The jobs processed by the "delayed_job" work may reference files that
have been uploaded to Archelon (specifically, the metadata file for an
import job).

Created an "archelon-storage" volume to share the
"/opt/archelon/storage" directory between the "archelon" and
"archelon-delayed-job-worker" containers. The
"archelon-delayed-job-worker" only needs "read-only" access.

https://issues.umd.edu/browse/LIBHYDRA-467