### PR TITLE
LIBHYDRA-487. Implement docker.rake tasks using boathook gem.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 COPY ./Gemfile ./Gemfile.lock /opt/archelon/
-RUN bundle install --deployment
+RUN bundle install --deployment --without development test
 COPY . /opt/archelon
 
 RUN npm install --global yarn && \

--- a/Gemfile
+++ b/Gemfile
@@ -84,6 +84,8 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
+
+  gem "boathook", git: 'https://github.com/umd-lib/boathook', branch: 'main'
 end
 
 group :test do
@@ -133,4 +135,3 @@ gem 'react-rails'
 gem 'delayed_job_active_record', '~> 4.1'
 gem 'faraday', '~> 1.0'
 gem 'delayed_cron_job', '~> 0.8'
-

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/umd-lib/boathook
+  revision: 513db1964fe2ddd854d4c249dd5488549f079880
+  branch: main
+  specs:
+    boathook (1.0.0.pre.dev)
+      mattock (~> 0.5.2)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -183,6 +191,9 @@ GEM
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     marcel (1.0.2)
+    mattock (0.5.2)
+      tilt (> 0)
+      valise (>= 0.9.1)
     mechanize (2.7.7)
       domain_name (~> 0.5, >= 0.5.1)
       http-cookie (~> 1.0)
@@ -385,6 +396,7 @@ GEM
       unf_ext
     unf_ext (0.0.7.7)
     unicode-display_width (1.6.1)
+    valise (1.2.1)
     web-console (3.7.0)
       actionview (>= 5.0)
       activemodel (>= 5.0)
@@ -417,6 +429,7 @@ DEPENDENCIES
   action-cable-testing
   addressable (~> 2.8)
   blacklight (~> 6.0)
+  boathook!
   bootsnap (>= 1.1.0)
   byebug
   cancancan

--- a/lib/tasks/docker.rake
+++ b/lib/tasks/docker.rake
@@ -1,59 +1,13 @@
 # frozen_string_literal: true
 
+require 'boathook'
+
 namespace :docker do
-  task :build do
-    images.each { |image| build_image(**image) }
+  Boathook::DockerTasks.new do |task|
+    task.version = Archelon::VERSION
+    task.image_specs = [
+      { name: 'docker.lib.umd.edu/archelon' },
+      { name: 'docker.lib.umd.edu/archelon-sftp', dockerfile: 'Dockerfile.sftp' }
+    ]
   end
-
-  task :push do
-    images.each { |image| push_image(tag: image[:tag]) }
-  end
-end
-
-def build_image(tag:, dockerfile: 'Dockerfile', context: '.')
-  puts "Building #{tag} (dockerfile: #{dockerfile}, context: #{context})"
-  puts "With labels #{label_pairs}" if labels
-  system 'docker', 'build', '-t', tag, *label_args, '-f', dockerfile, context
-end
-
-def push_image(tag:)
-  puts "Pushing #{tag}"
-  system 'docker', 'push', tag
-end
-
-def label_pairs
-  labels.map { |k, v| "#{k}=#{v}" }
-end
-
-def label_args
-  label_pairs.map { |label| ['--label', label] }.flatten
-end
-
-def images
-  [
-    { tag: "docker.lib.umd.edu/archelon:#{version_number}" },
-    { tag: "docker.lib.umd.edu/archelon-sftp:#{version_number}", dockerfile: 'Dockerfile.sftp' }
-  ]
-end
-
-# labels to add to each image
-# include the Archelon version, and the Git revision (for distinguishing between
-# "-dev" releases)
-def labels
-  {
-    'org.opencontainer.images.version': version_number,
-    'org.opencontainer.images.revision': git_revision
-  }
-end
-
-# Use "latest" for any development version (identified by the presence
-# of "dev" in the version number). Otherwise, just use the Archelon::VERSION.
-def version_number
-  return 'latest' if Archelon::VERSION.include? 'dev'
-
-  Archelon::VERSION
-end
-
-def git_revision
-  @git_revision ||= `git rev-parse HEAD`.chomp
 end


### PR DESCRIPTION
Uses the main branch at https://github.umd.edu/umd-lib/boathook

Additionally, exclude development- and test-only gems when building the Docker image.

https://issues.umd.edu/browse/LIBHYDRA-487