### PR TITLE
LIBDEVOPS-229. Fix solr query for job binaries.

### DIFF
--- a/app/services/mime_types.rb
+++ b/app/services/mime_types.rb
@@ -6,7 +6,7 @@ class MimeTypes < SolrQueryService
     q: '*:*',
     indent: 'on',
     rows: '1000',
-    fl: 'id,files:[subquery]',
+    fl: 'id,pcdm_members,files:[subquery]',
     'files.q': '{!terms f=pcdm_file_of v=$row.pcdm_members}',
     'files.fl': 'mime_type',
     'files.rows': '1000',


### PR DESCRIPTION
The fields used in the solr subquery needs to be explicitly included in the main query 'fl' param.

https://umd-dit.atlassian.net/browse/LIBDEVOPS-229