### PR TITLE
LIBHYDRA-541. Update select_all behavior.

### DIFF
--- a/app/assets/javascripts/select_all.js
+++ b/app/assets/javascripts/select_all.js
@@ -13,7 +13,8 @@
 // ---  END LICENSE_HEADER BLOCK  ---
 
 updateSelectAll = () => {
-  $("#bookmarks_selectall").prop("checked", $("input.toggle_bookmark:not(:checked)").size() == 0)
+  $("#bookmarks_selectall").prop("checked", $("input.toggle_bookmark").size() != 0 && $("input.toggle_bookmark:not(:checked)").size() == 0)
+  $("#bookmarks_selectall").prop("disabled", $("input.toggle_bookmark").size() == 0)
 }
 
 updateSelectAllResults = () => {


### PR DESCRIPTION
- The select_all checkbox should be disabled if there are no item with select box on the result page.
- The select_all should be selected only there are items with select box and none are unchecked.

https://umd-dit.atlassian.net/browse/LIBHYDRA-541