### PR TITLE
LIBHYDRA-543. Improve devcontainer definition.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,9 @@
 {
   "build": { "dockerfile": "../Dockerfile.vscode" },
+  "containerEnv": {
+    "EXPORT_BASE_DESTINATION": "${localWorkspaceFolder}/exports"
+  },
+  "runArgs": ["--network=umd-fcrepo_default"],
 
   "customizations": {
     "vscode": {
@@ -9,7 +13,7 @@
 
   // Only forward specific ports, as having auto-forwarding turned on will
   // mask the ports needed to contact fcrepo, Solr, and Plastron
-  "forwardPorts": [3000,5000,8080],
+  "forwardPorts": [3000],
   "otherPortsAttributes": {
     "onAutoForward": "ignore"
   }

--- a/.env.development
+++ b/.env.development
@@ -1,10 +1,8 @@
 # --- config/blacklight.yml
-# SOLR_URL=http://localhost:8983/solr/fedora4
-SOLR_URL=http://docker.for.mac.localhost:8983/solr/fedora4
+SOLR_URL=http://solr-fedora4:8983/solr/fedora4
 
 # --- config/environments/*.rb
-# FCREPO_BASE_URL=http://fcrepo-local:8080/fcrepo/rest/
-FCREPO_BASE_URL=http://docker.for.mac.localhost:8080/fcrepo/rest/
+FCREPO_BASE_URL=http://repository:8080/fcrepo/rest/
 
 # --- config/environments/*.rb
 # base URL of the IIIF server (which serves the manifests, images, and viewer)
@@ -25,7 +23,7 @@ LDAP_BIND_DN=uid=libr-fedora,cn=auth,ou=ldap,dc=umd,dc=edu
 
 # --- config/stomp.yml
 # STOMP_HOST=localhost
-STOMP_HOST=docker.for.mac.localhost
+STOMP_HOST=activemq
 STOMP_PORT=61613
 
 # Used by the STOMP listener to generate the URL of the Archelon web application

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ styleguide/
 
 # Docker configuration file
 docker-archelon.env
+
+# vendor bundles
+vendor/bundle


### PR DESCRIPTION
- only forward port 3000 (for the Archelon webapp)
- set the EXPORT_BASE_DESTINATION to an exports directory in the local workspace
- attach to the umd-fcrepo_default network, so that we can use the docker compose service names (repository, activemq, solr-fedora4, etc.)
- update .gitignore to ignore vendored bundles

https://umd-dit.atlassian.net/browse/LIBHYDRA-543