### PR TITLE
LIBHYDRA-559. Item detail page button updates.

### DIFF
--- a/app/views/mirador/_show.html.erb
+++ b/app/views/mirador/_show.html.erb
@@ -11,7 +11,6 @@
         <%= form.submit "Unpublish", name: 'command', class: 'btn btn-primary' %>
       <% else %>
         <%= form.submit "Publish", name: 'command', class: 'btn btn-primary' %>
-        <%= form.submit "Publish Hidden", name: 'command', class: 'btn btn-primary' %>
       <% end %>
     <% end %>
 

--- a/app/views/mirador/_show.html.erb
+++ b/app/views/mirador/_show.html.erb
@@ -3,7 +3,7 @@
     <a href="#metadata">Go to Metadata</a>
     <% if @show_edit_metadata %>
       &nbsp;
-      <a href="<%= resource_edit_url(id: @document.id) %>">Edit Metadata</a>
+      <a href="<%= resource_edit_url(id: @document.id) %>" class="btn btn-default">Edit Metadata</a>
     <% end %>
 
     <%= form_with url: update_resource_url(@document.id), method: :post, data: {remote: false}, class: 'publish-controls' do |form| %>


### PR DESCRIPTION
On the item detail page:

* Changed the styling of the “Edit Metadata” link to appear as a button; used a white interior to differentiate it from the “Publish” button
* Removed the “Publish Hidden” button

https://umd-dit.atlassian.net/browse/LIBHYDRA-559