### PR TITLE
LIBFCREPO-1302. Updated .env.development for VS Code Dev container

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -2,7 +2,7 @@
 SOLR_URL=http://solr-fedora4:8983/solr/fedora4
 
 # --- config/environments/*.rb
-FCREPO_BASE_URL=http://repository:8080/fcrepo/rest/
+FCREPO_BASE_URL=http://fcrepo-local:8080/fcrepo/rest
 
 # --- config/environments/*.rb
 # base URL of the IIIF server (which serves the manifests, images, and viewer)


### PR DESCRIPTION
Modified the "FCREPO_BASE_URL" property in the ".env.development" file to `http://fcrepo-local:8080/fcrepo/rest`, which is the value needed when running Archelon in a VS Code Dev container, which is currently the only supported way to run Archelon on a local workstation.

https://umd-dit.atlassian.net/browse/LIBFCREPO-1302