### PR TITLE
LIBHYDRA-568: Moving publish buttons underneath the check for metadata

### DIFF
--- a/app/views/mirador/_show.html.erb
+++ b/app/views/mirador/_show.html.erb
@@ -4,15 +4,17 @@
     <% if @show_edit_metadata %>
       &nbsp;
       <a href="<%= resource_edit_url(id: @document.id) %>" class="btn btn-default">Edit Metadata</a>
-    <% end %>
 
-    <%= form_with url: update_resource_url(@document.id), method: :post, data: {remote: false}, class: 'publish-controls' do |form| %>
-      <% if @published %>
-        <%= form.submit "Unpublish", name: 'command', class: 'btn btn-primary' %>
-      <% else %>
-        <%= form.submit "Publish", name: 'command', class: 'btn btn-primary' %>
+      <%= form_with url: update_resource_url(@document.id), method: :post, data: {remote: false}, class: 'publish-controls' do |form| %>
+        <% if @published %>
+          <%= form.submit "Unpublish", name: 'command', class: 'btn btn-primary' %>
+        <% else %>
+          <%= form.submit "Publish", name: 'command', class: 'btn btn-primary' %>
+        <% end %>
       <% end %>
     <% end %>
+
+
 
   </div>
   <div class="image-viewer intrinsic-container ratio-4x3">


### PR DESCRIPTION
This ensures that Pages or Articles do not have the publish buttons appear for them.

https://umd-dit.atlassian.net/browse/LIBHYDRA-568