### PR TITLE
LIBHYDRA-572. Updated ControlledURIRef to handle unsetting value

### DIFF
--- a/app/javascript/components/ControlledURIRef.jsx
+++ b/app/javascript/components/ControlledURIRef.jsx
@@ -49,8 +49,9 @@ class ControlledURIRef extends React.Component {
     }
 
     // If uri is not in vocabulary, append it to the vocabulary so that it
-    // shows up in the dropdown
-    if (!isUriInVocabulary) {
+    // shows up in the dropdown. Do not add if the uri is the empty value,
+    // as a separate "empty" option is added by default.
+    if (!isUriInVocabulary && this.state.uri !== "") {
       props.vocab[this.state.uri] = this.state.uri;
     }
 

--- a/app/javascript/components/ControlledURIRef.jsx
+++ b/app/javascript/components/ControlledURIRef.jsx
@@ -76,6 +76,11 @@ class ControlledURIRef extends React.Component {
     let statement = this.getStatement(this.state.uri);
     let valueIsUnchanged = (this.initialStatement === statement);
 
+    // valueIsUnset is for the case where there was an initial non-empty value
+    // and the user has chosen the empty value. This should disable the
+    // "insert" hidden field, so that a SPARQL INSERT statement is not generated
+    let valueIsUnset = (this.state.uri === "");
+
     let entries = Object.entries(this.props.vocab).map(([uri, label]) => ([uri, label]));
     const sortStringValues = (a, b) => (a[1] > b[1] && 1) || (a[1] === b[1] ? 0 : -1)
     entries.sort(sortStringValues); // Note: sort is "in-place"
@@ -83,7 +88,7 @@ class ControlledURIRef extends React.Component {
     return (
       <React.Fragment>
         <input type="hidden" name="delete[]" value={this.initialStatement} disabled={this.props.value.isNew || this.noStartingValue || valueIsUnchanged}/>
-        <input type="hidden" name="insert[]" value={statement} disabled={valueIsUnchanged}/>
+        <input type="hidden" name="insert[]" value={statement} disabled={valueIsUnchanged || valueIsUnset}/>
         <select name={this.props.name} value={this.state.uri} onChange={this.handleChange}>
           <option key="" value=""/>
           {entries.map(([uri, label]) => (


### PR DESCRIPTION
1) Modified the ControlledURIRef React component to disable the hidden
"insert" field when the user selects the "empty" option in drop-down
list.

This is done so that when the "empty" option is chosen, the
generated SPAQRL only contains a "DELETE" statement.

Prior to this change the SPARQL query should generate both a "DELETE"
statement, and an "INSERT" statement of the form:

```
INSERT { <subjectURI> <predicateURI> <> . }
```

which resulted in the <subjectURI> being used for the node field.

This change fixes the validation issue seen in Plastron, because no
value is being inserted, so validator that checks whether the new value
is in the vocabulary is not triggered.

2) Modified the ControlledURIRef component to remove a duplicate "empty"
option that occurs when the initial value of field is the empty value.

This was occurring because the "empty" value is not in the vocabulary,
and so gets added to the vocabulary in the constructor, while the
React component template also contains an "empty" option field.

Modified the ControlledURIRef component so that the initial field value
does not get added to the vocabulary if it is an empty string.

https://umd-dit.atlassian.net/browse/LIBHYDRA-572