### PR TITLE
LIBHYDRA-577: Updating about controller to ping Solr

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,6 +1,20 @@
 # frozen_string_literal: true
-
 class StaticPagesController < ApplicationController
   def about
+    # A simple ping to SOLR to see if it's running
+    begin
+      uri = URI(ENV['SOLR_URL'])
+      Net::HTTP.get(uri)
+    rescue Errno::ECONNREFUSED => e
+      solr_connection_error(e)
+    rescue SocketError => e
+      solr_connection_error(e)
+    end
   end
+
+  private
+    def solr_connection_error(err)
+      Rails.logger.error(err.message)
+      flash[:error] = I18n.t(:solr_is_down)
+    end
 end


### PR DESCRIPTION
When visiting the about page, pinging solr so that when refreshing the user can be sure that Solr is back up again. Previously refreshing the page would have user's think the service was back up. Now a flash screen will appear on refresh's of the page.

https://umd-dit.atlassian.net/browse/LIBHYDRA-577