### PR TITLE
LIBHYDRA-77. Limit initial number of pcdm:members displayed

### DIFF
--- a/app/views/catalog/_show_default.html.erb
+++ b/app/views/catalog/_show_default.html.erb
@@ -57,10 +57,28 @@
               </strong>
             <% end %>
             <ul class="multivalued-field-value">
-              <% subset.sort{|a,b| a['display_title'] <=> b['display_title']}.each do |v| %>
+              <% sorted_subset = subset.sort{|a,b| a['display_title'] <=> b['display_title']}
+                 # Split the sorted subset into "inital" and "more" lists,
+                 # to limit the number of items that are initally displayed.
+                 #
+                 # Hard-coding the limit, because setting up a configuration
+                 # setting for a single instance seems excessive
+                 item_limit = 8
+                 initial_list = sorted_subset.take(item_limit)
+                 more_list = sorted_subset.drop(item_limit)
+              %>
+              <% initial_list.each do |v| %>
                 <li><%= link_to v['display_title'], solr_document_path(v['id']) %></li>
               <% end %>
-            </ul>
+              <% unless more_list.empty? %>
+                <details>
+                  <summary style="display: list-item">More</summary>
+                  <% more_list.each do |v| %>
+                    <li><%= link_to v['display_title'], solr_document_path(v['id']) %></li>
+                  <% end %>
+                </details>
+              <% end %>
+         </ul>
           <% end %>
         </dd>
       <% elsif %w[pcdm_files pcdm_related_objects pcdm_related_object_of pcdm_member_of pcdm_file_of pcdm_collection annotation_source].include?(field_name) %>


### PR DESCRIPTION
Some items have tens or hundreds of "pcdm:members" (such as <https://archelon.lib.umd.edu/catalog/https:%2F%2Ffcrepo.lib.umd.edu%2Ffcrepo%2Frest%2Fdc%2F2023%2F1%2F31%2F26%2F3f%2F35%2F31263f35-6122-47d7-8c95-5566e5cbdee5>)

Since appears to be a "one-off" display issue, implemented the display handling within the "_show_default.html.erb" file itself, instead of doing anything fancier. The initial display limit of "8" is also hard-coded for the same reason.

In the "_show_default.html.erb" file, split the "pcdm_members" subset array into an "initial" list of (up to) 8 items, and a "more" list for any additional items. The "initial" list is display normally as "<li>" items in a "<ul>" unordered list.

If the "more" list has items, an HTML "Details disclosure" element is used with a "summary" of "More" to display the remaining items.

https://umd-dit.atlassian.net/browse/LIBHYDRA-77