### PR TITLE
LIBHYDRA-578. Updated .env.development for Docker-based Archelon

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,8 +1,19 @@
+# Entries in this file OVERRIDE entries in the ".env" file.
+#
+# This file is provides default values for non-workstation-specific,
+# non-secret environment variables for use in a development environment
+# consisting of Archelon running in a Docker container
+# and Plastron on a local workstation.
+#
+# Workstation-specific or private/secret environment variable settings should
+# be made in the ".env" file (which is generated from the "env_example" template
+# file).
+
 # --- config/blacklight.yml
 SOLR_URL=http://solr-fedora4:8983/solr/fedora4
 
 # --- config/environments/*.rb
-FCREPO_BASE_URL=http://repository:8080/fcrepo/rest/
+FCREPO_BASE_URL=http://fcrepo-local:8080/fcrepo/rest
 
 # --- config/environments/*.rb
 # base URL of the IIIF server (which serves the manifests, images, and viewer)
@@ -47,4 +58,8 @@ ARCHELON_DATABASE_ADAPTER=sqlite3
 ARCHELON_DATABASE_NAME=db/development.sqlite3
 ARCHELON_DATABASE_POOL=5
 
-PLASTRON_REST_BASE_URL=http://plastrond-http:5000/
+# --- config/imports.yml
+IMPORT_BINARIES_BASE_LOCATION=zip:../../archelon/imports
+
+# ---  config/initializers/plastron.rb
+PLASTRON_REST_BASE_URL=http://docker.for.mac.localhost:5000/

--- a/README.md
+++ b/README.md
@@ -107,7 +107,6 @@ functionality.
 2. Create a `.env` file from the `env_example` file, and adding these environment variables:
     - LDAP_BIND_PASSWORD (Obtained from LastPass)
     - FCREPO_AUTH_TOKEN (Obtained from generating a JWT token from the local fcrepo stack)
-    - PLASTRON_REST_BASE_URL=docker.for.mac.localhost:5000/
 
 3. Run yarn install
     ```bash


### PR DESCRIPTION
Updated the following environment variables in the ".env.development" configuration file with default values for a Docker-based Archelon interacting with a workstation-local Plastron:

* FCREPO_BASE_URL
* PLASTRON_REST_BASE_URL

Added "IMPORT_BINARIES_BASE_LOCATION" environment variable with default value, to support importing binaries via Archelon.

https://umd-dit.atlassian.net/browse/LIBHYDRA-578