### PR TITLE
LIBHYDRA-550. Identifier search implementation

### DIFF
--- a/app/views/catalog/_zero_results.html.erb
+++ b/app/views/catalog/_zero_results.html.erb
@@ -1,0 +1,16 @@
+<h2><%= t 'blacklight.search.zero_results.title' %></h2>
+<div id="documents" class="noresults">
+  <h3><%= t 'blacklight.search.zero_results.modify_search' %></h3>
+  <ul>
+    <li><%= t 'blacklight.search.zero_results.use_fewer_keywords' %></li>
+    <li><%= t 'blacklight.search.zero_results.identifier_search' %></li>
+    <li><%= t 'blacklight.search.zero_results.use_quotes_correctly' %></li>
+
+    <%- if params[:q] and params[:search_field] and params[:search_field] != blacklight_config.default_search_field.try(:key) -%>
+      <li><%= t 'blacklight.search.zero_results.search_fields', :search_fields => search_field_label(params) %> - 
+      <%= link_to t('blacklight.search.zero_results.search_everything', field: blacklight_config.default_search_field.label), url_for(search_state.params_for_search(search_field: blacklight_config.default_search_field.key)) %>
+      </li>
+    <%- end %>
+
+  </ul>
+</div>

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -47,3 +47,7 @@ en:
         title: 'Limit to'
       filters:
         none: 'Browse'
+      zero_results:
+        use_fewer_keywords: 'Use fewer keywords to start, then refine your search using the links on the left.'
+        identifier_search: 'When searching for pids or other identifiers, wrap them in quotes (eg: "umd:123", "hdl:1903.1/456", etc).'
+        use_quotes_correctly: 'Use quotes for identifier search as described above or for phrase search (search term(s) enclosed in quotes and does not contain any space will be processed as a identifier search.).'

--- a/test/controllers/catalog_controller_test.rb
+++ b/test/controllers/catalog_controller_test.rb
@@ -36,4 +36,58 @@ class CatalogControllerTest < ActionController::TestCase
     assert_not CatalogController.show_edit_metadata('Article')
     assert_not CatalogController.show_edit_metadata('Page')
   end
+
+  test 'should redirect to item detail page on identifier search with a single match' do
+    # Inject the stubbed search_results_mock into the controller
+    stub_search_results_single_result do
+      get :index, params: { q: '"test:123"' }
+
+      # Assert that the request was redirected to the show method with the correct ID param
+      assert_redirected_to(controller: 'catalog', action: 'show', id: 'http://fcrepo-test/123')
+    end
+  end
+
+  test 'should not redirect to item detail page regular search with a single match' do
+    # Inject the stubbed search_results_mock into the controller
+    stub_search_results_single_result do
+      get :index, params: { q: 'test' }
+
+      # Assert that the request was redirected to the show method with the correct ID param
+      assert_response(:success)
+    end
+  end
+
+  private
+
+    # Stubs the DownloadUrlsController.search_results call, so that it
+    # won't actually make a network call. Returns a sample SolrDocument
+    #
+    # Usage:
+    #
+    # stub_search_results do
+    #   <Code that calls "search_results">
+    # end
+    def stub_search_results_single_result
+      # Mock objects for response and document_list
+      bl_config = @controller.blacklight_config
+      response_mock = bl_config.response_model.new(mock_query_response('', 1, mock_solr_doc), {}, document_model: bl_config.document_model, blacklight_config: bl_config)
+      document_mock = SolrDocument.new(mock_solr_doc, response_mock)
+
+      # Stub the search_results method to return the desired values
+      stub_response = [response_mock, [document_mock]]
+
+      # byebug
+
+      @controller.stub :search_results, stub_response do
+        yield
+      end
+    end
+
+    def mock_query_response(query = '*:*', num_found = 0, doc = mock_solr_doc)
+      { 'responseHeader' => { 'status' => 0, 'QTime' => 12, 'params' => { 'f.author_not_tokenized.facet.limit' => '11', 'facet.field' => %w[collection_title_facet presentation_set_label author_not_tokenized type component_not_tokenized rdf_type visibility publication_status], 'hl' => 'true', 'f.presentation_set_label.facet.sort' => 'index', 'f.collection_title_facet.facet.limit' => '11', 'f.presentation_set_label.facet.limit' => '11', 'fq' => 'is_pcdm:true OR rdf_type:oa\\:Annotation', 'sort' => 'score desc, display_title asc', 'rows' => '10', 'f.extracted_text.hl.fragsize' => '500', 'q' => query, 'f.component_not_tokenized.facet.limit' => '11', 'f.rdf_type.facet.limit' => '11', 'f.type.facet.limit' => '11', 'hl.fl' => 'extracted_text', 'facet' => 'true', 'wt' => 'json', 'f.collection_title_facet.facet.sort' => 'index' } }, 'response' => { 'numFound' => num_found, 'start' => 0, 'maxScore' => 4.373658, 'docs' => [doc] }, 'facet_counts' => { 'facet_queries' => {}, 'facet_fields' => { 'collection_title_facet' => ['The Katherine Anne Porter Correspondence Collection', 1], 'presentation_set_label' => [], 'author_not_tokenized' => ['Porter, Katherine Anne, 1890-1980', 1], 'type' => [], 'component_not_tokenized' => ['Letter', 1], 'rdf_type' => ['bibo:Letter', 1, 'fedora:Container', 1, 'fedora:Resource', 1, 'ldp:Container', 1, 'ldp:RDFSource', 1, 'pcdm:Object', 1, 'umdaccess:Public', 1], 'visibility' => ['Visible', 1], 'publication_status' => ['Unpublished', 1] }, 'facet_ranges' => {}, 'facet_intervals' => {}, 'facet_heatmaps' => {} }, 'highlighting' => { 'http://fcrepo-test/fcrepo/rest/pcdm/dd/96/d9/b4/dd96d9b4-4fa5-4a85-81ff-7dc79100c6f9' => {} } }
+    end
+
+    def mock_solr_doc
+      { 'date' => '1948-07-19T00:00:00Z', 'extent' => ['1 page'], 'collection_title_facet' => ['Test Collection'], 'subject' => ['Porter, Katherine Anne, 1890-1980. Correspondence. Selections'], 'pcdm_members' => ['http://fcrepo-test/fcrepo/rest/pcdm/ed/6b/2e/63/ed6b2e63-fbd1-496c-8ba0-4879b90feb75'], 'geoname' => ['http://sws.geonames.org/5000306'], 'id' => 'http://fcrepo-test/123', 'last_modified' => '2024-04-19T15:15:56.118Z', 'identifier' => ['umd:85589'], 'created' => '2023-10-04T18:26:39.423Z', 'author' => ['Porter, Katherine Anne, 1890-1980'], 'author_not_tokenized' => ['Porter, Katherine Anne, 1890-1980'], 'collection' => ['http://fcrepo-test/fcrepo/rest/pcdm/3c/8e/8e/70/3c8e8e70-863c-4ac1-9819-139051292800'], 'created_by' => 'plastron', 'description' => ['Letter from Katherine Anne Porter to Gay Porter Holloway, July 19, 1948, typed. From Ann Heintze papers, Series 1, Box 1, Folder 7, Item 7. For complete collection information, visit the full finding aid at http://hdl.handle.net/1903.1/1497.'], 'title' => ['Letter from Katherine Anne Porter to Gay Porter Holloway, July 19, 1948'], 'rights' => ['http://rightsstatements.org/vocab/InC-NC/1.0/'], 'pcdm_member_of' => ['http://fcrepo-test/fcrepo/rest/pcdm/3c/8e/8e/70/3c8e8e70-863c-4ac1-9819-139051292800'], 'citation' => ['Ann Heintze papers, Series 1, Box 1, Folder 7, Item 7'], 'author_with_uri' => ['Porter, Katherine Anne, 1890-1980|http://viaf.org/viaf/56620604'], 'last_modified_by' => 'http://xmlns.com/foaf/0.1/Agent', 'recipient' => ['Holloway, Gay Porter, 1885-1969'], 'recipient_not_tokenized' => ['Holloway, Gay Porter, 1885-1969'], 'location' => ['Ludington, Michigan'], 'location_not_tokenized' => ['Ludington, Michigan'], 'recipient_with_uri' => ['Holloway, Gay Porter, 1885-1969|'], 'rdf_type' => ['fedora:Container', 'fedora:Resource', 'pcdm:Object', 'bibo:Letter', 'umdaccess:Public', 'ldp:Container', 'ldp:RDFSource'], 'is_pcdm' => true, 'component' => 'Letter', 'component_not_tokenized' => 'Letter', 'display_title' => 'Letter from Katherine Anne Porter to Gay Porter Holloway, July 19, 1948', 'display_date' => '1948-07-19', 'sort_date' => '1948-07-19', 'date_month' => '06::July', 'date_year' => 1948, 'date_decade' => '1940 - 1949', 'genre' => ['Letters'], 'timestamp' => '2023-10-04T18:26:44.313Z', 'is_published' => false, 'is_hidden' => false, 'is_top_level' => false, 'publication_status' => 'Unpublished', 'visibility' => 'Visible', 'is_discoverable' => false, '_version_' => 1_796_776_664_202_477_600, 'score' => 4.373658, 'annotation_source_info' => { 'numFound' => 0, 'start' => 0, 'docs' => [] } }
+    end
 end

--- a/test/controllers/publish_jobs_controller_test.rb
+++ b/test/controllers/publish_jobs_controller_test.rb
@@ -2,13 +2,6 @@
 
 require 'test_helper'
 
-# Monkey Patching the fetch method to return SolrDocuments
-module Blacklight::SearchHelper
-  def fetch(*)
-    [nil, SolrDocument.new]
-  end
-end
-
 # frozen_string_literal: true
 class PublishJobsControllerTest < ActionController::TestCase
   setup do
@@ -61,20 +54,22 @@ class PublishJobsControllerTest < ActionController::TestCase
     publish_job.state = 1
     publish_job.save!
 
-    get :show, params: { id: PublishJob.first.id }
+    @controller.stub :fetch, [nil, SolrDocument.new] do
+      get :show, params: { id: PublishJob.first.id }
 
-    job = assigns(:job)
-    hidden = assigns(:hidden)
-    published = assigns(:published)
-    unpublished = assigns(:unpublished)
-    result_documents = assigns(:result_documents)
+      job = assigns(:job)
+      hidden = assigns(:hidden)
+      published = assigns(:published)
+      unpublished = assigns(:unpublished)
+      result_documents = assigns(:result_documents)
 
-    assert_equal job.cas_user.cas_directory_id, @cas_user.cas_directory_id
-    assert job.publish == true
-    assert_equal job.state, 'publish_not_submitted'
-    assert_equal hidden, 0
-    assert_equal published, 0
-    assert_equal unpublished, 2
-    assert_equal result_documents.length, 2
+      assert_equal job.cas_user.cas_directory_id, @cas_user.cas_directory_id
+      assert job.publish == true
+      assert_equal job.state, 'publish_not_submitted'
+      assert_equal hidden, 0
+      assert_equal published, 0
+      assert_equal unpublished, 2
+      assert_equal result_documents.length, 2
+    end
   end
 end

--- a/test/helpers/umd_lib_environment_banner_helper_test.rb
+++ b/test/helpers/umd_lib_environment_banner_helper_test.rb
@@ -114,6 +114,11 @@ class UMDLibEnvironmentBannerHelperTest < ActiveSupport::TestCase
     Rails.env = 'test'
     ENV.clear
 
+    # The 'MT_KWARGS_HACK' env is set in test_helper.rb for ruby 2.7
+    # compatibility, so we need to add it back after clearing the ENV for this
+    # test
+    ENV['MT_KWARGS_HACK'] = '1'
+
     UMDLibEnvironmentBannerHelper.reset
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -35,6 +35,11 @@ class ActiveSupport::TestCase
   # Default user for testing has Admin privileges
   DEFAULT_TEST_USER = 'test_admin'
 
+  # Fix MiniTest stub errors Enable kwargs support to allow minitest to work
+  # with ruby 2.7:
+  #  https://github.com/minitest/minitest/blob/master/History.rdoc#5161--2022-06-20-
+  ENV['MT_KWARGS_HACK'] = '1'
+
   OmniAuth.config.test_mode = true
   OmniAuth.config.mock_auth[:cas] = {
     provider: 'cas',


### PR DESCRIPTION
- Support identifier search.
- Added test to verify redirect behavior for successful identifier search.
- Set MT_KWARGS_HACK in test_helper to workaround Minitest stubbing issues with Ruby 2.7
- Refactored PublishJobsControllerTest to use stubbing instead of monkey patching.

https://umd-dit.atlassian.net/browse/LIBHYDRA-550