### PR TITLE
LIBHYDRA-571. Display the "Handle" field in Archelon

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -27,6 +27,11 @@ MIRADOR_STATIC_VERSION=1.3.0
 # This should include the entire URL except for the token
 RETRIEVE_BASE_URL=http://archelon-local:3000/retrieve/
 
+# The base URL (including a trailing slash) for the handle proxy server
+# associated with this application.
+# For example: "https://hdl-test.lib.umd.edu/"
+HANDLE_HTTP_PROXY_BASE=http://hdl-local/
+
 # --- config/ldap.yml
 LDAP_HOST=directory.umd.edu
 LDAP_PORT=636

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -147,6 +147,8 @@ module ApplicationHelper # rubocop:disable Metrics/ModuleLength
   end
 
   def display_node(node, field, items) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/MethodLength, Metrics/LineLength
+    return display_handle(node) if field[:datatype] == 'http://vocab.lib.umd.edu/datatype#handle'
+
     if node.key? '@value'
       content = content_tag :span, node['@value']
       content << ' ' << language_badge(node) if node.key? '@language'
@@ -183,5 +185,20 @@ module ApplicationHelper # rubocop:disable Metrics/ModuleLength
     else
       node
     end
+  end
+
+  # Display formatting for the "handle" field
+  def display_handle(node)
+    handle_value = node['@value'].delete_prefix('hdl:')
+
+    content = content_tag :span, handle_value
+
+    if ENV['HANDLE_HTTP_PROXY_BASE'].present?
+      handle_server_base_url = ENV['HANDLE_HTTP_PROXY_BASE']
+      handle_url = URI.join(handle_server_base_url, handle_value).to_s
+      content << ' - ' << link_to(handle_url, handle_url) << ''
+    end
+
+    content
   end
 end

--- a/app/helpers/resource_helper.rb
+++ b/app/helpers/resource_helper.rb
@@ -1,16 +1,18 @@
 # frozen_string_literal: true
 
 module ResourceHelper
-  # generate a lookup hash of (predicate, datatype) => fieldname
-  def uri_to_fieldname(fields)
-    Hash[fields.map { |field| [[field[:uri], field[:datatype]], field[:name]] }]
-  end
+  # # generate a lookup hash of (predicate, datatype) => fieldname
+  # def uri_to_fieldname(fields)
+  #   Hash[fields.map { |field| [[field[:uri], field[:datatype]], field[:name]] }]
+  # end
 
-  def get_field_values(fields, item, predicate_uri)
+  def get_field_values(item, field)
     # for fields with a particular datatype, check the value type as well as the predicate URI
-    (item[predicate_uri] || []).select do |value|
-      uri_to_fieldname(fields).include?([predicate_uri, value['@type']])
-    end
+    field_predicate_uri = field[:uri]
+    item_values_for_predicate = item[field_predicate_uri] || []
+
+    field_data_type = field[:datatype]
+    item_values_for_predicate.select { |value| value['@type'] == field_data_type }
   end
 
   def define_react_components(fields, items, uri) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
@@ -24,7 +26,7 @@ module ResourceHelper
         # ... and key them by their predicate
         predicateURI: field[:uri],
         componentType: field[:type],
-        values: get_field_values(fields, item, field[:uri])
+        values: get_field_values(item, field)
       }.tap do |args|
         args[:vocab] = get_vocab_hash(field) if field[:vocab].present?
         args[:maxValues] = 1 unless field[:repeatable]

--- a/app/views/catalog/_show_default.html.erb
+++ b/app/views/catalog/_show_default.html.erb
@@ -19,7 +19,7 @@
           end
           values = item.fetch('@type', []).select { |uri| terms.include? uri }.map { |uri| { '@id' => uri } }
         else
-          values = get_field_values(fields, item, field[:uri])
+          values = get_field_values(item, field)
         end
       %>
       <% unless values.empty? %>

--- a/config/content_models.yml
+++ b/config/content_models.yml
@@ -120,6 +120,12 @@ Item:
       type: :TypedLiteral
       datatype: http://vocab.lib.umd.edu/datatype#accessionNumber
 
+    - name: 'handle'
+      uri: 'http://purl.org/dc/terms/identifier'
+      label: 'Handle'
+      type: :TypedLiteral
+      datatype: http://vocab.lib.umd.edu/datatype#handle
+
     - name: 'presentation_set'
       uri: 'http://www.openarchives.org/ore/terms/isAggregatedBy'
       label: 'Presentation Set'

--- a/env_example
+++ b/env_example
@@ -23,6 +23,11 @@ MIRADOR_STATIC_VERSION = '1.3.0'
 # This should include the entire URL except for the token
 RETRIEVE_BASE_URL=http://archelon-local:3000/retrieve/
 
+# The base URL (including a trailing slash) for the handle proxy server
+# associated with this application.
+# For example: "https://hdl-test.lib.umd.edu/"
+HANDLE_HTTP_PROXY_BASE=
+
 # --- config/ldap.yml
 # LDAP Authentication Credentials
 LDAP_HOST=

--- a/test/fixtures/files/sample_vocabularies/form.json
+++ b/test/fixtures/files/sample_vocabularies/form.json
@@ -1,0 +1,414 @@
+{
+  "@context": {
+    "owl": "http://www.w3.org/2002/07/owl#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "dc": "http://purl.org/dc/elements/1.1/"
+  },
+  "@graph": [
+    {
+      "@id": "http://vocab.lib.umd.edu/form#photographs",
+      "rdfs:label": "Photographs",
+      "dc:identifier": "photographs",
+      "owl:sameAs": {
+        "@id": "http://id.loc.gov/authorities/genreForms/gf2017027249"
+      }
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#newspapers",
+      "rdfs:label": "Newspapers",
+      "dc:identifier": "newspapers",
+      "owl:sameAs": {
+        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026132"
+      }
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#rosters",
+      "rdfs:label": "Rosters",
+      "dc:identifier": "rosters",
+      "owl:sameAs": {
+        "@id": "http://vocab.getty.edu/page/aat/300027178"
+      }
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#maps",
+      "rdfs:label": "Maps",
+      "dc:identifier": "maps",
+      "owl:sameAs": {
+        "@id": "http://id.loc.gov/authorities/genreForms/gf2011026387"
+      }
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#greeting_cards",
+      "rdfs:label": "Greeting cards",
+      "dc:identifier": "greeting_cards",
+      "owl:sameAs": {
+        "@id": "http://vocab.getty.edu/page/aat/300026778"
+      }
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#catalogs",
+      "rdfs:label": "Catalogs",
+      "dc:identifier": "catalogs",
+      "owl:sameAs": {
+        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026057"
+      }
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#paintings",
+      "rdfs:label": "Paintings (visual works)",
+      "dc:identifier": "paintings",
+      "owl:sameAs": {
+        "@id": "http://vocab.getty.edu/page/aat/300033618"
+      }
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#architectural_drawings",
+      "rdfs:label": "Architectural drawings (visual works)",
+      "dc:identifier": "architectural_drawings",
+      "owl:sameAs": {
+        "@id": "http://vocab.getty.edu/page/aat/300034787"
+      }
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#property_records",
+      "rdfs:label": "Property records",
+      "dc:identifier": "property_records",
+      "owl:sameAs": {
+        "@id": "http://vocab.getty.edu/page/aat/300027243"
+      }
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#programs",
+      "rdfs:label": "Programs (publications)",
+      "dc:identifier": "programs",
+      "owl:sameAs": {
+        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026156"
+      }
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#nonfiction_films",
+      "rdfs:label": "Nonfiction films",
+      "dc:identifier": "nonfiction_films",
+      "owl:sameAs": {
+        "@id": "http://id.loc.gov/authorities/genreForms/gf2011026423"
+      }
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#art",
+      "rdfs:label": "Art",
+      "dc:identifier": "art",
+      "owl:sameAs": {
+        "@id": "http://id.loc.gov/authorities/genreForms/gf2017027218"
+      }
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#fanzines",
+      "rdfs:label": "Fanzines",
+      "dc:identifier": "fanzines",
+      "owl:sameAs": {
+        "@id": "http://vocab.getty.edu/page/aat/300252980"
+      }
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#spoken_word",
+      "rdfs:label": "Spoken word poetry",
+      "dc:identifier": "spoken_word",
+      "owl:sameAs": {
+        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026552"
+      }
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#sculpture",
+      "rdfs:label": "Sculpture (visual works)",
+      "dc:identifier": "sculpture",
+      "owl:sameAs": {
+        "@id": "http://vocab.getty.edu/page/aat/300047090"
+      }
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#prints",
+      "rdfs:label": "Prints (visual works)",
+      "dc:identifier": "prints",
+      "owl:sameAs": {
+        "@id": "http://vocab.getty.edu/page/aat/300041273"
+      }
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#drama",
+      "rdfs:label": "Drama",
+      "dc:identifier": "drama",
+      "owl:sameAs": {
+        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026297"
+      }
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#drawings",
+      "rdfs:label": "Drawings",
+      "dc:identifier": "drawings",
+      "owl:sameAs": {
+        "@id": "http://id.loc.gov/authorities/genreForms/gf2017027231"
+      }
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#chapbooks",
+      "rdfs:label": "Chapbooks",
+      "dc:identifier": "chapbooks",
+      "owl:sameAs": {
+        "@id": "http://vocab.getty.edu/page/aat/300152367"
+      }
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#research_notes",
+      "rdfs:label": "Research notes",
+      "dc:identifier": "research_notes",
+      "owl:sameAs": {
+        "@id": "http://vocab.getty.edu/page/aat/300265639"
+      }
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#transcripts",
+      "rdfs:label": "Transcripts",
+      "dc:identifier": "transcripts",
+      "owl:sameAs": {
+        "@id": "http://vocab.getty.edu/page/aat/300027388"
+      }
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#certificates",
+      "rdfs:label": "Certificates",
+      "dc:identifier": "certificates",
+      "owl:sameAs": {
+        "@id": "http://vocab.getty.edu/page/aat/300026841"
+      }
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#ephemera",
+      "rdfs:label": "Ephemera",
+      "dc:identifier": "ephemera",
+      "owl:sameAs": {
+        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026093"
+      }
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#speeches",
+      "rdfs:label": "Speeches",
+      "dc:identifier": "speeches",
+      "owl:sameAs": {
+        "@id": "http://id.loc.gov/authorities/genreForms/gf2011026363"
+      }
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#broadsides_notices",
+      "rdfs:label": "Broadsides (notices)",
+      "dc:identifier": "broadsides_notices",
+      "owl:sameAs": {
+        "@id": "http://vocab.getty.edu/page/aat/300026739"
+      }
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#conference_papers",
+      "rdfs:label": "Conference papers and proceedings",
+      "dc:identifier": "conference_papers",
+      "owl:sameAs": {
+        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026068"
+      }
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#scrapbooks",
+      "rdfs:label": "Scrapbooks",
+      "dc:identifier": "scrapbooks",
+      "owl:sameAs": {
+        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026173"
+      }
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#business_correspondence",
+      "rdfs:label": "Business correspondence",
+      "dc:identifier": "business_correspondence",
+      "owl:sameAs": {
+        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026054"
+      }
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#records",
+      "rdfs:label": "Records (documents)",
+      "dc:identifier": "records",
+      "owl:sameAs": {
+        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026163"
+      }
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#newspaper_clippings",
+      "rdfs:label": "Newspaper clippings",
+      "dc:identifier": "newspaper_clippings",
+      "owl:sameAs": {
+        "@id": "http://vocab.getty.edu/page/aat/300429554"
+      }
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#postcards",
+      "rdfs:label": "Postcards",
+      "dc:identifier": "postcards",
+      "owl:sameAs": {
+        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026151"
+      }
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#sheet_music",
+      "rdfs:label": "Sheet music",
+      "dc:identifier": "sheet_music",
+      "owl:sameAs": {
+        "@id": "http://vocab.getty.edu/page/aat/300026430"
+      }
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#personal_correspondence",
+      "rdfs:label": "Personal correspondence",
+      "dc:identifier": "personal_correspondence",
+      "owl:sameAs": {
+        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026141"
+      }
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#books",
+      "rdfs:label": "Books",
+      "dc:identifier": "books",
+      "owl:sameAs": {
+        "@id": "http://vocab.getty.edu/page/aat/300028051"
+      }
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#diaries",
+      "rdfs:label": "Diaries",
+      "dc:identifier": "diaries",
+      "owl:sameAs": {
+        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026085"
+      }
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#manuscripts",
+      "rdfs:label": "Manuscripts (documents)",
+      "dc:identifier": "manuscripts",
+      "owl:sameAs": {
+        "@id": "http://vocab.getty.edu/page/aat/300028569"
+      }
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#periodicals",
+      "rdfs:label": "Periodicals",
+      "dc:identifier": "periodicals",
+      "owl:sameAs": {
+        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026139"
+      }
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#essays",
+      "rdfs:label": "Essays",
+      "dc:identifier": "essays",
+      "owl:sameAs": {
+        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026094"
+      }
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#yearbooks",
+      "rdfs:label": "School yearbooks",
+      "dc:identifier": "yearbooks",
+      "owl:sameAs": {
+        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026172"
+      }
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#photograph_albums",
+      "rdfs:label": "Photograph albums",
+      "dc:identifier": "photograph_albums",
+      "owl:sameAs": {
+        "@id": "http://vocab.getty.edu/page/aat/300026695"
+      }
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#pool_reports",
+      "rdfs:label": "Pool reports",
+      "dc:identifier": "pool_reports"
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#fliers_ephemera",
+      "rdfs:label": "Fliers (ephemera)",
+      "dc:identifier": "fliers_ephemera",
+      "owl:sameAs": {
+        "@id": "http://id.loc.gov/authorities/genreForms/gf2017026133"
+      }
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#illustrated_works",
+      "rdfs:label": "Illustrated works",
+      "dc:identifier": "illustrated_works",
+      "owl:sameAs": {
+        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026111"
+      }
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#poetry",
+      "rdfs:label": "Poetry",
+      "dc:identifier": "poetry",
+      "owl:sameAs": {
+        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026481"
+      }
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#newsletters",
+      "rdfs:label": "Newsletters",
+      "dc:identifier": "newsletters",
+      "owl:sameAs": {
+        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026131"
+      }
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#scores",
+      "rdfs:label": "Scores",
+      "dc:identifier": "scores",
+      "owl:sameAs": {
+        "@id": "http://id.loc.gov/authorities/genreForms/gf2014027077"
+      }
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#slides_photographs",
+      "rdfs:label": "Slides (photographs)",
+      "dc:identifier": "slides_photographs",
+      "owl:sameAs": {
+        "@id": "http://vocab.getty.edu/page/aat/300128371"
+      }
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#negatives",
+      "rdfs:label": "Negatives (photographs)",
+      "dc:identifier": "negatives",
+      "owl:sameAs": {
+        "@id": "http://id.loc.gov/authorities/genreForms/gf2019026026"
+      }
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#posters",
+      "rdfs:label": "Posters",
+      "dc:identifier": "posters",
+      "owl:sameAs": {
+        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026152"
+      }
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#exhibition_catalogs",
+      "rdfs:label": "Exhibition catalogs",
+      "dc:identifier": "exhibition_catalogs",
+      "owl:sameAs": {
+        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026098"
+      }
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#pamphlets",
+      "rdfs:label": "Pamphlets",
+      "dc:identifier": "pamphlets",
+      "owl:sameAs": {
+        "@id": "http://vocab.getty.edu/page/aat/300220572"
+      }
+    }
+  ]
+}

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ApplicationHelperTest < ActionView::TestCase
+  include ApplicationHelper, ResourceHelper
+  def setup
+    @item_content_model = CONTENT_MODELS[:Item]
+
+    @sample_items={
+      "http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643"=>{
+        "http://fedora.info/definitions/v4/repository#created"=>[{"@value"=>"2024-04-26T13:10:24.331Z", "@type"=>"http://www.w3.org/2001/XMLSchema#dateTime"}],
+        "http://purl.org/dc/terms/rights"=>[{"@id"=>"http://vocab.lib.umd.edu/rightsStatement#InC-NC"}],
+        "http://www.iana.org/assignments/relation/last"=>[{"@id"=>"http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643/x/brC8J_6K"}],
+        "http://pcdm.org/models#hasMember"=>[{"@id"=>"http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643/m/AMXxF4CM"}],
+        "http://www.w3.org/ns/ldp#contains"=>[{"@id"=>"http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643/m"}, {"@id"=>"http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643/x"}],
+        "http://www.europeana.eu/schemas/edm/hasType"=>[{"@id"=>"http://vocab.lib.umd.edu/form#photographs"}],
+        "@type"=>["http://fedora.info/definitions/v4/repository#Resource", "http://www.w3.org/ns/ldp#RDFSource", "http://fedora.info/definitions/v4/repository#Container", "http://vocab.lib.umd.edu/access#Campus", "http://vocab.lib.umd.edu/access#Published", "http://pcdm.org/models#Object", "http://vocab.lib.umd.edu/model#Item", "http://www.w3.org/ns/ldp#Container"],
+        "http://fedora.info/definitions/v4/repository#lastModifiedBy"=>[{"@value"=>"plastron"}],
+        "http://purl.org/dc/terms/identifier"=>[{"@value"=>"univarch-028986-0001"}, {"@value"=>"hdl:1903.1/1", "@type"=>"http://vocab.lib.umd.edu/datatype#handle"}, {"@value"=>"2008-51", "@type"=>"http://vocab.lib.umd.edu/datatype#accessionNumber"}],
+        "http://www.iana.org/assignments/relation/first"=>[{"@id"=>"http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643/x/brC8J_6K"}],
+        "http://purl.org/dc/terms/title"=>[{"@value"=>"Sample Title"}],
+        "http://fedora.info/definitions/v4/repository#createdBy"=>[{"@value"=>"plastron"}],
+        "http://purl.org/dc/terms/publisher"=>[{"@id"=>"http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643#dc376873-0d58-462d-a3b7-5d22b42655fc"}],
+        "http://purl.org/dc/terms/isPartOf"=>[{"@id"=>"http://vocab.lib.umd.edu/collection#0211-UA"}],
+        "http://purl.org/dc/terms/creator"=>[{"@id"=>"http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643#f003df99-400a-474e-a720-1d3596e068d0"}],
+        "http://purl.org/dc/terms/bibliographicCitation"=>[{"@value"=>"Sample Bibliographic Citation"}],
+        "http://fedora.info/definitions/v4/repository#hasParent"=>[{"@id"=>"http://fcrepo-local:8080/fcrepo/rest/dc/2021/2"}],
+        "http://purl.org/dc/elements/1.1/date"=>[{"@value"=>"1994-11-23"}],
+        "http://purl.org/dc/terms/rightsHolder"=>[{"@id"=>"http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643#14982574-c1b4-4bb9-a94f-801a422b4637"}],
+        "http://fedora.info/definitions/v4/repository#lastModified"=>[{"@value"=>"2024-04-26T19:09:47.092Z", "@type"=>"http://www.w3.org/2001/XMLSchema#dateTime"}],
+        "http://purl.org/dc/terms/type"=>[{"@id"=>"http://purl.org/dc/dcmitype/Image"}],
+        "http://purl.org/dc/terms/subject"=>[{"@id"=>"http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643#ef3035aa-85c1-45bf-b3a2-0047289942c6"}, {"@id"=>"http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643#c9b313f2-82aa-485f-8f63-4e126cdfc5d3"}],
+        "http://purl.org/dc/terms/description"=>[{"@value"=>"Sample Description"}],
+        "http://pcdm.org/models#memberOf"=>[{"@id"=>"http://fcrepo-local:8080/fcrepo/rest/dc/2021/2"}],
+        "http://fedora.info/definitions/v4/repository#writable"=>[{"@value"=>true}],
+
+        "http://purl.org/dc/terms/alternative"=>[{"@value"=>"Sample Alternate Title", "@language"=>"en"}],
+        "http://purl.org/dc/terms/contributor"=>[{"@id"=>"http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643#492870b8-525c-4308-9e42-7aa6e974cbf0"}],
+        "http://purl.org/dc/terms/spatial"=>[{"@id"=>"http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643#4b959803-b739-4425-ae0b-68500e249fd8"}],
+        "http://purl.org/dc/terms/extent"=>[{"@value"=>"Sample Extent", "@language"=>"en"}],
+        "http://purl.org/dc/elements/1.1/language"=>[{"@value"=>"en"}],
+        "http://www.openarchives.org/ore/terms/isAggregatedBy"=>[{"@id"=>"http://vocab.lib.umd.edu/set#test"}],
+        "http://purl.org/dc/terms/spatial"=>[{"@id"=>"http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643#4b959803-b739-4425-ae0b-68500e249fd8"}],
+      },
+
+      "http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643#14982574-c1b4-4bb9-a94f-801a422b4637"=>{"http://www.w3.org/2000/01/rdf-schema#label"=>[{"@value"=>"Sample Rights Holder"}]},
+      "http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643#c9b313f2-82aa-485f-8f63-4e126cdfc5d3"=>{"http://www.w3.org/2000/01/rdf-schema#label"=>[{"@value"=>"Sample Subject 2"}]},
+      "http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643#dc376873-0d58-462d-a3b7-5d22b42655fc"=>{"http://www.w3.org/2000/01/rdf-schema#label"=>[{"@value"=>"Sample Publisher"}]},
+      "http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643#ef3035aa-85c1-45bf-b3a2-0047289942c6"=>{"http://www.w3.org/2000/01/rdf-schema#label"=>[{"@value"=>"Sample Subject 1"}]},
+      "http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643#f003df99-400a-474e-a720-1d3596e068d0"=>{"http://www.w3.org/2000/01/rdf-schema#label"=>[{"@value"=>"Sample Creator"}]},
+
+      "http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643#492870b8-525c-4308-9e42-7aa6e974cbf0"=>{"http://www.w3.org/2000/01/rdf-schema#label"=>[{"@value"=>"Sample Contributor", "@language"=>"en"}]},
+      "http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643#4b959803-b739-4425-ae0b-68500e249fd8"=>{"http://www.w3.org/2002/07/owl#sameAs"=>[{"@id"=>"http://sws.geonames.org/5000306"}], "http://www.w3.org/2000/01/rdf-schema#label"=>[{"@value"=>"Sample Location", "@language"=>"en"}]},
+    }
+
+    @sample_item_id = 'http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643'
+    @sample_item = @sample_items[@sample_item_id]
+  end
+
+  test 'display_node' do
+    object_type_field = { name: 'object_type', uri: 'http://purl.org/dc/terms/type', label: 'Object Type', type: :ControlledURIRef }
+    identifier_field = { name: 'identifier', uri: 'http://purl.org/dc/terms/identifier', label: 'Identifier', type: :TypedLiteral, repeatable: true }
+    rights_field = { name: 'rights', uri: 'http://purl.org/dc/terms/rights', label: 'Rights Statement', type: :ControlledURIRef, vocab: 'rightsStatement' }
+    title_field = { name: 'title', uri: 'http://purl.org/dc/terms/title', label: 'Title', type: :PlainLiteral, repeatable: true }
+    access_field = { name: 'access', label: 'Access Level', type: :ControlledURIRef, vocab: 'access', terms: ['Public', 'Campus'] }
+
+    format_field = { name: 'format', uri: 'http://www.europeana.eu/schemas/edm/hasType', label: 'Format', type: :ControlledURIRef, vocab: 'form', repeatable: true }
+
+    creator_field = { name: 'creator', uri: 'http://purl.org/dc/terms/creator', label: 'Creator', type: :LabeledThing, repeatable: true }
+    location_field = { name: 'location', uri: 'http://purl.org/dc/terms/spatial', label: 'Location', type: :LabeledThing, repeatable: true }
+    handle_field = { name: 'handle', uri: 'http://purl.org/dc/terms/identifier', label: 'Handle', type: :TypedLiteral, datatype: 'http://vocab.lib.umd.edu/datatype#handle' }
+
+
+    expected = [
+      # object_type_field - :ControlledURIRef, no vocabulary
+      [object_type_field, '<a href="http://purl.org/dc/dcmitype/Image">http://purl.org/dc/dcmitype/Image</a>'],
+      # identifier_field - :TypedLiteral
+      [identifier_field, '<span>univarch-028986-0001</span>' ],
+      # rights_field - :ControlledURIRef, "rightsStatement" vocabulary, "same as" entry
+      [rights_field, '<span>In Copyright - Non-Commercial Use Permitted</span> → <a href="http://rightsstatements.org/vocab/InC-NC/1.0/">http://rightsstatements.org/vocab/InC-NC/1.0/</a>'],
+      # title_field - :PlainLiteral
+      [title_field, '<span>Sample Title</span>'],
+      # access_field - :ControlledURIRef, "access" vocabulary, defined terms
+      [access_field, '<span>Campus</span>'],
+      # format_field - :ControlledURIRef, "form" vocabulary
+      [format_field,'<span>Photographs</span> → <a href="http://id.loc.gov/authorities/genreForms/gf2017027249">http://id.loc.gov/authorities/genreForms/gf2017027249</a>'],
+      # creator_field - :LabeledThing
+      [creator_field, '<span><span>Sample Creator</span></span>'],
+      # location_field - :LabeledThing, "same as" entry
+      [location_field, '<span>Sample Location</span> <span class="badge badge-light" style="background: #ddd; color: #333">en</span> → <a href="http://sws.geonames.org/5000306">http://sws.geonames.org/5000306</a>'],
+      # handle_field - :TypedLiteral, "datatype" entry
+      [handle_field, '<span>hdl:1903.1/1</span> <a class="badge badge-light" style="background: #ddd; color: #333" href="http://vocab.lib.umd.edu/datatype#handle">http://vocab.lib.umd.edu/datatype#handle</a>'],
+    ]
+
+    expected.each do |expect|
+      field, expected_value = *expect
+
+      stub_vocabulary_server(field)
+      item_values = get_item_values(field, @sample_item)
+
+      node = item_values.first
+      assert_equal expected_value, display_node(node, field, @sample_items), "Unexpected value returned for '#{field[:name]}' field"
+    end
+  end
+
+  # Helper methods
+
+  # Stubs the call to the vocabulary server, if used by the field.
+  # Replaces the call by retrieving the appropriate vocabulary fixture file.
+  def stub_vocabulary_server(field)
+    if field[:vocab]
+      # Stub the call to the vocabulary server, using a sample vocabulary
+      # from the file fixtures instead.
+      json_fixture_file = "sample_vocabularies/#{field[:vocab]}.json"
+      stub_request(:get, /.*/)
+        .to_return(status: 200, body: file_fixture(json_fixture_file).read, headers: {})
+    end
+  end
+
+  # Return the actual values from the item for the given field.
+  # This method duplicates the logic in the
+  # "app/views/catalog/_show_default.html.erb" file
+  def get_item_values(field, item)
+    if field[:name] == 'access'
+      vocab = VocabularyService.get_vocabulary(field[:vocab])
+      if field.key? :terms
+        terms = field[:terms].map { |term| vocab.uri + term }
+      else
+        terms = vocab.terms.map { |term| term.uri }
+      end
+
+      item_values = item.fetch('@type', []).select { |uri| terms.include? uri }.map { |uri| { '@id' => uri } }
+    else
+      item_values = get_field_values(item, field)
+    end
+    item_values
+  end
+end

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -3,67 +3,68 @@
 require 'test_helper'
 
 class ApplicationHelperTest < ActionView::TestCase
-  include ApplicationHelper, ResourceHelper
-  def setup
+  include ApplicationHelper
+  include ResourceHelper
+
+  def setup # rubocop:disable Metrics/MethodLength
     @item_content_model = CONTENT_MODELS[:Item]
 
-    @sample_items={
-      "http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643"=>{
-        "http://fedora.info/definitions/v4/repository#created"=>[{"@value"=>"2024-04-26T13:10:24.331Z", "@type"=>"http://www.w3.org/2001/XMLSchema#dateTime"}],
-        "http://purl.org/dc/terms/rights"=>[{"@id"=>"http://vocab.lib.umd.edu/rightsStatement#InC-NC"}],
-        "http://www.iana.org/assignments/relation/last"=>[{"@id"=>"http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643/x/brC8J_6K"}],
-        "http://pcdm.org/models#hasMember"=>[{"@id"=>"http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643/m/AMXxF4CM"}],
-        "http://www.w3.org/ns/ldp#contains"=>[{"@id"=>"http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643/m"}, {"@id"=>"http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643/x"}],
-        "http://www.europeana.eu/schemas/edm/hasType"=>[{"@id"=>"http://vocab.lib.umd.edu/form#photographs"}],
-        "@type"=>["http://fedora.info/definitions/v4/repository#Resource", "http://www.w3.org/ns/ldp#RDFSource", "http://fedora.info/definitions/v4/repository#Container", "http://vocab.lib.umd.edu/access#Campus", "http://vocab.lib.umd.edu/access#Published", "http://pcdm.org/models#Object", "http://vocab.lib.umd.edu/model#Item", "http://www.w3.org/ns/ldp#Container"],
-        "http://fedora.info/definitions/v4/repository#lastModifiedBy"=>[{"@value"=>"plastron"}],
-        "http://purl.org/dc/terms/identifier"=>[{"@value"=>"univarch-028986-0001"}, {"@value"=>"hdl:1903.1/1", "@type"=>"http://vocab.lib.umd.edu/datatype#handle"}, {"@value"=>"2008-51", "@type"=>"http://vocab.lib.umd.edu/datatype#accessionNumber"}],
-        "http://www.iana.org/assignments/relation/first"=>[{"@id"=>"http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643/x/brC8J_6K"}],
-        "http://purl.org/dc/terms/title"=>[{"@value"=>"Sample Title"}],
-        "http://fedora.info/definitions/v4/repository#createdBy"=>[{"@value"=>"plastron"}],
-        "http://purl.org/dc/terms/publisher"=>[{"@id"=>"http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643#dc376873-0d58-462d-a3b7-5d22b42655fc"}],
-        "http://purl.org/dc/terms/isPartOf"=>[{"@id"=>"http://vocab.lib.umd.edu/collection#0211-UA"}],
-        "http://purl.org/dc/terms/creator"=>[{"@id"=>"http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643#f003df99-400a-474e-a720-1d3596e068d0"}],
-        "http://purl.org/dc/terms/bibliographicCitation"=>[{"@value"=>"Sample Bibliographic Citation"}],
-        "http://fedora.info/definitions/v4/repository#hasParent"=>[{"@id"=>"http://fcrepo-local:8080/fcrepo/rest/dc/2021/2"}],
-        "http://purl.org/dc/elements/1.1/date"=>[{"@value"=>"1994-11-23"}],
-        "http://purl.org/dc/terms/rightsHolder"=>[{"@id"=>"http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643#14982574-c1b4-4bb9-a94f-801a422b4637"}],
-        "http://fedora.info/definitions/v4/repository#lastModified"=>[{"@value"=>"2024-04-26T19:09:47.092Z", "@type"=>"http://www.w3.org/2001/XMLSchema#dateTime"}],
-        "http://purl.org/dc/terms/type"=>[{"@id"=>"http://purl.org/dc/dcmitype/Image"}],
-        "http://purl.org/dc/terms/subject"=>[{"@id"=>"http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643#ef3035aa-85c1-45bf-b3a2-0047289942c6"}, {"@id"=>"http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643#c9b313f2-82aa-485f-8f63-4e126cdfc5d3"}],
-        "http://purl.org/dc/terms/description"=>[{"@value"=>"Sample Description"}],
-        "http://pcdm.org/models#memberOf"=>[{"@id"=>"http://fcrepo-local:8080/fcrepo/rest/dc/2021/2"}],
-        "http://fedora.info/definitions/v4/repository#writable"=>[{"@value"=>true}],
+    @sample_items = {
+      'http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643' => {
+        'http://fedora.info/definitions/v4/repository#created' => [{ '@value' => '2024-04-26T13:10:24.331Z', '@type' => 'http://www.w3.org/2001/XMLSchema#dateTime' }],
+        'http://purl.org/dc/terms/rights' => [{ '@id' => 'http://vocab.lib.umd.edu/rightsStatement#InC-NC' }],
+        'http://www.iana.org/assignments/relation/last' => [{ '@id' => 'http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643/x/brC8J_6K' }],
+        'http://pcdm.org/models#hasMember' => [{ '@id' => 'http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643/m/AMXxF4CM' }],
+        'http://www.w3.org/ns/ldp#contains' => [{ '@id' => 'http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643/m' }, { '@id' => 'http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643/x' }],
+        'http://www.europeana.eu/schemas/edm/hasType' => [{ '@id' => 'http://vocab.lib.umd.edu/form#photographs' }],
+        '@type' => ['http://fedora.info/definitions/v4/repository#Resource', 'http://www.w3.org/ns/ldp#RDFSource', 'http://fedora.info/definitions/v4/repository#Container', 'http://vocab.lib.umd.edu/access#Campus', 'http://vocab.lib.umd.edu/access#Published', 'http://pcdm.org/models#Object', 'http://vocab.lib.umd.edu/model#Item', 'http://www.w3.org/ns/ldp#Container'],
+        'http://fedora.info/definitions/v4/repository#lastModifiedBy' => [{ '@value' => 'plastron' }],
+        'http://purl.org/dc/terms/identifier' => [{ '@value' => 'univarch-028986-0001' }, { '@value' => 'hdl:1903.1/1', '@type' => 'http://vocab.lib.umd.edu/datatype#handle' }, { '@value' => '2008-51', '@type' => 'http://vocab.lib.umd.edu/datatype#accessionNumber' }],
+        'http://www.iana.org/assignments/relation/first' => [{ '@id' => 'http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643/x/brC8J_6K' }],
+        'http://purl.org/dc/terms/title' => [{ '@value' => 'Sample Title' }],
+        'http://fedora.info/definitions/v4/repository#createdBy' => [{ '@value' => 'plastron' }],
+        'http://purl.org/dc/terms/publisher' => [{ '@id' => 'http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643#dc376873-0d58-462d-a3b7-5d22b42655fc' }],
+        'http://purl.org/dc/terms/isPartOf' => [{ '@id' => 'http://vocab.lib.umd.edu/collection#0211-UA' }],
+        'http://purl.org/dc/terms/creator' => [{ '@id' => 'http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643#f003df99-400a-474e-a720-1d3596e068d0' }],
+        'http://purl.org/dc/terms/bibliographicCitation' => [{ '@value' => 'Sample Bibliographic Citation' }],
+        'http://fedora.info/definitions/v4/repository#hasParent' => [{ '@id' => 'http://fcrepo-local:8080/fcrepo/rest/dc/2021/2' }],
+        'http://purl.org/dc/elements/1.1/date' => [{ '@value' => '1994-11-23' }],
+        'http://purl.org/dc/terms/rightsHolder' => [{ '@id' => 'http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643#14982574-c1b4-4bb9-a94f-801a422b4637' }],
+        'http://fedora.info/definitions/v4/repository#lastModified' => [{ '@value' => '2024-04-26T19:09:47.092Z', '@type' => 'http://www.w3.org/2001/XMLSchema#dateTime' }],
+        'http://purl.org/dc/terms/type' => [{ '@id' => 'http://purl.org/dc/dcmitype/Image' }],
+        'http://purl.org/dc/terms/subject' => [{ '@id' => 'http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643#ef3035aa-85c1-45bf-b3a2-0047289942c6' }, { '@id' => 'http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643#c9b313f2-82aa-485f-8f63-4e126cdfc5d3' }],
+        'http://purl.org/dc/terms/description' => [{ '@value' => 'Sample Description' }],
+        'http://pcdm.org/models#memberOf' => [{ '@id' => 'http://fcrepo-local:8080/fcrepo/rest/dc/2021/2' }],
+        'http://fedora.info/definitions/v4/repository#writable' => [{ '@value' => true }],
 
-        "http://purl.org/dc/terms/alternative"=>[{"@value"=>"Sample Alternate Title", "@language"=>"en"}],
-        "http://purl.org/dc/terms/contributor"=>[{"@id"=>"http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643#492870b8-525c-4308-9e42-7aa6e974cbf0"}],
-        "http://purl.org/dc/terms/spatial"=>[{"@id"=>"http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643#4b959803-b739-4425-ae0b-68500e249fd8"}],
-        "http://purl.org/dc/terms/extent"=>[{"@value"=>"Sample Extent", "@language"=>"en"}],
-        "http://purl.org/dc/elements/1.1/language"=>[{"@value"=>"en"}],
-        "http://www.openarchives.org/ore/terms/isAggregatedBy"=>[{"@id"=>"http://vocab.lib.umd.edu/set#test"}],
-        "http://purl.org/dc/terms/spatial"=>[{"@id"=>"http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643#4b959803-b739-4425-ae0b-68500e249fd8"}],
+        'http://purl.org/dc/terms/alternative' => [{ '@value' => 'Sample Alternate Title', '@language' => 'en' }],
+        'http://purl.org/dc/terms/contributor' => [{ '@id' => 'http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643#492870b8-525c-4308-9e42-7aa6e974cbf0' }],
+        'http://purl.org/dc/terms/spatial' => [{ '@id' => 'http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643#4b959803-b739-4425-ae0b-68500e249fd8' }],
+        'http://purl.org/dc/terms/extent' => [{ '@value' => 'Sample Extent', '@language' => 'en' }],
+        'http://purl.org/dc/elements/1.1/language' => [{ '@value' => 'en' }],
+        'http://www.openarchives.org/ore/terms/isAggregatedBy' => [{ '@id' => 'http://vocab.lib.umd.edu/set#test' }]
       },
 
-      "http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643#14982574-c1b4-4bb9-a94f-801a422b4637"=>{"http://www.w3.org/2000/01/rdf-schema#label"=>[{"@value"=>"Sample Rights Holder"}]},
-      "http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643#c9b313f2-82aa-485f-8f63-4e126cdfc5d3"=>{"http://www.w3.org/2000/01/rdf-schema#label"=>[{"@value"=>"Sample Subject 2"}]},
-      "http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643#dc376873-0d58-462d-a3b7-5d22b42655fc"=>{"http://www.w3.org/2000/01/rdf-schema#label"=>[{"@value"=>"Sample Publisher"}]},
-      "http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643#ef3035aa-85c1-45bf-b3a2-0047289942c6"=>{"http://www.w3.org/2000/01/rdf-schema#label"=>[{"@value"=>"Sample Subject 1"}]},
-      "http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643#f003df99-400a-474e-a720-1d3596e068d0"=>{"http://www.w3.org/2000/01/rdf-schema#label"=>[{"@value"=>"Sample Creator"}]},
+      'http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643#14982574-c1b4-4bb9-a94f-801a422b4637' => { 'http://www.w3.org/2000/01/rdf-schema#label' => [{ '@value' => 'Sample Rights Holder' }] },
+      'http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643#c9b313f2-82aa-485f-8f63-4e126cdfc5d3' => { 'http://www.w3.org/2000/01/rdf-schema#label' => [{ '@value' => 'Sample Subject 2' }] },
+      'http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643#dc376873-0d58-462d-a3b7-5d22b42655fc' => { 'http://www.w3.org/2000/01/rdf-schema#label' => [{ '@value' => 'Sample Publisher' }] },
+      'http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643#ef3035aa-85c1-45bf-b3a2-0047289942c6' => { 'http://www.w3.org/2000/01/rdf-schema#label' => [{ '@value' => 'Sample Subject 1' }] },
+      'http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643#f003df99-400a-474e-a720-1d3596e068d0' => { 'http://www.w3.org/2000/01/rdf-schema#label' => [{ '@value' => 'Sample Creator' }] },
 
-      "http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643#492870b8-525c-4308-9e42-7aa6e974cbf0"=>{"http://www.w3.org/2000/01/rdf-schema#label"=>[{"@value"=>"Sample Contributor", "@language"=>"en"}]},
-      "http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643#4b959803-b739-4425-ae0b-68500e249fd8"=>{"http://www.w3.org/2002/07/owl#sameAs"=>[{"@id"=>"http://sws.geonames.org/5000306"}], "http://www.w3.org/2000/01/rdf-schema#label"=>[{"@value"=>"Sample Location", "@language"=>"en"}]},
+      'http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643#492870b8-525c-4308-9e42-7aa6e974cbf0' => { 'http://www.w3.org/2000/01/rdf-schema#label' => [{ '@value' => 'Sample Contributor', '@language' => 'en' }] },
+      'http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643#4b959803-b739-4425-ae0b-68500e249fd8' => { 'http://www.w3.org/2002/07/owl#sameAs' => [{ '@id' => 'http://sws.geonames.org/5000306' }], 'http://www.w3.org/2000/01/rdf-schema#label' => [{ '@value' => 'Sample Location', '@language' => 'en' }] }
     }
 
     @sample_item_id = 'http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643'
     @sample_item = @sample_items[@sample_item_id]
   end
 
-  test 'display_node' do
+  test 'display_node' do # rubocop:disable Metrics/BlockLength
     object_type_field = { name: 'object_type', uri: 'http://purl.org/dc/terms/type', label: 'Object Type', type: :ControlledURIRef }
     identifier_field = { name: 'identifier', uri: 'http://purl.org/dc/terms/identifier', label: 'Identifier', type: :TypedLiteral, repeatable: true }
     rights_field = { name: 'rights', uri: 'http://purl.org/dc/terms/rights', label: 'Rights Statement', type: :ControlledURIRef, vocab: 'rightsStatement' }
     title_field = { name: 'title', uri: 'http://purl.org/dc/terms/title', label: 'Title', type: :PlainLiteral, repeatable: true }
-    access_field = { name: 'access', label: 'Access Level', type: :ControlledURIRef, vocab: 'access', terms: ['Public', 'Campus'] }
+    access_field = { name: 'access', label: 'Access Level', type: :ControlledURIRef, vocab: 'access', terms: ['Public', 'Campus'] } # rubocop:disable Style/WordArray
 
     format_field = { name: 'format', uri: 'http://www.europeana.eu/schemas/edm/hasType', label: 'Format', type: :ControlledURIRef, vocab: 'form', repeatable: true }
 
@@ -71,12 +72,11 @@ class ApplicationHelperTest < ActionView::TestCase
     location_field = { name: 'location', uri: 'http://purl.org/dc/terms/spatial', label: 'Location', type: :LabeledThing, repeatable: true }
     handle_field = { name: 'handle', uri: 'http://purl.org/dc/terms/identifier', label: 'Handle', type: :TypedLiteral, datatype: 'http://vocab.lib.umd.edu/datatype#handle' }
 
-
     expected = [
       # object_type_field - :ControlledURIRef, no vocabulary
       [object_type_field, '<a href="http://purl.org/dc/dcmitype/Image">http://purl.org/dc/dcmitype/Image</a>'],
       # identifier_field - :TypedLiteral
-      [identifier_field, '<span>univarch-028986-0001</span>' ],
+      [identifier_field, '<span>univarch-028986-0001</span>'],
       # rights_field - :ControlledURIRef, "rightsStatement" vocabulary, "same as" entry
       [rights_field, '<span>In Copyright - Non-Commercial Use Permitted</span> → <a href="http://rightsstatements.org/vocab/InC-NC/1.0/">http://rightsstatements.org/vocab/InC-NC/1.0/</a>'],
       # title_field - :PlainLiteral
@@ -84,13 +84,13 @@ class ApplicationHelperTest < ActionView::TestCase
       # access_field - :ControlledURIRef, "access" vocabulary, defined terms
       [access_field, '<span>Campus</span>'],
       # format_field - :ControlledURIRef, "form" vocabulary
-      [format_field,'<span>Photographs</span> → <a href="http://id.loc.gov/authorities/genreForms/gf2017027249">http://id.loc.gov/authorities/genreForms/gf2017027249</a>'],
+      [format_field, '<span>Photographs</span> → <a href="http://id.loc.gov/authorities/genreForms/gf2017027249">http://id.loc.gov/authorities/genreForms/gf2017027249</a>'],
       # creator_field - :LabeledThing
       [creator_field, '<span><span>Sample Creator</span></span>'],
       # location_field - :LabeledThing, "same as" entry
       [location_field, '<span>Sample Location</span> <span class="badge badge-light" style="background: #ddd; color: #333">en</span> → <a href="http://sws.geonames.org/5000306">http://sws.geonames.org/5000306</a>'],
       # handle_field - :TypedLiteral, "datatype" entry
-      [handle_field, '<span>hdl:1903.1/1</span> <a class="badge badge-light" style="background: #ddd; color: #333" href="http://vocab.lib.umd.edu/datatype#handle">http://vocab.lib.umd.edu/datatype#handle</a>'],
+      [handle_field, '<span>hdl:1903.1/1</span> <a class="badge badge-light" style="background: #ddd; color: #333" href="http://vocab.lib.umd.edu/datatype#handle">http://vocab.lib.umd.edu/datatype#handle</a>']
     ]
 
     expected.each do |expect|
@@ -109,25 +109,25 @@ class ApplicationHelperTest < ActionView::TestCase
   # Stubs the call to the vocabulary server, if used by the field.
   # Replaces the call by retrieving the appropriate vocabulary fixture file.
   def stub_vocabulary_server(field)
-    if field[:vocab]
-      # Stub the call to the vocabulary server, using a sample vocabulary
-      # from the file fixtures instead.
-      json_fixture_file = "sample_vocabularies/#{field[:vocab]}.json"
-      stub_request(:get, /.*/)
-        .to_return(status: 200, body: file_fixture(json_fixture_file).read, headers: {})
-    end
+    return unless field[:vocab]
+
+    # Stub the call to the vocabulary server, using a sample vocabulary
+    # from the file fixtures instead.
+    json_fixture_file = "sample_vocabularies/#{field[:vocab]}.json"
+    stub_request(:get, /.*/)
+      .to_return(status: 200, body: file_fixture(json_fixture_file).read, headers: {})
   end
 
   # Return the actual values from the item for the given field.
   # This method duplicates the logic in the
   # "app/views/catalog/_show_default.html.erb" file
-  def get_item_values(field, item)
+  def get_item_values(field, item) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
     if field[:name] == 'access'
       vocab = VocabularyService.get_vocabulary(field[:vocab])
-      if field.key? :terms
+      if field.key? :terms # rubocop:disable Style/ConditionalAssignment
         terms = field[:terms].map { |term| vocab.uri + term }
       else
-        terms = vocab.terms.map { |term| term.uri }
+        terms = vocab.terms.map { |term| term.uri } # rubocop:disable Style/SymbolProc
       end
 
       item_values = item.fetch('@type', []).select { |uri| terms.include? uri }.map { |uri| { '@id' => uri } }

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -7,6 +7,8 @@ class ApplicationHelperTest < ActionView::TestCase
   include ResourceHelper
 
   def setup # rubocop:disable Metrics/MethodLength
+    ENV['HANDLE_HTTP_PROXY_BASE'] = 'https://hdl.handle.net/'
+
     @item_content_model = CONTENT_MODELS[:Item]
 
     @sample_items = {
@@ -57,40 +59,40 @@ class ApplicationHelperTest < ActionView::TestCase
 
     @sample_item_id = 'http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643'
     @sample_item = @sample_items[@sample_item_id]
+
+    @fields = {
+      object_type: { name: 'object_type', uri: 'http://purl.org/dc/terms/type', label: 'Object Type', type: :ControlledURIRef },
+      identifier: { name: 'identifier', uri: 'http://purl.org/dc/terms/identifier', label: 'Identifier', type: :TypedLiteral, repeatable: true },
+      rights: { name: 'rights', uri: 'http://purl.org/dc/terms/rights', label: 'Rights Statement', type: :ControlledURIRef, vocab: 'rightsStatement' },
+      title: { name: 'title', uri: 'http://purl.org/dc/terms/title', label: 'Title', type: :PlainLiteral, repeatable: true },
+      access: { name: 'access', label: 'Access Level', type: :ControlledURIRef, vocab: 'access', terms: ['Public', 'Campus'] }, # rubocop:disable Style/WordArray
+      format: { name: 'format', uri: 'http://www.europeana.eu/schemas/edm/hasType', label: 'Format', type: :ControlledURIRef, vocab: 'form', repeatable: true },
+      creator: { name: 'creator', uri: 'http://purl.org/dc/terms/creator', label: 'Creator', type: :LabeledThing, repeatable: true },
+      location: { name: 'location', uri: 'http://purl.org/dc/terms/spatial', label: 'Location', type: :LabeledThing, repeatable: true },
+      handle: { name: 'handle', uri: 'http://purl.org/dc/terms/identifier', label: 'Handle', type: :TypedLiteral, datatype: 'http://vocab.lib.umd.edu/datatype#handle' }
+    }
   end
 
-  test 'display_node' do # rubocop:disable Metrics/BlockLength
-    object_type_field = { name: 'object_type', uri: 'http://purl.org/dc/terms/type', label: 'Object Type', type: :ControlledURIRef }
-    identifier_field = { name: 'identifier', uri: 'http://purl.org/dc/terms/identifier', label: 'Identifier', type: :TypedLiteral, repeatable: true }
-    rights_field = { name: 'rights', uri: 'http://purl.org/dc/terms/rights', label: 'Rights Statement', type: :ControlledURIRef, vocab: 'rightsStatement' }
-    title_field = { name: 'title', uri: 'http://purl.org/dc/terms/title', label: 'Title', type: :PlainLiteral, repeatable: true }
-    access_field = { name: 'access', label: 'Access Level', type: :ControlledURIRef, vocab: 'access', terms: ['Public', 'Campus'] } # rubocop:disable Style/WordArray
-
-    format_field = { name: 'format', uri: 'http://www.europeana.eu/schemas/edm/hasType', label: 'Format', type: :ControlledURIRef, vocab: 'form', repeatable: true }
-
-    creator_field = { name: 'creator', uri: 'http://purl.org/dc/terms/creator', label: 'Creator', type: :LabeledThing, repeatable: true }
-    location_field = { name: 'location', uri: 'http://purl.org/dc/terms/spatial', label: 'Location', type: :LabeledThing, repeatable: true }
-    handle_field = { name: 'handle', uri: 'http://purl.org/dc/terms/identifier', label: 'Handle', type: :TypedLiteral, datatype: 'http://vocab.lib.umd.edu/datatype#handle' }
-
+  test 'display_node' do
     expected = [
-      # object_type_field - :ControlledURIRef, no vocabulary
-      [object_type_field, '<a href="http://purl.org/dc/dcmitype/Image">http://purl.org/dc/dcmitype/Image</a>'],
-      # identifier_field - :TypedLiteral
-      [identifier_field, '<span>univarch-028986-0001</span>'],
-      # rights_field - :ControlledURIRef, "rightsStatement" vocabulary, "same as" entry
-      [rights_field, '<span>In Copyright - Non-Commercial Use Permitted</span> → <a href="http://rightsstatements.org/vocab/InC-NC/1.0/">http://rightsstatements.org/vocab/InC-NC/1.0/</a>'],
-      # title_field - :PlainLiteral
-      [title_field, '<span>Sample Title</span>'],
-      # access_field - :ControlledURIRef, "access" vocabulary, defined terms
-      [access_field, '<span>Campus</span>'],
-      # format_field - :ControlledURIRef, "form" vocabulary
-      [format_field, '<span>Photographs</span> → <a href="http://id.loc.gov/authorities/genreForms/gf2017027249">http://id.loc.gov/authorities/genreForms/gf2017027249</a>'],
-      # creator_field - :LabeledThing
-      [creator_field, '<span><span>Sample Creator</span></span>'],
-      # location_field - :LabeledThing, "same as" entry
-      [location_field, '<span>Sample Location</span> <span class="badge badge-light" style="background: #ddd; color: #333">en</span> → <a href="http://sws.geonames.org/5000306">http://sws.geonames.org/5000306</a>'],
-      # handle_field - :TypedLiteral, "datatype" entry
-      [handle_field, '<span>hdl:1903.1/1</span> <a class="badge badge-light" style="background: #ddd; color: #333" href="http://vocab.lib.umd.edu/datatype#handle">http://vocab.lib.umd.edu/datatype#handle</a>']
+      # object_type - :ControlledURIRef, no vocabulary
+      [@fields[:object_type], '<a href="http://purl.org/dc/dcmitype/Image">http://purl.org/dc/dcmitype/Image</a>'],
+      # identifier - :TypedLiteral
+      [@fields[:identifier], '<span>univarch-028986-0001</span>'],
+      # rights - :ControlledURIRef, "rightsStatement" vocabulary, "same as" entry
+      [@fields[:rights], '<span>In Copyright - Non-Commercial Use Permitted</span> → <a href="http://rightsstatements.org/vocab/InC-NC/1.0/">http://rightsstatements.org/vocab/InC-NC/1.0/</a>'],
+      # title - :PlainLiteral
+      [@fields[:title], '<span>Sample Title</span>'],
+      # access - :ControlledURIRef, "access" vocabulary, defined terms
+      [@fields[:access], '<span>Campus</span>'],
+      # format - :ControlledURIRef, "form" vocabulary
+      [@fields[:format], '<span>Photographs</span> → <a href="http://id.loc.gov/authorities/genreForms/gf2017027249">http://id.loc.gov/authorities/genreForms/gf2017027249</a>'],
+      # creator - :LabeledThing
+      [@fields[:creator], '<span><span>Sample Creator</span></span>'],
+      # location - :LabeledThing, "same as" entry
+      [@fields[:location], '<span>Sample Location</span> <span class="badge badge-light" style="background: #ddd; color: #333">en</span> → <a href="http://sws.geonames.org/5000306">http://sws.geonames.org/5000306</a>'],
+      # handle - :TypedLiteral, "datatype" entry
+      [@fields[:handle], '<span>1903.1/1</span> - <a href="https://hdl.handle.net/1903.1/1">https://hdl.handle.net/1903.1/1</a>']
     ]
 
     expected.each do |expect|
@@ -102,6 +104,26 @@ class ApplicationHelperTest < ActionView::TestCase
       node = item_values.first
       assert_equal expected_value, display_node(node, field, @sample_items), "Unexpected value returned for '#{field[:name]}' field"
     end
+  end
+
+  test 'display_handle when HANDLE_HTTP_PROXY_BASE is empty' do
+    item_values = get_item_values(@fields[:handle], @sample_item)
+    node = item_values.first
+    ENV['HANDLE_HTTP_PROXY_BASE'] = ''
+
+    content = display_handle(node)
+    expected = '<span>1903.1/1</span>'
+    assert_equal expected, content
+  end
+
+  test 'display_handle when HANDLE_HTTP_PROXY_BASE is populated' do
+    item_values = get_item_values(@fields[:handle], @sample_item)
+    node = item_values.first
+    ENV['HANDLE_HTTP_PROXY_BASE'] = 'https://hdl.handle.net/'
+
+    content = display_handle(node)
+    expected = '<span>1903.1/1</span> - <a href="https://hdl.handle.net/1903.1/1">https://hdl.handle.net/1903.1/1</a>'
+    assert_equal expected, content
   end
 
   # Helper methods

--- a/test/helpers/resource_helper_test.rb
+++ b/test/helpers/resource_helper_test.rb
@@ -3,10 +3,9 @@
 require 'test_helper'
 
 class ResourcerHelperTest < ActiveSupport::TestCase
-  def setup # rubocop:disable Metrics/MethodLength
-    @object = Object.new
-    @object.extend(ResourceHelper)
+  include ResourceHelper
 
+  def setup # rubocop:disable Metrics/MethodLength
     @item = {
       'http://fedora.info/definitions/v4/repository#created' => [{ '@value' => '2024-04-26T13:10:24.331Z', '@type' => 'http://www.w3.org/2001/XMLSchema#dateTime' }],
       'http://purl.org/dc/terms/rights' => [{ '@id' => 'http://vocab.lib.umd.edu/rightsStatement#InC-NC' }],
@@ -42,15 +41,15 @@ class ResourcerHelperTest < ActiveSupport::TestCase
     accession_field = { name: 'accession_number', uri: 'http://purl.org/dc/terms/identifier', label: 'Accession Number', type: :TypedLiteral, datatype: 'http://vocab.lib.umd.edu/datatype#accessionNumber' }
     handle_field = { name: 'handle', uri: 'http://purl.org/dc/terms/identifier', label: 'Handle', type: :TypedLiteral, datatype: 'http://vocab.lib.umd.edu/datatype#handle' }
 
-    identifier_result = @object.get_field_values(@item, identifier_field)
+    identifier_result = get_field_values(@item, identifier_field)
     expected = [{ '@value' => 'univarch-028986-0001' }]
     assert_equal expected, identifier_result
 
-    accession_result = @object.get_field_values(@item, accession_field)
+    accession_result = get_field_values(@item, accession_field)
     expected = [{ '@value' => '2008-51', '@type' => 'http://vocab.lib.umd.edu/datatype#accessionNumber' }]
     assert_equal expected, accession_result
 
-    handle_result = @object.get_field_values(@item, handle_field)
+    handle_result = get_field_values(@item, handle_field)
     expected = [{ '@value' => 'hdl:1903.1/1', '@type' => 'http://vocab.lib.umd.edu/datatype#handle' }]
     assert_equal expected, handle_result
   end

--- a/test/helpers/resource_helper_test.rb
+++ b/test/helpers/resource_helper_test.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ResourcerHelperTest < ActiveSupport::TestCase
+  def setup
+    @object = Object.new
+    @object.extend(ResourceHelper)
+
+    @item = {
+        "http://fedora.info/definitions/v4/repository#created"=>[{"@value"=>"2024-04-26T13:10:24.331Z", "@type"=>"http://www.w3.org/2001/XMLSchema#dateTime"}],
+        "http://purl.org/dc/terms/rights"=>[{"@id"=>"http://vocab.lib.umd.edu/rightsStatement#InC-NC"}],
+        "http://www.iana.org/assignments/relation/last"=>[{"@id"=>"http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643/x/brC8J_6K"}],
+        "http://pcdm.org/models#hasMember"=>[{"@id"=>"http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643/m/AMXxF4CM"}],
+        "http://www.w3.org/ns/ldp#contains"=>[{"@id"=>"http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643/m"}, {"@id"=>"http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643/x"}],
+        "http://www.europeana.eu/schemas/edm/hasType"=>[{"@id"=>"http://vocab.lib.umd.edu/form#photographs"}],
+        "@type"=>["http://fedora.info/definitions/v4/repository#Resource", "http://www.w3.org/ns/ldp#RDFSource", "http://fedora.info/definitions/v4/repository#Container", "http://vocab.lib.umd.edu/access#Published", "http://pcdm.org/models#Object", "http://vocab.lib.umd.edu/model#Item", "http://www.w3.org/ns/ldp#Container"],
+        "http://fedora.info/definitions/v4/repository#lastModifiedBy"=>[{"@value"=>"plastron"}],
+        "http://purl.org/dc/terms/identifier"=>[{"@value"=>"univarch-028986-0001"}, {"@value"=>"hdl:1903.1/1", "@type"=>"http://vocab.lib.umd.edu/datatype#handle"}, {"@value"=>"2008-51", "@type"=>"http://vocab.lib.umd.edu/datatype#accessionNumber"}],
+        "http://www.iana.org/assignments/relation/first"=>[{"@id"=>"http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643/x/brC8J_6K"}],
+        "http://purl.org/dc/terms/title"=>[{"@value"=>"Angel Guerra (#42), Maryland Terrapin defensive back, against Tyrone Davis (#82), University of Virginia wide receiver"}],
+        "http://fedora.info/definitions/v4/repository#createdBy"=>[{"@value"=>"plastron"}],
+        "http://purl.org/dc/terms/publisher"=>[{"@id"=>"http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643#dc376873-0d58-462d-a3b7-5d22b42655fc"}],
+        "http://purl.org/dc/terms/isPartOf"=>[{"@id"=>"http://vocab.lib.umd.edu/collection#0211-UA"}],
+        "http://purl.org/dc/terms/creator"=>[{"@id"=>"http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643#f003df99-400a-474e-a720-1d3596e068d0"}],
+        "http://purl.org/dc/terms/bibliographicCitation"=>[{"@value"=>"Diamondback Photos, Box 17, item 1439"}],
+        "http://fedora.info/definitions/v4/repository#hasParent"=>[{"@id"=>"http://fcrepo-local:8080/fcrepo/rest/dc/2021/2"}],
+        "http://purl.org/dc/elements/1.1/date"=>[{"@value"=>"1994-11-23"}],
+        "http://purl.org/dc/terms/rightsHolder"=>[{"@id"=>"http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643#14982574-c1b4-4bb9-a94f-801a422b4637"}],
+        "http://purl.org/dc/terms/type"=>[{"@id"=>"http://purl.org/dc/dcmitype/Image"}],
+        "http://purl.org/dc/terms/subject"=>[{"@id"=>"http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643#ef3035aa-85c1-45bf-b3a2-0047289942c6"}, {"@id"=>"http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643#c9b313f2-82aa-485f-8f63-4e126cdfc5d3"}],
+        "http://fedora.info/definitions/v4/repository#lastModified"=>[{"@value"=>"2024-04-26T13:40:09.436Z", "@type"=>"http://www.w3.org/2001/XMLSchema#dateTime"}],
+        "http://purl.org/dc/terms/description"=>[{"@value"=>"The Diamondback Photo Morgue consists of images taken for the primary University of Maryland student newspaper, The Diamondback. Photographers took multiple shots at various campus events, athletic games, and of general campus life. Some images were printed in the newspaper, others were kept on file. This collection covers the period from the early 1970s to the late 1990s."}],
+        "http://pcdm.org/models#memberOf"=>[{"@id"=>"http://fcrepo-local:8080/fcrepo/rest/dc/2021/2"}],
+        "http://fedora.info/definitions/v4/repository#writable"=>[{"@value"=>true}]
+    }
+  end
+
+  test 'get_field_values can distinguish values by datatype' do
+    #  Fields have same predicate, but different (or nil) datatypes
+    identifier_field = {name: "identifier", uri: "http://purl.org/dc/terms/identifier", label: "Identifier", type: :TypedLiteral, repeatable: true}
+    accession_field = {name: "accession_number", uri: "http://purl.org/dc/terms/identifier", label: "Accession Number", type: :TypedLiteral, datatype: "http://vocab.lib.umd.edu/datatype#accessionNumber"}
+    handle_field = {name: "handle", uri: "http://purl.org/dc/terms/identifier", label: "Handle", type: :TypedLiteral, datatype: "http://vocab.lib.umd.edu/datatype#handle"}
+
+    identifier_result = @object.get_field_values(@item, identifier_field)
+    expected = [{"@value"=>"univarch-028986-0001"}]
+    assert_equal expected, identifier_result
+
+    accession_result = @object.get_field_values(@item, accession_field)
+    expected = [{"@value"=>"2008-51", "@type"=>"http://vocab.lib.umd.edu/datatype#accessionNumber"}]
+    assert_equal expected, accession_result
+
+    handle_result = @object.get_field_values(@item, handle_field)
+    expected = [{"@value"=>"hdl:1903.1/1", "@type"=>"http://vocab.lib.umd.edu/datatype#handle"}]
+    assert_equal expected, handle_result
+  end
+end

--- a/test/helpers/resource_helper_test.rb
+++ b/test/helpers/resource_helper_test.rb
@@ -3,55 +3,55 @@
 require 'test_helper'
 
 class ResourcerHelperTest < ActiveSupport::TestCase
-  def setup
+  def setup # rubocop:disable Metrics/MethodLength
     @object = Object.new
     @object.extend(ResourceHelper)
 
     @item = {
-        "http://fedora.info/definitions/v4/repository#created"=>[{"@value"=>"2024-04-26T13:10:24.331Z", "@type"=>"http://www.w3.org/2001/XMLSchema#dateTime"}],
-        "http://purl.org/dc/terms/rights"=>[{"@id"=>"http://vocab.lib.umd.edu/rightsStatement#InC-NC"}],
-        "http://www.iana.org/assignments/relation/last"=>[{"@id"=>"http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643/x/brC8J_6K"}],
-        "http://pcdm.org/models#hasMember"=>[{"@id"=>"http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643/m/AMXxF4CM"}],
-        "http://www.w3.org/ns/ldp#contains"=>[{"@id"=>"http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643/m"}, {"@id"=>"http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643/x"}],
-        "http://www.europeana.eu/schemas/edm/hasType"=>[{"@id"=>"http://vocab.lib.umd.edu/form#photographs"}],
-        "@type"=>["http://fedora.info/definitions/v4/repository#Resource", "http://www.w3.org/ns/ldp#RDFSource", "http://fedora.info/definitions/v4/repository#Container", "http://vocab.lib.umd.edu/access#Published", "http://pcdm.org/models#Object", "http://vocab.lib.umd.edu/model#Item", "http://www.w3.org/ns/ldp#Container"],
-        "http://fedora.info/definitions/v4/repository#lastModifiedBy"=>[{"@value"=>"plastron"}],
-        "http://purl.org/dc/terms/identifier"=>[{"@value"=>"univarch-028986-0001"}, {"@value"=>"hdl:1903.1/1", "@type"=>"http://vocab.lib.umd.edu/datatype#handle"}, {"@value"=>"2008-51", "@type"=>"http://vocab.lib.umd.edu/datatype#accessionNumber"}],
-        "http://www.iana.org/assignments/relation/first"=>[{"@id"=>"http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643/x/brC8J_6K"}],
-        "http://purl.org/dc/terms/title"=>[{"@value"=>"Angel Guerra (#42), Maryland Terrapin defensive back, against Tyrone Davis (#82), University of Virginia wide receiver"}],
-        "http://fedora.info/definitions/v4/repository#createdBy"=>[{"@value"=>"plastron"}],
-        "http://purl.org/dc/terms/publisher"=>[{"@id"=>"http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643#dc376873-0d58-462d-a3b7-5d22b42655fc"}],
-        "http://purl.org/dc/terms/isPartOf"=>[{"@id"=>"http://vocab.lib.umd.edu/collection#0211-UA"}],
-        "http://purl.org/dc/terms/creator"=>[{"@id"=>"http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643#f003df99-400a-474e-a720-1d3596e068d0"}],
-        "http://purl.org/dc/terms/bibliographicCitation"=>[{"@value"=>"Diamondback Photos, Box 17, item 1439"}],
-        "http://fedora.info/definitions/v4/repository#hasParent"=>[{"@id"=>"http://fcrepo-local:8080/fcrepo/rest/dc/2021/2"}],
-        "http://purl.org/dc/elements/1.1/date"=>[{"@value"=>"1994-11-23"}],
-        "http://purl.org/dc/terms/rightsHolder"=>[{"@id"=>"http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643#14982574-c1b4-4bb9-a94f-801a422b4637"}],
-        "http://purl.org/dc/terms/type"=>[{"@id"=>"http://purl.org/dc/dcmitype/Image"}],
-        "http://purl.org/dc/terms/subject"=>[{"@id"=>"http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643#ef3035aa-85c1-45bf-b3a2-0047289942c6"}, {"@id"=>"http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643#c9b313f2-82aa-485f-8f63-4e126cdfc5d3"}],
-        "http://fedora.info/definitions/v4/repository#lastModified"=>[{"@value"=>"2024-04-26T13:40:09.436Z", "@type"=>"http://www.w3.org/2001/XMLSchema#dateTime"}],
-        "http://purl.org/dc/terms/description"=>[{"@value"=>"The Diamondback Photo Morgue consists of images taken for the primary University of Maryland student newspaper, The Diamondback. Photographers took multiple shots at various campus events, athletic games, and of general campus life. Some images were printed in the newspaper, others were kept on file. This collection covers the period from the early 1970s to the late 1990s."}],
-        "http://pcdm.org/models#memberOf"=>[{"@id"=>"http://fcrepo-local:8080/fcrepo/rest/dc/2021/2"}],
-        "http://fedora.info/definitions/v4/repository#writable"=>[{"@value"=>true}]
+      'http://fedora.info/definitions/v4/repository#created' => [{ '@value' => '2024-04-26T13:10:24.331Z', '@type' => 'http://www.w3.org/2001/XMLSchema#dateTime' }],
+      'http://purl.org/dc/terms/rights' => [{ '@id' => 'http://vocab.lib.umd.edu/rightsStatement#InC-NC' }],
+      'http://www.iana.org/assignments/relation/last' => [{ '@id' => 'http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643/x/brC8J_6K' }],
+      'http://pcdm.org/models#hasMember' => [{ '@id' => 'http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643/m/AMXxF4CM' }],
+      'http://www.w3.org/ns/ldp#contains' => [{ '@id' => 'http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643/m' }, { '@id' => 'http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643/x' }],
+      'http://www.europeana.eu/schemas/edm/hasType' => [{ '@id' => 'http://vocab.lib.umd.edu/form#photographs' }],
+      '@type' => ['http://fedora.info/definitions/v4/repository#Resource', 'http://www.w3.org/ns/ldp#RDFSource', 'http://fedora.info/definitions/v4/repository#Container', 'http://vocab.lib.umd.edu/access#Published', 'http://pcdm.org/models#Object', 'http://vocab.lib.umd.edu/model#Item', 'http://www.w3.org/ns/ldp#Container'],
+      'http://fedora.info/definitions/v4/repository#lastModifiedBy' => [{ '@value' => 'plastron' }],
+      'http://purl.org/dc/terms/identifier' => [{ '@value' => 'univarch-028986-0001' }, { '@value' => 'hdl:1903.1/1', '@type' => 'http://vocab.lib.umd.edu/datatype#handle' }, { '@value' => '2008-51', '@type' => 'http://vocab.lib.umd.edu/datatype#accessionNumber' }],
+      'http://www.iana.org/assignments/relation/first' => [{ '@id' => 'http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643/x/brC8J_6K' }],
+      'http://purl.org/dc/terms/title' => [{ '@value' => 'Angel Guerra (#42), Maryland Terrapin defensive back, against Tyrone Davis (#82), University of Virginia wide receiver' }],
+      'http://fedora.info/definitions/v4/repository#createdBy' => [{ '@value' => 'plastron' }],
+      'http://purl.org/dc/terms/publisher' => [{ '@id' => 'http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643#dc376873-0d58-462d-a3b7-5d22b42655fc' }],
+      'http://purl.org/dc/terms/isPartOf' => [{ '@id' => 'http://vocab.lib.umd.edu/collection#0211-UA' }],
+      'http://purl.org/dc/terms/creator' => [{ '@id' => 'http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643#f003df99-400a-474e-a720-1d3596e068d0' }],
+      'http://purl.org/dc/terms/bibliographicCitation' => [{ '@value' => 'Diamondback Photos, Box 17, item 1439' }],
+      'http://fedora.info/definitions/v4/repository#hasParent' => [{ '@id' => 'http://fcrepo-local:8080/fcrepo/rest/dc/2021/2' }],
+      'http://purl.org/dc/elements/1.1/date' => [{ '@value' => '1994-11-23' }],
+      'http://purl.org/dc/terms/rightsHolder' => [{ '@id' => 'http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643#14982574-c1b4-4bb9-a94f-801a422b4637' }],
+      'http://purl.org/dc/terms/type' => [{ '@id' => 'http://purl.org/dc/dcmitype/Image' }],
+      'http://purl.org/dc/terms/subject' => [{ '@id' => 'http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643#ef3035aa-85c1-45bf-b3a2-0047289942c6' }, { '@id' => 'http://fcrepo-local:8080/fcrepo/rest/dc/2021/2/37/3b/87/72/373b8772-881b-4f1f-91e2-8b6b4d04b643#c9b313f2-82aa-485f-8f63-4e126cdfc5d3' }],
+      'http://fedora.info/definitions/v4/repository#lastModified' => [{ '@value' => '2024-04-26T13:40:09.436Z', '@type' => 'http://www.w3.org/2001/XMLSchema#dateTime' }],
+      'http://purl.org/dc/terms/description' => [{ '@value' => 'The Diamondback Photo Morgue consists of images taken for the primary University of Maryland student newspaper, The Diamondback. Photographers took multiple shots at various campus events, athletic games, and of general campus life. Some images were printed in the newspaper, others were kept on file. This collection covers the period from the early 1970s to the late 1990s.' }],
+      'http://pcdm.org/models#memberOf' => [{ '@id' => 'http://fcrepo-local:8080/fcrepo/rest/dc/2021/2' }],
+      'http://fedora.info/definitions/v4/repository#writable' => [{ '@value' => true }]
     }
   end
 
   test 'get_field_values can distinguish values by datatype' do
     #  Fields have same predicate, but different (or nil) datatypes
-    identifier_field = {name: "identifier", uri: "http://purl.org/dc/terms/identifier", label: "Identifier", type: :TypedLiteral, repeatable: true}
-    accession_field = {name: "accession_number", uri: "http://purl.org/dc/terms/identifier", label: "Accession Number", type: :TypedLiteral, datatype: "http://vocab.lib.umd.edu/datatype#accessionNumber"}
-    handle_field = {name: "handle", uri: "http://purl.org/dc/terms/identifier", label: "Handle", type: :TypedLiteral, datatype: "http://vocab.lib.umd.edu/datatype#handle"}
+    identifier_field = { name: 'identifier', uri: 'http://purl.org/dc/terms/identifier', label: 'Identifier', type: :TypedLiteral, repeatable: true }
+    accession_field = { name: 'accession_number', uri: 'http://purl.org/dc/terms/identifier', label: 'Accession Number', type: :TypedLiteral, datatype: 'http://vocab.lib.umd.edu/datatype#accessionNumber' }
+    handle_field = { name: 'handle', uri: 'http://purl.org/dc/terms/identifier', label: 'Handle', type: :TypedLiteral, datatype: 'http://vocab.lib.umd.edu/datatype#handle' }
 
     identifier_result = @object.get_field_values(@item, identifier_field)
-    expected = [{"@value"=>"univarch-028986-0001"}]
+    expected = [{ '@value' => 'univarch-028986-0001' }]
     assert_equal expected, identifier_result
 
     accession_result = @object.get_field_values(@item, accession_field)
-    expected = [{"@value"=>"2008-51", "@type"=>"http://vocab.lib.umd.edu/datatype#accessionNumber"}]
+    expected = [{ '@value' => '2008-51', '@type' => 'http://vocab.lib.umd.edu/datatype#accessionNumber' }]
     assert_equal expected, accession_result
 
     handle_result = @object.get_field_values(@item, handle_field)
-    expected = [{"@value"=>"hdl:1903.1/1", "@type"=>"http://vocab.lib.umd.edu/datatype#handle"}]
+    expected = [{ '@value' => 'hdl:1903.1/1', '@type' => 'http://vocab.lib.umd.edu/datatype#handle' }]
     assert_equal expected, handle_result
   end
 end


### PR DESCRIPTION
Modified Archelon to display a "Handle" field on the item detail page when an item has a handle.

Implemented as follows:

* The "get_field_values" method in "resource_helper.rb" was not properly distinguishing item values based on the predicate and datatype. Instead, it would return all the values for a given predicate, irrespective of its datatype (meaning that if two fields had the same predicate, but different datatypes, each field would get both values).

    In fixing the "get_field_values" method to properly distinguish between datatypes, the "uri_to_fieldname" method turned out to be unnecessary, and the method signature itself was changed to only require an "item" parameter, and a "field" parameter (so both the field's predicate and datatype (if present) could be queried).

    Updated the places where the "get_field_values" method was used with the new method signature. Added a unit test to verify that the "get_field_values" method now properly distinguishes between datatypes.
Added a unit test to verify the various ways the "display_node" generates the content to display for individual field values for an item.

* Added "display_handle" method to "application_helper.rb" to control the formatting of the "handle" field.

    Updated the "display_node" method to delegate to the "display_handle" method when a field's datatype is “http://vocab.lib.umd.edu/datatype#handle”

* Added the "HANDLE_HTTP_PROXY_BASE" environment variable to the "env_example" file, with a default of "http://hdl-local/" in the ".env.development" file.

https://umd-dit.atlassian.net/browse/LIBHYDRA-571