### PR TITLE
LIBHYDRA-516. Additional STOMP listener fixes.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -138,7 +138,7 @@ pipeline {
       post {
         always {
           // Collect Rubocop reports
-          recordIssues(tools: [ruboCop(reportEncoding: 'UTF-8')], unstableTotalAll: 1)
+          recordIssues(tools: [ruboCop(reportEncoding: 'UTF-8')], qualityGates: [[threshold: 1, type: 'TOTAL', criticality: 'UNSTABLE']])
 
           // Collect coverage reports
           publishHTML([

--- a/lib/tasks/stomp.rake
+++ b/lib/tasks/stomp.rake
@@ -37,12 +37,10 @@ namespace :stomp do # rubocop:disable Metrics/BlockLength
         # Wrapping in "with_connection" in case connection has timed out
         ActiveRecord::Base.connection_pool.with_connection do
           message.find_job.update_progress(message)
-          listener.send_ack(message)
           notify_archelon(message, type: :progress)
         end
       rescue StandardError => e
         puts "An error occurred processing stomp_msg: #{stomp_msg}"
-        listener.send_nack(message)
         puts e, e.backtrace
       end
     end

--- a/lib/tasks/stomp.rake
+++ b/lib/tasks/stomp.rake
@@ -31,17 +31,20 @@ namespace :stomp do # rubocop:disable Metrics/BlockLength
 
     listener.subscribe(:job_progress) do |stomp_msg|
       message = PlastronMessage.new(stomp_msg)
-      puts "Updating job progress for #{message.job_id}"
+      # ignore synchronous job progress messages
+      unless message.job_id.start_with? 'SYNCHRONOUS'
+        puts "Updating job progress for #{message.job_id}"
 
-      begin
-        # Wrapping in "with_connection" in case connection has timed out
-        ActiveRecord::Base.connection_pool.with_connection do
-          message.find_job.update_progress(message)
-          notify_archelon(message, type: :progress)
+        begin
+          # Wrapping in "with_connection" in case connection has timed out
+          ActiveRecord::Base.connection_pool.with_connection do
+            message.find_job.update_progress(message)
+            notify_archelon(message, type: :progress)
+          end
+        rescue StandardError => e
+          puts "An error occurred processing stomp_msg: #{stomp_msg}"
+          puts e, e.backtrace
         end
-      rescue StandardError => e
-        puts "An error occurred processing stomp_msg: #{stomp_msg}"
-        puts e, e.backtrace
       end
     end
 


### PR DESCRIPTION
- Removed ack/nack calls from the progress messages. Messages in ActiveMQ topics can't be acked or nacked.
- Ignore synchronous jobs in the progress topic listener.

https://umd-dit.atlassian.net/browse/LIBHYDRA-516