### PR TITLE
LIBFCREPO-1409. "Cancel" on "Generate Download URL" goes to binary page

### DIFF
--- a/app/views/download_urls/generate_download_url.html.erb
+++ b/app/views/download_urls/generate_download_url.html.erb
@@ -14,7 +14,7 @@
 
   <div class="row">
     <%= f.submit class: 'btn btn-success' %>
-    <%= link_to 'Cancel', (@download_url.new_record? ? download_urls_path : download_url_path(@download_url)), class: 'btn btn-danger' %>
+    <%= link_to 'Cancel', (@download_url.new_record? ? solr_document_url(@download_url.url) : download_url_path(@download_url)), class: 'btn btn-danger' %>
   </div>
 <% end %>
 


### PR DESCRIPTION
Modified the "Cancel" button on the "Generate Download URL" page to return to the binary detail page from which is came.

https://umd-dit.atlassian.net/browse/LIBFCREPO-1409