### PR TITLE
LIBFCREPO-1429. Add optional "terms_of_use" field to content models

### DIFF
--- a/config/content_models.yml
+++ b/config/content_models.yml
@@ -109,6 +109,12 @@ Item:
       type: :LabeledThing
       repeatable: true
 
+    - name: 'terms_of_use'
+      uri: 'http://purl.org/dc/terms/license'
+      label: 'Terms of Use'
+      type: :ControlledURIRef
+      vocab: 'termsOfUse'
+
     - name: 'copyright_notice'
       uri: 'http://schema.org/copyrightNotice'
       label: 'Copyright Notice'
@@ -227,6 +233,12 @@ Letter:
       label: 'Author'
       type: :LabeledThing
       repeatable: true
+
+    - name: 'terms_of_use'
+      uri: 'http://purl.org/dc/terms/license'
+      label: 'Terms of Use'
+      type: :ControlledURIRef
+      vocab: 'termsOfUse'
 
     - name: 'copyright_notice'
       uri: 'http://schema.org/copyrightNotice'
@@ -347,6 +359,12 @@ Poster:
       label: 'Longitude'
       type: :TypedLiteral
 
+    - name: 'terms_of_use'
+      uri: 'http://purl.org/dc/terms/license'
+      label: 'Terms of Use'
+      type: :ControlledURIRef
+      vocab: 'termsOfUse'
+
     - name: 'copyright_notice'
       uri: 'http://schema.org/copyrightNotice'
       label: 'Copyright Notice'
@@ -395,6 +413,12 @@ Issue:
 
   recommended: []
   optional:
+    - name: 'terms_of_use'
+      uri: 'http://purl.org/dc/terms/license'
+      label: 'Terms of Use'
+      type: :ControlledURIRef
+      vocab: 'termsOfUse'
+
     - name: 'copyright_notice'
       uri: 'http://schema.org/copyrightNotice'
       label: 'Copyright Notice'


### PR DESCRIPTION
Added optional "terms_of_use" field to the Item, Letter, Poster, and Issue models, so that a "Terms of Use" field is displayed on the item detail page, and as an editable field on the metadata edit page.

https://umd-dit.atlassian.net/browse/LIBFCREPO-1429