### PR TITLE
LIBFCREPO-1411: Updating the names for the hyperlinks

### DIFF
--- a/app/views/catalog/_show_sidebar.html.erb
+++ b/app/views/catalog/_show_sidebar.html.erb
@@ -20,7 +20,7 @@
     <div class="panel-body">
       <ul class="nav">
         <% pages.first(8).each do |v| %>
-          <li><%= link_to "Page #{v['page_number']}", solr_document_path(v['id']) %></li>
+          <li><%= link_to v['display_title'], solr_document_path(v['id']) %></li>
         <% end %>
         <% if pages.length > 8 %>
           <li><a href="#pages" data-toggle="modal">more »</a></li>
@@ -82,7 +82,7 @@
 <% end %>
 
 <% if ExportJob.exportable? @document %>
-  <% 
+  <%
     selected_count = current_user.bookmarks.count
     max_selction = max_bookmarks_selection_limit
   %>


### PR DESCRIPTION
Uses the display_title rather than hardcoding the name and page number

https://umd-dit.atlassian.net/browse/LIBFCREPO-1411