### PR TITLE
LIBFCREPO-1431. Changed "schema" prefix to "https://schema.org/"

### DIFF
--- a/config/content_models.yml
+++ b/config/content_models.yml
@@ -110,7 +110,7 @@ Item:
       repeatable: true
 
     - name: 'copyright_notice'
-      uri: 'http://schema.org/copyrightNotice'
+      uri: 'https://schema.org/copyrightNotice'
       label: 'Copyright Notice'
       type: :PlainLiteral
 
@@ -229,7 +229,7 @@ Letter:
       repeatable: true
 
     - name: 'copyright_notice'
-      uri: 'http://schema.org/copyrightNotice'
+      uri: 'https://schema.org/copyrightNotice'
       label: 'Copyright Notice'
       type: :PlainLiteral
 
@@ -348,7 +348,7 @@ Poster:
       type: :TypedLiteral
 
     - name: 'copyright_notice'
-      uri: 'http://schema.org/copyrightNotice'
+      uri: 'https://schema.org/copyrightNotice'
       label: 'Copyright Notice'
       type: :PlainLiteral
 
@@ -396,7 +396,7 @@ Issue:
   recommended: []
   optional:
     - name: 'copyright_notice'
-      uri: 'http://schema.org/copyrightNotice'
+      uri: 'https://schema.org/copyrightNotice'
       label: 'Copyright Notice'
       type: :PlainLiteral
 


### PR DESCRIPTION
Changed the "schema" prefix from "http://schema.org/" to "https://schema.org/" as "https" is the protocol used in the canonical URLs on the schema.org website.

https://umd-dit.atlassian.net/browse/LIBFCREPO-1431