### PR TITLE
LIBFCREPO-1430. Remove vocab URI label from dropdown options

### DIFF
--- a/app/services/vocabulary_service.rb
+++ b/app/services/vocabulary_service.rb
@@ -23,7 +23,7 @@ class VocabularyService
   #
   # The returned hash is suitable for use in the "vocab" field of the
   # ControlledURIRef React component.
-  def self.vocab_options_hash(content_model_field)
+  def self.vocab_options_hash(content_model_field) # rubocop:disable Metrics/AbcSize
     return {} unless valid?(content_model_field)
 
     vocab_identifier = content_model_field[:vocab]
@@ -34,6 +34,11 @@ class VocabularyService
     vocab = VocabularyService.get_vocabulary(vocab_identifier)
 
     filtered_terms = filter_terms(vocab.terms, allowed_terms)
+
+    # Remove any term exactly matching the vocabulary URI, which is just
+    # a label for the vocabulary itself
+    filtered_terms = filtered_terms.delete_if { |v| v.uri == vocab.uri }
+
     filtered_options = parse_options(filtered_terms)
     Rails.logger.debug { "filtered_options: #{filtered_options}" }
 

--- a/test/fixtures/files/sample_vocabularies/README.md
+++ b/test/fixtures/files/sample_vocabularies/README.md
@@ -15,6 +15,12 @@ All commands were run from the project directory.
 $ curl --location 'http://vocab.lib.umd.edu/access#' > test/fixtures/files/sample_vocabularies/access.json
 ```
 
+### form.json
+
+```zsh
+$ curl --location 'http://vocab.lib.umd.edu/form#' > test/fixtures/files/sample_vocabularies/form.json
+```
+
 ### rightsStatement.json
 
 ```zsh

--- a/test/fixtures/files/sample_vocabularies/access.json
+++ b/test/fixtures/files/sample_vocabularies/access.json
@@ -1,25 +1,35 @@
 {
   "@context": {
-    "owl": "http://www.w3.org/2002/07/owl#",
+    "dc": "http://purl.org/dc/elements/1.1/",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
     "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
-    "dc": "http://purl.org/dc/elements/1.1/"
+    "vann": "http://purl.org/vocab/vann/"
   },
   "@graph": [
     {
-      "@id": "http://vocab.lib.umd.edu/access#Public",
-      "@type": "rdfs:Class"
-    },
-    {
       "@id": "http://vocab.lib.umd.edu/access#Published",
-      "@type": "rdfs:Class"
+      "@type": "rdfs:Class",
+      "dc:identifier": "Published"
     },
     {
-      "@id": "http://vocab.lib.umd.edu/access#Campus",
-      "@type": "rdfs:Class"
+      "@id": "http://vocab.lib.umd.edu/access#",
+      "rdfs:label": "Access Classes",
+      "vann:preferredNamespacePrefix": "umdaccess"
     },
     {
       "@id": "http://vocab.lib.umd.edu/access#Hidden",
-      "@type": "rdfs:Class"
+      "@type": "rdfs:Class",
+      "dc:identifier": "Hidden"
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/access#Public",
+      "@type": "rdfs:Class",
+      "dc:identifier": "Public"
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/access#Campus",
+      "@type": "rdfs:Class",
+      "dc:identifier": "Campus"
     }
   ]
 }

--- a/test/fixtures/files/sample_vocabularies/form.json
+++ b/test/fixtures/files/sample_vocabularies/form.json
@@ -1,414 +1,452 @@
 {
   "@context": {
+    "dc": "http://purl.org/dc/elements/1.1/",
     "owl": "http://www.w3.org/2002/07/owl#",
     "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
-    "dc": "http://purl.org/dc/elements/1.1/"
+    "vann": "http://purl.org/vocab/vann/"
   },
   "@graph": [
     {
-      "@id": "http://vocab.lib.umd.edu/form#photographs",
-      "rdfs:label": "Photographs",
-      "dc:identifier": "photographs",
-      "owl:sameAs": {
-        "@id": "http://id.loc.gov/authorities/genreForms/gf2017027249"
-      }
-    },
-    {
-      "@id": "http://vocab.lib.umd.edu/form#newspapers",
-      "rdfs:label": "Newspapers",
-      "dc:identifier": "newspapers",
-      "owl:sameAs": {
-        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026132"
-      }
-    },
-    {
-      "@id": "http://vocab.lib.umd.edu/form#rosters",
-      "rdfs:label": "Rosters",
-      "dc:identifier": "rosters",
-      "owl:sameAs": {
-        "@id": "http://vocab.getty.edu/page/aat/300027178"
-      }
-    },
-    {
-      "@id": "http://vocab.lib.umd.edu/form#maps",
-      "rdfs:label": "Maps",
-      "dc:identifier": "maps",
-      "owl:sameAs": {
-        "@id": "http://id.loc.gov/authorities/genreForms/gf2011026387"
-      }
-    },
-    {
-      "@id": "http://vocab.lib.umd.edu/form#greeting_cards",
-      "rdfs:label": "Greeting cards",
-      "dc:identifier": "greeting_cards",
-      "owl:sameAs": {
-        "@id": "http://vocab.getty.edu/page/aat/300026778"
-      }
-    },
-    {
-      "@id": "http://vocab.lib.umd.edu/form#catalogs",
-      "rdfs:label": "Catalogs",
-      "dc:identifier": "catalogs",
-      "owl:sameAs": {
-        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026057"
-      }
-    },
-    {
-      "@id": "http://vocab.lib.umd.edu/form#paintings",
-      "rdfs:label": "Paintings (visual works)",
-      "dc:identifier": "paintings",
-      "owl:sameAs": {
-        "@id": "http://vocab.getty.edu/page/aat/300033618"
-      }
-    },
-    {
-      "@id": "http://vocab.lib.umd.edu/form#architectural_drawings",
-      "rdfs:label": "Architectural drawings (visual works)",
-      "dc:identifier": "architectural_drawings",
-      "owl:sameAs": {
-        "@id": "http://vocab.getty.edu/page/aat/300034787"
-      }
-    },
-    {
-      "@id": "http://vocab.lib.umd.edu/form#property_records",
-      "rdfs:label": "Property records",
-      "dc:identifier": "property_records",
-      "owl:sameAs": {
-        "@id": "http://vocab.getty.edu/page/aat/300027243"
-      }
-    },
-    {
-      "@id": "http://vocab.lib.umd.edu/form#programs",
-      "rdfs:label": "Programs (publications)",
-      "dc:identifier": "programs",
-      "owl:sameAs": {
-        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026156"
-      }
-    },
-    {
-      "@id": "http://vocab.lib.umd.edu/form#nonfiction_films",
-      "rdfs:label": "Nonfiction films",
-      "dc:identifier": "nonfiction_films",
-      "owl:sameAs": {
-        "@id": "http://id.loc.gov/authorities/genreForms/gf2011026423"
-      }
-    },
-    {
-      "@id": "http://vocab.lib.umd.edu/form#art",
-      "rdfs:label": "Art",
-      "dc:identifier": "art",
-      "owl:sameAs": {
-        "@id": "http://id.loc.gov/authorities/genreForms/gf2017027218"
-      }
-    },
-    {
-      "@id": "http://vocab.lib.umd.edu/form#fanzines",
-      "rdfs:label": "Fanzines",
-      "dc:identifier": "fanzines",
-      "owl:sameAs": {
-        "@id": "http://vocab.getty.edu/page/aat/300252980"
-      }
-    },
-    {
-      "@id": "http://vocab.lib.umd.edu/form#spoken_word",
-      "rdfs:label": "Spoken word poetry",
-      "dc:identifier": "spoken_word",
-      "owl:sameAs": {
-        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026552"
-      }
-    },
-    {
-      "@id": "http://vocab.lib.umd.edu/form#sculpture",
-      "rdfs:label": "Sculpture (visual works)",
-      "dc:identifier": "sculpture",
-      "owl:sameAs": {
-        "@id": "http://vocab.getty.edu/page/aat/300047090"
-      }
-    },
-    {
-      "@id": "http://vocab.lib.umd.edu/form#prints",
-      "rdfs:label": "Prints (visual works)",
-      "dc:identifier": "prints",
-      "owl:sameAs": {
-        "@id": "http://vocab.getty.edu/page/aat/300041273"
-      }
-    },
-    {
-      "@id": "http://vocab.lib.umd.edu/form#drama",
-      "rdfs:label": "Drama",
-      "dc:identifier": "drama",
-      "owl:sameAs": {
-        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026297"
-      }
-    },
-    {
       "@id": "http://vocab.lib.umd.edu/form#drawings",
-      "rdfs:label": "Drawings",
       "dc:identifier": "drawings",
       "owl:sameAs": {
         "@id": "http://id.loc.gov/authorities/genreForms/gf2017027231"
-      }
-    },
-    {
-      "@id": "http://vocab.lib.umd.edu/form#chapbooks",
-      "rdfs:label": "Chapbooks",
-      "dc:identifier": "chapbooks",
-      "owl:sameAs": {
-        "@id": "http://vocab.getty.edu/page/aat/300152367"
-      }
-    },
-    {
-      "@id": "http://vocab.lib.umd.edu/form#research_notes",
-      "rdfs:label": "Research notes",
-      "dc:identifier": "research_notes",
-      "owl:sameAs": {
-        "@id": "http://vocab.getty.edu/page/aat/300265639"
-      }
-    },
-    {
-      "@id": "http://vocab.lib.umd.edu/form#transcripts",
-      "rdfs:label": "Transcripts",
-      "dc:identifier": "transcripts",
-      "owl:sameAs": {
-        "@id": "http://vocab.getty.edu/page/aat/300027388"
-      }
-    },
-    {
-      "@id": "http://vocab.lib.umd.edu/form#certificates",
-      "rdfs:label": "Certificates",
-      "dc:identifier": "certificates",
-      "owl:sameAs": {
-        "@id": "http://vocab.getty.edu/page/aat/300026841"
-      }
-    },
-    {
-      "@id": "http://vocab.lib.umd.edu/form#ephemera",
-      "rdfs:label": "Ephemera",
-      "dc:identifier": "ephemera",
-      "owl:sameAs": {
-        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026093"
-      }
-    },
-    {
-      "@id": "http://vocab.lib.umd.edu/form#speeches",
-      "rdfs:label": "Speeches",
-      "dc:identifier": "speeches",
-      "owl:sameAs": {
-        "@id": "http://id.loc.gov/authorities/genreForms/gf2011026363"
-      }
-    },
-    {
-      "@id": "http://vocab.lib.umd.edu/form#broadsides_notices",
-      "rdfs:label": "Broadsides (notices)",
-      "dc:identifier": "broadsides_notices",
-      "owl:sameAs": {
-        "@id": "http://vocab.getty.edu/page/aat/300026739"
-      }
-    },
-    {
-      "@id": "http://vocab.lib.umd.edu/form#conference_papers",
-      "rdfs:label": "Conference papers and proceedings",
-      "dc:identifier": "conference_papers",
-      "owl:sameAs": {
-        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026068"
-      }
-    },
-    {
-      "@id": "http://vocab.lib.umd.edu/form#scrapbooks",
-      "rdfs:label": "Scrapbooks",
-      "dc:identifier": "scrapbooks",
-      "owl:sameAs": {
-        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026173"
-      }
-    },
-    {
-      "@id": "http://vocab.lib.umd.edu/form#business_correspondence",
-      "rdfs:label": "Business correspondence",
-      "dc:identifier": "business_correspondence",
-      "owl:sameAs": {
-        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026054"
-      }
-    },
-    {
-      "@id": "http://vocab.lib.umd.edu/form#records",
-      "rdfs:label": "Records (documents)",
-      "dc:identifier": "records",
-      "owl:sameAs": {
-        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026163"
-      }
-    },
-    {
-      "@id": "http://vocab.lib.umd.edu/form#newspaper_clippings",
-      "rdfs:label": "Newspaper clippings",
-      "dc:identifier": "newspaper_clippings",
-      "owl:sameAs": {
-        "@id": "http://vocab.getty.edu/page/aat/300429554"
-      }
-    },
-    {
-      "@id": "http://vocab.lib.umd.edu/form#postcards",
-      "rdfs:label": "Postcards",
-      "dc:identifier": "postcards",
-      "owl:sameAs": {
-        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026151"
-      }
-    },
-    {
-      "@id": "http://vocab.lib.umd.edu/form#sheet_music",
-      "rdfs:label": "Sheet music",
-      "dc:identifier": "sheet_music",
-      "owl:sameAs": {
-        "@id": "http://vocab.getty.edu/page/aat/300026430"
-      }
-    },
-    {
-      "@id": "http://vocab.lib.umd.edu/form#personal_correspondence",
-      "rdfs:label": "Personal correspondence",
-      "dc:identifier": "personal_correspondence",
-      "owl:sameAs": {
-        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026141"
-      }
-    },
-    {
-      "@id": "http://vocab.lib.umd.edu/form#books",
-      "rdfs:label": "Books",
-      "dc:identifier": "books",
-      "owl:sameAs": {
-        "@id": "http://vocab.getty.edu/page/aat/300028051"
-      }
+      },
+      "rdfs:label": "Drawings"
     },
     {
       "@id": "http://vocab.lib.umd.edu/form#diaries",
-      "rdfs:label": "Diaries",
       "dc:identifier": "diaries",
       "owl:sameAs": {
         "@id": "http://id.loc.gov/authorities/genreForms/gf2014026085"
-      }
-    },
-    {
-      "@id": "http://vocab.lib.umd.edu/form#manuscripts",
-      "rdfs:label": "Manuscripts (documents)",
-      "dc:identifier": "manuscripts",
-      "owl:sameAs": {
-        "@id": "http://vocab.getty.edu/page/aat/300028569"
-      }
-    },
-    {
-      "@id": "http://vocab.lib.umd.edu/form#periodicals",
-      "rdfs:label": "Periodicals",
-      "dc:identifier": "periodicals",
-      "owl:sameAs": {
-        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026139"
-      }
-    },
-    {
-      "@id": "http://vocab.lib.umd.edu/form#essays",
-      "rdfs:label": "Essays",
-      "dc:identifier": "essays",
-      "owl:sameAs": {
-        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026094"
-      }
-    },
-    {
-      "@id": "http://vocab.lib.umd.edu/form#yearbooks",
-      "rdfs:label": "School yearbooks",
-      "dc:identifier": "yearbooks",
-      "owl:sameAs": {
-        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026172"
-      }
-    },
-    {
-      "@id": "http://vocab.lib.umd.edu/form#photograph_albums",
-      "rdfs:label": "Photograph albums",
-      "dc:identifier": "photograph_albums",
-      "owl:sameAs": {
-        "@id": "http://vocab.getty.edu/page/aat/300026695"
-      }
-    },
-    {
-      "@id": "http://vocab.lib.umd.edu/form#pool_reports",
-      "rdfs:label": "Pool reports",
-      "dc:identifier": "pool_reports"
-    },
-    {
-      "@id": "http://vocab.lib.umd.edu/form#fliers_ephemera",
-      "rdfs:label": "Fliers (ephemera)",
-      "dc:identifier": "fliers_ephemera",
-      "owl:sameAs": {
-        "@id": "http://id.loc.gov/authorities/genreForms/gf2017026133"
-      }
-    },
-    {
-      "@id": "http://vocab.lib.umd.edu/form#illustrated_works",
-      "rdfs:label": "Illustrated works",
-      "dc:identifier": "illustrated_works",
-      "owl:sameAs": {
-        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026111"
-      }
+      },
+      "rdfs:label": "Diaries"
     },
     {
       "@id": "http://vocab.lib.umd.edu/form#poetry",
-      "rdfs:label": "Poetry",
       "dc:identifier": "poetry",
       "owl:sameAs": {
         "@id": "http://id.loc.gov/authorities/genreForms/gf2014026481"
-      }
+      },
+      "rdfs:label": "Poetry"
     },
     {
-      "@id": "http://vocab.lib.umd.edu/form#newsletters",
-      "rdfs:label": "Newsletters",
-      "dc:identifier": "newsletters",
+      "@id": "http://vocab.lib.umd.edu/form#broadsides_notices",
+      "dc:identifier": "broadsides_notices",
       "owl:sameAs": {
-        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026131"
-      }
+        "@id": "http://vocab.getty.edu/page/aat/300026739"
+      },
+      "rdfs:label": "Broadsides (notices)"
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#rosters",
+      "dc:identifier": "rosters",
+      "owl:sameAs": {
+        "@id": "http://vocab.getty.edu/page/aat/300027178"
+      },
+      "rdfs:label": "Rosters"
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#conference_papers",
+      "dc:identifier": "conference_papers",
+      "owl:sameAs": {
+        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026068"
+      },
+      "rdfs:label": "Conference papers and proceedings"
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#essays",
+      "dc:identifier": "essays",
+      "owl:sameAs": {
+        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026094"
+      },
+      "rdfs:label": "Essays"
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#personal_correspondence",
+      "dc:identifier": "personal_correspondence",
+      "owl:sameAs": {
+        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026141"
+      },
+      "rdfs:label": "Personal correspondence"
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#property_records",
+      "dc:identifier": "property_records",
+      "owl:sameAs": {
+        "@id": "http://vocab.getty.edu/page/aat/300027243"
+      },
+      "rdfs:label": "Property records"
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#architectural_drawings",
+      "dc:identifier": "architectural_drawings",
+      "owl:sameAs": {
+        "@id": "http://vocab.getty.edu/page/aat/300034787"
+      },
+      "rdfs:label": "Architectural drawings (visual works)"
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#art",
+      "dc:identifier": "art",
+      "owl:sameAs": {
+        "@id": "http://id.loc.gov/authorities/genreForms/gf2017027218"
+      },
+      "rdfs:label": "Art"
     },
     {
       "@id": "http://vocab.lib.umd.edu/form#scores",
-      "rdfs:label": "Scores",
       "dc:identifier": "scores",
       "owl:sameAs": {
         "@id": "http://id.loc.gov/authorities/genreForms/gf2014027077"
-      }
+      },
+      "rdfs:label": "Scores"
     },
     {
-      "@id": "http://vocab.lib.umd.edu/form#slides_photographs",
-      "rdfs:label": "Slides (photographs)",
-      "dc:identifier": "slides_photographs",
+      "@id": "http://vocab.lib.umd.edu/form#records",
+      "dc:identifier": "records",
       "owl:sameAs": {
-        "@id": "http://vocab.getty.edu/page/aat/300128371"
-      }
+        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026163"
+      },
+      "rdfs:label": "Records (documents)"
     },
     {
-      "@id": "http://vocab.lib.umd.edu/form#negatives",
-      "rdfs:label": "Negatives (photographs)",
-      "dc:identifier": "negatives",
+      "@id": "http://vocab.lib.umd.edu/form#paintings",
+      "dc:identifier": "paintings",
       "owl:sameAs": {
-        "@id": "http://id.loc.gov/authorities/genreForms/gf2019026026"
-      }
+        "@id": "http://vocab.getty.edu/page/aat/300033618"
+      },
+      "rdfs:label": "Paintings (visual works)"
     },
     {
-      "@id": "http://vocab.lib.umd.edu/form#posters",
-      "rdfs:label": "Posters",
-      "dc:identifier": "posters",
+      "@id": "http://vocab.lib.umd.edu/form#spoken_word",
+      "dc:identifier": "spoken_word",
       "owl:sameAs": {
-        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026152"
-      }
+        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026552"
+      },
+      "rdfs:label": "Spoken word poetry"
     },
     {
       "@id": "http://vocab.lib.umd.edu/form#exhibition_catalogs",
-      "rdfs:label": "Exhibition catalogs",
       "dc:identifier": "exhibition_catalogs",
       "owl:sameAs": {
         "@id": "http://id.loc.gov/authorities/genreForms/gf2014026098"
-      }
+      },
+      "rdfs:label": "Exhibition catalogs"
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#invitations",
+      "dc:identifier": "invitations",
+      "owl:sameAs": {
+        "@id": "http://vocab.getty.edu/page/aat/300027083"
+      },
+      "rdfs:label": "Invitations"
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#newspaper_clippings",
+      "dc:identifier": "newspaper_clippings",
+      "owl:sameAs": {
+        "@id": "http://vocab.getty.edu/page/aat/300429554"
+      },
+      "rdfs:label": "Newspaper clippings"
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#greeting_cards",
+      "dc:identifier": "greeting_cards",
+      "owl:sameAs": {
+        "@id": "http://vocab.getty.edu/page/aat/300026778"
+      },
+      "rdfs:label": "Greeting cards"
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#newsletters",
+      "dc:identifier": "newsletters",
+      "owl:sameAs": {
+        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026131"
+      },
+      "rdfs:label": "Newsletters"
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#newspapers",
+      "dc:identifier": "newspapers",
+      "owl:sameAs": {
+        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026132"
+      },
+      "rdfs:label": "Newspapers"
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#manuscripts",
+      "dc:identifier": "manuscripts",
+      "owl:sameAs": {
+        "@id": "http://vocab.getty.edu/page/aat/300028569"
+      },
+      "rdfs:label": "Manuscripts (documents)"
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#catalogs",
+      "dc:identifier": "catalogs",
+      "owl:sameAs": {
+        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026057"
+      },
+      "rdfs:label": "Catalogs"
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#research_notes",
+      "dc:identifier": "research_notes",
+      "owl:sameAs": {
+        "@id": "http://vocab.getty.edu/page/aat/300265639"
+      },
+      "rdfs:label": "Research notes"
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#maps",
+      "dc:identifier": "maps",
+      "owl:sameAs": {
+        "@id": "http://id.loc.gov/authorities/genreForms/gf2011026387"
+      },
+      "rdfs:label": "Maps"
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#programs",
+      "dc:identifier": "programs",
+      "owl:sameAs": {
+        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026156"
+      },
+      "rdfs:label": "Programs (publications)"
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#postcards",
+      "dc:identifier": "postcards",
+      "owl:sameAs": {
+        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026151"
+      },
+      "rdfs:label": "Postcards"
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#manuscripts_publication",
+      "dc:identifier": "manuscripts_publication",
+      "owl:sameAs": {
+        "@id": "http://vocab.getty.edu/page/aat/300028579"
+      },
+      "rdfs:label": "Manuscripts for publication"
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#books",
+      "dc:identifier": "books",
+      "owl:sameAs": {
+        "@id": "http://vocab.getty.edu/page/aat/300028051"
+      },
+      "rdfs:label": "Books"
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#negatives",
+      "dc:identifier": "negatives",
+      "owl:sameAs": {
+        "@id": "http://id.loc.gov/authorities/genreForms/gf2019026026"
+      },
+      "rdfs:label": "Negatives (photographs)"
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#ephemera",
+      "dc:identifier": "ephemera",
+      "owl:sameAs": {
+        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026093"
+      },
+      "rdfs:label": "Ephemera"
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#reports",
+      "dc:identifier": "reports",
+      "owl:sameAs": {
+        "@id": "http://vocab.getty.edu/page/aat/300027267"
+      },
+      "rdfs:label": "Reports"
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#pool_reports",
+      "dc:identifier": "pool_reports",
+      "rdfs:label": "Pool reports"
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#drama",
+      "dc:identifier": "drama",
+      "owl:sameAs": {
+        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026297"
+      },
+      "rdfs:label": "Drama"
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#prints",
+      "dc:identifier": "prints",
+      "owl:sameAs": {
+        "@id": "http://vocab.getty.edu/page/aat/300041273"
+      },
+      "rdfs:label": "Prints (visual works)"
     },
     {
       "@id": "http://vocab.lib.umd.edu/form#pamphlets",
-      "rdfs:label": "Pamphlets",
       "dc:identifier": "pamphlets",
       "owl:sameAs": {
         "@id": "http://vocab.getty.edu/page/aat/300220572"
-      }
+      },
+      "rdfs:label": "Pamphlets"
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#business_correspondence",
+      "dc:identifier": "business_correspondence",
+      "owl:sameAs": {
+        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026054"
+      },
+      "rdfs:label": "Business correspondence"
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#posters",
+      "dc:identifier": "posters",
+      "owl:sameAs": {
+        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026152"
+      },
+      "rdfs:label": "Posters"
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#transcripts",
+      "dc:identifier": "transcripts",
+      "owl:sameAs": {
+        "@id": "http://vocab.getty.edu/page/aat/300027388"
+      },
+      "rdfs:label": "Transcripts"
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#sculpture",
+      "dc:identifier": "sculpture",
+      "owl:sameAs": {
+        "@id": "http://vocab.getty.edu/page/aat/300047090"
+      },
+      "rdfs:label": "Sculpture (visual works)"
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#illustrated_works",
+      "dc:identifier": "illustrated_works",
+      "owl:sameAs": {
+        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026111"
+      },
+      "rdfs:label": "Illustrated works"
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#photographs",
+      "dc:identifier": "photographs",
+      "owl:sameAs": {
+        "@id": "http://id.loc.gov/authorities/genreForms/gf2017027249"
+      },
+      "rdfs:label": "Photographs"
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#fliers_ephemera",
+      "dc:identifier": "fliers_ephemera",
+      "owl:sameAs": {
+        "@id": "http://id.loc.gov/authorities/genreForms/gf2017026133"
+      },
+      "rdfs:label": "Fliers (ephemera)"
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#sheet_music",
+      "dc:identifier": "sheet_music",
+      "owl:sameAs": {
+        "@id": "http://vocab.getty.edu/page/aat/300026430"
+      },
+      "rdfs:label": "Sheet music"
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#fanzines",
+      "dc:identifier": "fanzines",
+      "owl:sameAs": {
+        "@id": "http://vocab.getty.edu/page/aat/300252980"
+      },
+      "rdfs:label": "Fanzines"
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#periodicals",
+      "dc:identifier": "periodicals",
+      "owl:sameAs": {
+        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026139"
+      },
+      "rdfs:label": "Periodicals"
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#slides_photographs",
+      "dc:identifier": "slides_photographs",
+      "owl:sameAs": {
+        "@id": "http://vocab.getty.edu/page/aat/300128371"
+      },
+      "rdfs:label": "Slides (photographs)"
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#chapbooks",
+      "dc:identifier": "chapbooks",
+      "owl:sameAs": {
+        "@id": "http://vocab.getty.edu/page/aat/300152367"
+      },
+      "rdfs:label": "Chapbooks"
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#certificates",
+      "dc:identifier": "certificates",
+      "owl:sameAs": {
+        "@id": "http://vocab.getty.edu/page/aat/300026841"
+      },
+      "rdfs:label": "Certificates"
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#yearbooks",
+      "dc:identifier": "yearbooks",
+      "owl:sameAs": {
+        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026172"
+      },
+      "rdfs:label": "School yearbooks"
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#",
+      "rdfs:label": "Genres/Forms",
+      "vann:preferredNamespacePrefix": "umdform"
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#photograph_albums",
+      "dc:identifier": "photograph_albums",
+      "owl:sameAs": {
+        "@id": "http://vocab.getty.edu/page/aat/300026695"
+      },
+      "rdfs:label": "Photograph albums"
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#speeches",
+      "dc:identifier": "speeches",
+      "owl:sameAs": {
+        "@id": "http://id.loc.gov/authorities/genreForms/gf2011026363"
+      },
+      "rdfs:label": "Speeches"
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#press_releases",
+      "dc:identifier": "press_releases",
+      "owl:sameAs": {
+        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026153"
+      },
+      "rdfs:label": "Press releases"
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#scrapbooks",
+      "dc:identifier": "scrapbooks",
+      "owl:sameAs": {
+        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026173"
+      },
+      "rdfs:label": "Scrapbooks"
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/form#nonfiction_films",
+      "dc:identifier": "nonfiction_films",
+      "owl:sameAs": {
+        "@id": "http://id.loc.gov/authorities/genreForms/gf2011026423"
+      },
+      "rdfs:label": "Nonfiction films"
     }
   ]
 }

--- a/test/fixtures/files/sample_vocabularies/rightsStatement.json
+++ b/test/fixtures/files/sample_vocabularies/rightsStatement.json
@@ -1,73 +1,78 @@
 {
   "@context": {
+    "dc": "http://purl.org/dc/elements/1.1/",
     "owl": "http://www.w3.org/2002/07/owl#",
     "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
-    "dc": "http://purl.org/dc/elements/1.1/"
+    "vann": "http://purl.org/vocab/vann/"
   },
   "@graph": [
     {
-      "@id": "http://vocab.lib.umd.edu/rightsStatement#CNE",
-      "rdfs:label": "Copyright Not Evaluated",
-      "dc:identifier": "CNE",
-      "owl:sameAs": {
-        "@id": "http://rightsstatements.org/vocab/CNE/1.0/"
-      }
-    },
-    {
-      "@id": "http://vocab.lib.umd.edu/rightsStatement#InC-EDU",
-      "rdfs:label": "In Copyright - Educational Use Permitted",
-      "dc:identifier": "InC-EDU",
-      "owl:sameAs": {
-        "@id": "http://rightsstatements.org/vocab/InC-EDU/1.0/"
-      }
-    },
-    {
-      "@id": "http://vocab.lib.umd.edu/rightsStatement#InC-RUU",
-      "rdfs:label": "In Copyright - Rights-Holder(s) Unlocatable or Unidentifiable",
-      "dc:identifier": "InC-RUU",
-      "owl:sameAs": {
-        "@id": "http://rightsstatements.org/vocab/InC-RUU/1.0/"
-      }
-    },
-    {
-      "@id": "http://vocab.lib.umd.edu/rightsStatement#InC-NC",
-      "rdfs:label": "In Copyright - Non-Commercial Use Permitted",
-      "dc:identifier": "InC-NC",
-      "owl:sameAs": {
-        "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
-      }
-    },
-    {
-      "@id": "http://vocab.lib.umd.edu/rightsStatement#UND",
-      "rdfs:label": "Copyright Undetermined",
-      "dc:identifier": "UND",
-      "owl:sameAs": {
-        "@id": "http://rightsstatements.org/vocab/UND/1.0/"
-      }
-    },
-    {
-      "@id": "http://vocab.lib.umd.edu/rightsStatement#NoC-US",
-      "rdfs:label": "No Copyright - United States",
-      "dc:identifier": "NoC-US",
-      "owl:sameAs": {
-        "@id": "http://rightsstatements.org/vocab/NoC-US/1.0/"
-      }
-    },
-    {
-      "@id": "http://vocab.lib.umd.edu/rightsStatement#InC",
-      "rdfs:label": "In Copyright",
-      "dc:identifier": "InC",
-      "owl:sameAs": {
-        "@id": "http://rightsstatements.org/vocab/InC/1.0/"
-      }
-    },
-    {
       "@id": "http://vocab.lib.umd.edu/rightsStatement#NKC",
-      "rdfs:label": "No Known Copyright",
       "dc:identifier": "NKC",
       "owl:sameAs": {
         "@id": "http://rightsstatements.org/vocab/NKC/1.0/"
-      }
+      },
+      "rdfs:label": "No Known Copyright"
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/rightsStatement#CNE",
+      "dc:identifier": "CNE",
+      "owl:sameAs": {
+        "@id": "http://rightsstatements.org/vocab/CNE/1.0/"
+      },
+      "rdfs:label": "Copyright Not Evaluated"
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/rightsStatement#InC-RUU",
+      "dc:identifier": "InC-RUU",
+      "owl:sameAs": {
+        "@id": "http://rightsstatements.org/vocab/InC-RUU/1.0/"
+      },
+      "rdfs:label": "In Copyright - Rights-Holder(s) Unlocatable or Unidentifiable"
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/rightsStatement#",
+      "rdfs:label": "Rights Statement"
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/rightsStatement#InC-NC",
+      "dc:identifier": "InC-NC",
+      "owl:sameAs": {
+        "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
+      },
+      "rdfs:label": "In Copyright - Non-Commercial Use Permitted"
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/rightsStatement#InC",
+      "dc:identifier": "InC",
+      "owl:sameAs": {
+        "@id": "http://rightsstatements.org/vocab/InC/1.0/"
+      },
+      "rdfs:label": "In Copyright"
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/rightsStatement#NoC-US",
+      "dc:identifier": "NoC-US",
+      "owl:sameAs": {
+        "@id": "http://rightsstatements.org/vocab/NoC-US/1.0/"
+      },
+      "rdfs:label": "No Copyright - United States"
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/rightsStatement#InC-EDU",
+      "dc:identifier": "InC-EDU",
+      "owl:sameAs": {
+        "@id": "http://rightsstatements.org/vocab/InC-EDU/1.0/"
+      },
+      "rdfs:label": "In Copyright - Educational Use Permitted"
+    },
+    {
+      "@id": "http://vocab.lib.umd.edu/rightsStatement#UND",
+      "dc:identifier": "UND",
+      "owl:sameAs": {
+        "@id": "http://rightsstatements.org/vocab/UND/1.0/"
+      },
+      "rdfs:label": "Copyright Undetermined"
     }
   ]
 }


### PR DESCRIPTION
Modified the "vocab_options_hash" method in
"app/services/vocabulary_service.rb" to filter out any entries where the URI exactly matches the URI of the vocabulary.

This is done so that the dropdown options do not contain an extraneous option related to the name of the vocabulary itself.

Updated the following vocabulary test fixtures, based on the current results from the "vocab.lib.umd.edu" server:

* test/fixtures/files/sample_vocabularies/access.json
* test/fixtures/files/sample_vocabularies/form.json
* test/fixtures/files/sample_vocabularies/rightsStatement.json

Did not update "one_term_vocabulary.json", because the "collection" vocabulary on the "vocab.lib.umd.edu" server now has more than one term.

https://umd-dit.atlassian.net/browse/LIBFCREPO-1430