### PR TITLE
LIBFCREPO-1439. Remove extraneous entry from "Access" field on "New Import Job" page

### DIFF
--- a/app/services/vocabulary_service.rb
+++ b/app/services/vocabulary_service.rb
@@ -10,7 +10,7 @@ class VocabularyService
   def self.get_vocabulary(identifier)
     url = generate_url(identifier)
     json_rest_result = retrieve(url)
-    terms = parse(json_rest_result)
+    terms = parse(identifier, json_rest_result)
     Vocabulary.new(identifier, terms)
   end
 
@@ -23,7 +23,7 @@ class VocabularyService
   #
   # The returned hash is suitable for use in the "vocab" field of the
   # ControlledURIRef React component.
-  def self.vocab_options_hash(content_model_field) # rubocop:disable Metrics/AbcSize
+  def self.vocab_options_hash(content_model_field)
     return {} unless valid?(content_model_field)
 
     vocab_identifier = content_model_field[:vocab]
@@ -34,10 +34,6 @@ class VocabularyService
     vocab = VocabularyService.get_vocabulary(vocab_identifier)
 
     filtered_terms = filter_terms(vocab.terms, allowed_terms)
-
-    # Remove any term exactly matching the vocabulary URI, which is just
-    # a label for the vocabulary itself
-    filtered_terms = filtered_terms.delete_if { |v| v.uri == vocab.uri }
 
     filtered_options = parse_options(filtered_terms)
     Rails.logger.debug { "filtered_options: #{filtered_options}" }
@@ -82,15 +78,15 @@ class VocabularyService
         json_rest_result
       end
 
-      # Parses the JSON result from the network requestm returning either an
+      # Parses the JSON result from the network request, returning either an
       # empty array, or an array of VocabularyTerm objects.
-      def parse(json_rest_result)
+      def parse(identifier, json_rest_result)
         return [] if json_rest_result.error_occurred?
 
         graph = json_rest_result.parsed_json['@graph']
 
         # @graph element exists for vocabularies with two or more elements
-        return graph.map { |g| parse_entry(g) } if graph.present?
+        return parse_graph(identifier, graph) if graph.present?
 
         # Single term vocabularies don't have "@graph" element, but do have
         # "@id" and (possibly) "@rdfs.label" elements, so we can just go
@@ -108,6 +104,18 @@ class VocabularyService
         end
 
         terms.select { |term| allowed_terms.include?(term.label) }
+      end
+
+      # Parses a vocabulary graph, returning an array of VocabularyTerm objects.
+      def parse_graph(identifier, graph)
+        entries = graph.map { |g| parse_entry(g) }
+
+        # Assume that the vocab URI is the same as the URL
+        vocab_uri = generate_url(identifier)
+
+        # Filter out any term with a uri exactly matching the vocabulary URI,
+        # as it is just a label for the vocabulary itself, not an actual term.
+        entries.reject { |v| v.uri == vocab_uri }
       end
 
       # Parses a single term from the graph, returning a VocabularyTerm object

--- a/test/services/vocabulary_service_test.rb
+++ b/test/services/vocabulary_service_test.rb
@@ -29,46 +29,46 @@ class VocabularyServiceTest < ActiveSupport::TestCase
     assert vocab.terms.empty?
   end
 
-  test 'vocab_hash returns empty hash when given nil or empty content model field' do
+  test 'vocab_options_hash returns empty hash when given nil or empty content model field' do
     assert_equal({}, VocabularyService.vocab_options_hash(nil))
     assert_equal({}, VocabularyService.vocab_options_hash({}))
     assert_equal({}, VocabularyService.vocab_options_hash([]))
   end
 
-  test 'vocab_hash returns empty hash on standard error' do
+  test 'vocab_options_hash returns empty hash on standard error' do
     stub_request(:get, 'http://vocab.lib.umd.edu/rightsStatement')
       .to_raise(StandardError)
 
-    vocab_hash = VocabularyService.vocab_options_hash(@rights_field)
-    assert_equal({}, vocab_hash)
+    vocab_options_hash = VocabularyService.vocab_options_hash(@rights_field)
+    assert_equal({}, vocab_options_hash)
   end
 
-  test 'vocab_hash returns empty hash on HTTP connection error' do
+  test 'vocab_options_hash returns empty hash on HTTP connection error' do
     stub_request(:get, 'http://vocab.lib.umd.edu/rightsStatement')
       .to_raise(HTTP::ConnectionError)
 
-    vocab_hash = VocabularyService.vocab_options_hash(@rights_field)
-    assert_equal({}, vocab_hash)
+    vocab_options_hash = VocabularyService.vocab_options_hash(@rights_field)
+    assert_equal({}, vocab_options_hash)
   end
 
-  test 'vocab_hash returns empty hash on network timeout' do
+  test 'vocab_options_hash returns empty hash on network timeout' do
     stub_request(:get, 'http://vocab.lib.umd.edu/rightsStatement')
       .to_timeout
 
-    vocab_hash = VocabularyService.vocab_options_hash(@rights_field)
-    assert_equal({}, vocab_hash)
+    vocab_options_hash = VocabularyService.vocab_options_hash(@rights_field)
+    assert_equal({}, vocab_options_hash)
   end
 
-  test 'vocab_hash returns empty hash unparseable JSON is returned' do
+  test 'vocab_options_hash returns empty hash unparseable JSON is returned' do
     invalid_json = '{'
     stub_request(:get, 'http://vocab.lib.umd.edu/rightsStatement')
       .to_return(status: 200, body: invalid_json, headers: {})
 
-    vocab_hash = VocabularyService.vocab_options_hash(@rights_field)
-    assert_equal({}, vocab_hash)
+    vocab_options_hash = VocabularyService.vocab_options_hash(@rights_field)
+    assert_equal({}, vocab_options_hash)
   end
 
-  test 'vocab_hash returns options list when given vocabulary with one term' do
+  test 'vocab_options_hash returns options list when given vocabulary with one term' do
     # The JSON from vocabularies with only one term do not have the "@graph"
     # element that is present when vocabularies have two or more terms.
     json_fixture_file = 'sample_vocabularies/one_term_vocabulary.json'
@@ -77,11 +77,11 @@ class VocabularyServiceTest < ActiveSupport::TestCase
 
     expected_hash = { 'http://vocab.lib.umd.edu/collection#0001-GDOC' => 'United States Government Posters' }
 
-    vocab_hash = VocabularyService.vocab_options_hash(@collection_field)
-    assert_equal(expected_hash, vocab_hash)
+    vocab_options_hash = VocabularyService.vocab_options_hash(@collection_field)
+    assert_equal(expected_hash, vocab_options_hash)
   end
 
-  test 'vocab_hash returns options list when given value content model field' do
+  test 'vocab_options_hash returns options list when given value content model field' do
     json_fixture_file = 'sample_vocabularies/rightsStatement.json'
     stub_request(:get, 'http://vocab.lib.umd.edu/rightsStatement')
       .to_return(status: 200, body: file_fixture(json_fixture_file).read, headers: {})
@@ -97,11 +97,11 @@ class VocabularyServiceTest < ActiveSupport::TestCase
       'http://vocab.lib.umd.edu/rightsStatement#NKC' => 'No Known Copyright'
     }
 
-    vocab_hash = VocabularyService.vocab_options_hash(@rights_field)
-    assert_equal(expected_hash, vocab_hash)
+    vocab_options_hash = VocabularyService.vocab_options_hash(@rights_field)
+    assert_equal(expected_hash, vocab_options_hash)
   end
 
-  test 'vocab_hash returns options list with only allowed terms when terms are provided' do
+  test 'vocab_options_hash returns options list with only allowed terms when terms are provided' do
     json_fixture_file = 'sample_vocabularies/access.json'
     stub_request(:get, 'http://vocab.lib.umd.edu/access')
       .to_return(status: 200, body: file_fixture(json_fixture_file).read, headers: {})
@@ -111,8 +111,8 @@ class VocabularyServiceTest < ActiveSupport::TestCase
       'http://vocab.lib.umd.edu/access#Campus' => 'Campus'
     }
 
-    vocab_hash = VocabularyService.vocab_options_hash(@access_field)
-    assert_equal(expected_hash, vocab_hash)
+    vocab_options_hash = VocabularyService.vocab_options_hash(@access_field)
+    assert_equal(expected_hash, vocab_options_hash)
   end
 
   # Returns a specific field the given section of a content_model


### PR DESCRIPTION
* In “test/services/vocabulary_service_test.rb”, replaced "vocab_hash" in test names with "vocab_options_hash", as that is more descriptive of what is being testedAlso renamed "vocab_hash" local variable in the tests to "vocab_options_hash" to be more consistent.

* In “app/services/vocabulary_service.rb“, Moved the parsing of vocabulary "graph" objects into the "parse_graph" method to enable the filtering out any "term" that has a "uri" that exactly matches the URL of the vocabulary being downloaded. This removes the extraneous the self-identifying vocabulary term.

    * In the "vocab_options_hash" method, removed the filtering of the self-identifying vocabulary term, as it is no longer needed.

    *  In the “parse_graph” method, specifically decided to pass the vocabulary identifier to the method, and using it to generate the vocabulary URI to be filtered out (via the "generate_url" method), in the expectation that at some point there may be a difference between the vocabulary URI and the URL from which the vocabulary is retrieved. This will hopefully confine any necessary change to this particular method.

https://umd-dit.atlassian.net/browse/LIBFCREPO-1439