### PR TITLE
LIBFCREPO-1440. Removed "Access Level" field from metadata edit page

### DIFF
--- a/config/content_models.yml
+++ b/config/content_models.yml
@@ -24,12 +24,6 @@ Item:
       type: :PlainLiteral
       repeatable: true
 
-    - name: 'access'
-      label: 'Access Level'
-      type: :ControlledURIRef
-      vocab: 'access'
-      terms: ['Public', 'Campus']
-
   recommended:
     - name: 'format'
       uri: 'http://www.europeana.eu/schemas/edm/hasType'
@@ -163,12 +157,6 @@ Letter:
       label: 'Title'
       type: :PlainLiteral
 
-    - name: 'access'
-      label: 'Access Level'
-      type: :ControlledURIRef
-      vocab: 'access'
-      terms: ['Public', 'Campus']
-
     - name: 'type'
       uri: 'http://www.europeana.eu/schemas/edm/hasType'
       label: 'Resource Type'
@@ -271,12 +259,6 @@ Poster:
       label: 'Title'
       type: :PlainLiteral
       repeatable: true
-
-    - name: 'access'
-      label: 'Access Level'
-      type: :ControlledURIRef
-      vocab: 'access'
-      terms: ['Public', 'Campus']
 
     - name: 'type'
       uri: 'http://www.europeana.eu/schemas/edm/hasType'
@@ -396,12 +378,6 @@ Issue:
       uri: 'http://purl.org/dc/terms/title'
       label: 'Title'
       type: :PlainLiteral
-
-    - name: 'access'
-      label: 'Access Level'
-      type: :ControlledURIRef
-      vocab: 'access'
-      terms: ['Public', 'Campus']
 
     - name: 'date'
       uri: 'http://purl.org/dc/elements/1.1/date'

--- a/test/services/vocabulary_service_test.rb
+++ b/test/services/vocabulary_service_test.rb
@@ -6,7 +6,6 @@ class VocabularyServiceTest < ActiveSupport::TestCase
   def setup
     item_content_model = CONTENT_MODELS[:Item]
     @rights_field = field_from_content_model(item_content_model, 'required', 'rights')
-    @access_field = field_from_content_model(item_content_model, 'required', 'access')
     @collection_field = field_from_content_model(item_content_model, 'recommended', 'archival_collection')
   end
 
@@ -102,6 +101,15 @@ class VocabularyServiceTest < ActiveSupport::TestCase
   end
 
   test 'vocab_options_hash returns options list with only allowed terms when terms are provided' do
+    # Sample access field, with allowed terms limited to "Public" and "Campus"
+    access_field = {
+      name: 'access',
+      label: 'Access Level',
+      type: :ControlledURIRef,
+      vocab: 'access',
+      terms: %w[Public Campus]
+    }
+
     json_fixture_file = 'sample_vocabularies/access.json'
     stub_request(:get, 'http://vocab.lib.umd.edu/access')
       .to_return(status: 200, body: file_fixture(json_fixture_file).read, headers: {})
@@ -111,7 +119,7 @@ class VocabularyServiceTest < ActiveSupport::TestCase
       'http://vocab.lib.umd.edu/access#Campus' => 'Campus'
     }
 
-    vocab_options_hash = VocabularyService.vocab_options_hash(@access_field)
+    vocab_options_hash = VocabularyService.vocab_options_hash(access_field)
     assert_equal(expected_hash, vocab_options_hash)
   end
 


### PR DESCRIPTION
Removed the "access" field from the Item, Poster, Letter, and Issue content models. This remotes the "Access Level" field from the item metadata edit page.

Updated the "test/services/vocabulary_service_test.rb", which was using the "access" field from the content model in one of the tests to use a locally-generated example of the field.

https://umd-dit.atlassian.net/browse/LIBFCREPO-1440