### PR TITLE
LIBFCREPO-1444. Changed "Collection" to "Administrative Set" in GUI

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -82,7 +82,9 @@ class CatalogController < ApplicationController # rubocop:disable Metrics/ClassL
     # :index_range can be an array or range of prefixes that will be used to create the navigation
     # (note: It is case sensitive when searching values)
 
-    config.add_facet_field 'collection_title_facet', label: 'Collection', limit: 10, collapse: false, sort: 'index'
+    # rubocop:disable Metrics/LineLength
+    config.add_facet_field 'collection_title_facet', label: 'Administrative Set', limit: 10, collapse: false, sort: 'index'
+    # rubocop:enable Metrics/LineLength
     config.add_facet_field 'presentation_set_label', label: 'Presentation Set', limit: 10, collapse: false,
                                                      sort: 'index', if: :collection_facet_selected?
     config.add_facet_field 'author_not_tokenized', label: 'Author', limit: 10

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -79,7 +79,7 @@ en:
           true: 'Yes'
           false: 'No'
         cas_user: User
-        collection: Collection
+        collection: Administrative Set
         id: Job ID
         metadata_file: Metadata File
         model: Content Model


### PR DESCRIPTION
To better align with current terminology, relabelled "Collection" to "Administrative Set" in the following places:

1) The "Limit your Search" facet display in the left sidebar on the
   search page - "app/controllers/catalog_controller.rb"

2) The "New Import Job" form - "config/locales/en.yml"

https://umd-dit.atlassian.net/browse/LIBFCREPO-1444