### PR TITLE
LIBFCREPO-1445. Show "Presentation Set" facets at all times in Archleon

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -82,11 +82,9 @@ class CatalogController < ApplicationController # rubocop:disable Metrics/ClassL
     # :index_range can be an array or range of prefixes that will be used to create the navigation
     # (note: It is case sensitive when searching values)
 
-    # rubocop:disable Metrics/LineLength
-    config.add_facet_field 'collection_title_facet', label: 'Administrative Set', limit: 10, collapse: false, sort: 'index'
-    # rubocop:enable Metrics/LineLength
     config.add_facet_field 'presentation_set_label', label: 'Presentation Set', limit: 10, collapse: false,
-                                                     sort: 'index', if: :collection_facet_selected?
+                                                     sort: 'index'
+    config.add_facet_field 'collection_title_facet', label: 'Administrative Set', limit: 10, sort: 'index'
     config.add_facet_field 'author_not_tokenized', label: 'Author', limit: 10
     config.add_facet_field 'type', label: 'Type', limit: 10
     config.add_facet_field 'component_not_tokenized', label: 'Resource Type', limit: 10


### PR DESCRIPTION
In “app/controllers/catalog_controller.rb”, modified the facets in the
“Limit your Search” sidebar, so that:

* The “Presentation Set” facet is at the top of the list, and shown as
  “open” by default.
* The “Administrative Set” facet has been moved to the second position,
  and is "closed" by default.

https://umd-dit.atlassian.net/browse/LIBFCREPO-1445