### PR TITLE
LIBFCREPO-1448. Removed "jquery_ujs" to fix doubled confirmation popup

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,7 +13,6 @@
 //= require rails-ujs
 //= require activestorage
 //= require jquery
-//= require jquery_ujs
 
 // Required by Blacklight
 //= require blacklight/blacklight


### PR DESCRIPTION
Removed the "jquery_ujs" JavaScript dependency, which should have been removed as part of the Rails 4 to Rails 5 migration (it was replaced in Rails 5 with the "rails-ujs" dependency).

This has done (as suggested in https://stackoverflow.com/a/55239361) to fix the "data-confirm" confirmation dialog pop appearing twice.

https://umd-dit.atlassian.net/browse/LIBFCREPO-1448