### PR TITLE
LIBFCREPO-1458. Added optional "edit_only" content model field

### DIFF
--- a/app/views/catalog/_show_default.html.erb
+++ b/app/views/catalog/_show_default.html.erb
@@ -9,6 +9,9 @@
     <%
       fields = @resource[:content_model][level]
       fields.each do |field|
+        # Skip display of any fields that are "edit_only"
+        next if field[:edit_only]
+
         # special handling for the access field
         if field[:name] == 'access'
           vocab = VocabularyService.get_vocabulary(field[:vocab])

--- a/config/content_models.yml
+++ b/config/content_models.yml
@@ -137,6 +137,7 @@ Item:
       type: :ControlledURIRef
       vocab: 'set'
       repeatable: true
+      edit_only: true
 
 
 Letter:

--- a/docs/ContentModelDefinitions.md
+++ b/docs/ContentModelDefinitions.md
@@ -63,3 +63,5 @@ A field definition may also have the following optional attributes:
   that are displayed in the GUI. Terms in the array (specified by the "label"
   attribute) will be displayed. If this attribute is not provided, all terms
   from the vocabulary are displayed.
+* `edit_only` - Set as `edit_only: true` to indicate that the field should
+  only be displayed in the metadata edit form, not on the item detail page.


### PR DESCRIPTION
Added an optional "edit_only" field to the content model definition to enable specific fields, such as "Presentation Set" to not be displayed on the item detail page.

This is needed because otherwise the "Presentation Set" field would be shown twice on the item detail page -- once for the Solr-based field specified in the “app/controllers/catalog_controller.rb” configuration and once for the Fedora-based field specified in the “config/content_models.yml” file.

Based on June 26, 2024 WebEx discussions in the “Fedora” channel with Josh Westgard, the preference is to display the Solr field on the item detail page because:

> ... that way we know that the update has "stuck" all the way throughthe stack. So even though there is a delay associated with making such a change, in the long run this is better for display in Archelon.

Modified the "_show_default.html.erb" file to skip display of any fields where the "edit_only" field is true.

Updated the "ContentModelDefinitions.md" documentation.

https://umd-dit.atlassian.net/browse/LIBFCREPO-1458