### PR TITLE
LIBFCREPO-1460. Fix "ControlledURIRef" delete when "Repeatable"

### DIFF
--- a/app/javascript/components/ControlledURIRef.jsx
+++ b/app/javascript/components/ControlledURIRef.jsx
@@ -75,6 +75,12 @@ class ControlledURIRef extends React.Component {
     );
   };
 
+  componentWillUnmount() {
+    if (this.props.notifyContainer && !this.props.value.isNew) {
+      this.props.notifyContainer(this.initialStatement)
+    }
+  }
+
   render () {
     let statement = this.getStatement(this.state.uri);
     let valueIsUnchanged = (this.initialStatement === statement);

--- a/app/views/catalog/_show_default.html.erb
+++ b/app/views/catalog/_show_default.html.erb
@@ -9,6 +9,9 @@
     <%
       fields = @resource[:content_model][level]
       fields.each do |field|
+        # Skip display of any fields that are "edit_only"
+        next if field[:edit_only]
+
         # special handling for the access field
         if field[:name] == 'access'
           vocab = VocabularyService.get_vocabulary(field[:vocab])

--- a/config/content_models.yml
+++ b/config/content_models.yml
@@ -137,6 +137,7 @@ Item:
       type: :ControlledURIRef
       vocab: 'set'
       repeatable: true
+      edit_only: true
 
 
 Letter:

--- a/docs/ContentModelDefinitions.md
+++ b/docs/ContentModelDefinitions.md
@@ -63,3 +63,5 @@ A field definition may also have the following optional attributes:
   that are displayed in the GUI. Terms in the array (specified by the "label"
   attribute) will be displayed. If this attribute is not provided, all terms
   from the vocabulary are displayed.
+* `edit_only` - Set as `edit_only: true` to indicate that the field should
+  only be displayed in the metadata edit form, not on the item detail page.


### PR DESCRIPTION
In LIBHYDRA-356, a "componentWillUnmount" method was added to the React
components to support deletion when used with the "Repeatable" React
component. The "ControlledURIRef" component apparently missed in the
update.

Added the "componentWillUnmount" to fix the issue with deleting entries
when the "ControlledURIRef" component is used with a "Repeatable" React
component.

https://umd-dit.atlassian.net/browse/LIBFCREPO-1460