### PR TITLE
LIBFCREPO-1491: Adding terms_of_use_text to catalog_controller

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -135,6 +135,7 @@ class CatalogController < ApplicationController # rubocop:disable Metrics/ClassL
     # Note that as of implementation of in-browser editing of descriptive metadata,
     # the only fields being displayed from Solr are those relating to structural,
     # administrative, and technical metadata.
+    config.add_show_field 'terms_of_use_text', label: 'Terms of Use'
     config.add_show_field 'pcdm_collection', label: 'Collection', helper_method: :collection_from_subquery
     config.add_show_field 'publication_status', label: 'Publication Status'
     config.add_show_field 'visibility', label: 'Visibility'

--- a/config/content_models.yml
+++ b/config/content_models.yml
@@ -108,6 +108,7 @@ Item:
       label: 'Terms of Use'
       type: :ControlledURIRef
       vocab: 'termsOfUse'
+      edit_only: true
 
     - name: 'copyright_notice'
       uri: 'https://schema.org/copyrightNotice'
@@ -228,6 +229,7 @@ Letter:
       label: 'Terms of Use'
       type: :ControlledURIRef
       vocab: 'termsOfUse'
+      edit_only: true
 
     - name: 'copyright_notice'
       uri: 'https://schema.org/copyrightNotice'
@@ -353,6 +355,7 @@ Poster:
       label: 'Terms of Use'
       type: :ControlledURIRef
       vocab: 'termsOfUse'
+      edit_only: true
 
     - name: 'copyright_notice'
       uri: 'https://schema.org/copyrightNotice'
@@ -407,6 +410,7 @@ Issue:
       label: 'Terms of Use'
       type: :ControlledURIRef
       vocab: 'termsOfUse'
+      edit_only: true
 
     - name: 'copyright_notice'
       uri: 'https://schema.org/copyrightNotice'

--- a/config/content_models.yml
+++ b/config/content_models.yml
@@ -108,7 +108,6 @@ Item:
       label: 'Terms of Use'
       type: :ControlledURIRef
       vocab: 'termsOfUse'
-      edit_only: true
 
     - name: 'copyright_notice'
       uri: 'https://schema.org/copyrightNotice'
@@ -229,7 +228,6 @@ Letter:
       label: 'Terms of Use'
       type: :ControlledURIRef
       vocab: 'termsOfUse'
-      edit_only: true
 
     - name: 'copyright_notice'
       uri: 'https://schema.org/copyrightNotice'
@@ -355,7 +353,6 @@ Poster:
       label: 'Terms of Use'
       type: :ControlledURIRef
       vocab: 'termsOfUse'
-      edit_only: true
 
     - name: 'copyright_notice'
       uri: 'https://schema.org/copyrightNotice'
@@ -410,7 +407,6 @@ Issue:
       label: 'Terms of Use'
       type: :ControlledURIRef
       vocab: 'termsOfUse'
-      edit_only: true
 
     - name: 'copyright_notice'
       uri: 'https://schema.org/copyrightNotice'


### PR DESCRIPTION
Have to also change the content_model to make the terms of use from fcrepo only appear in the edit section, so that it doesn't appear twice in the details.

https://umd-dit.atlassian.net/browse/LIBFCREPO-1491