### PR TITLE
LIBFCREPO-1523. Dynamic Status Updates for Import/Export/Publish Jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,9 @@ the GUI.
 
 See [ActionCable](docs/ActionCable.md) for more information.
 
+**Note:** In the local development environment, dynamic updates to *not* work
+in Firefox, but do work in Chrome and Safari.
+
 ## ActiveJob and Delayed::Job
 
 Archelon is configured to use the [Delayed::Job][delayed_job] queue adapter, via

--- a/README.md
+++ b/README.md
@@ -178,8 +178,9 @@ the GUI.
 
 See [ActionCable](docs/ActionCable.md) for more information.
 
-**Note:** In the local development environment, dynamic updates to *not* work
-in Firefox, but do work in Chrome and Safari.
+**Note:** In the local development environment, dynamic status updates (for
+Export Jobs, Import Jobs, and Publish Jobs) *may not* work in reliably in
+Firefox, but do appear to work consistently in Chrome and Safari.
 
 ## ActiveJob and Delayed::Job
 

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,4 +1,24 @@
+# frozen_string_literal: true
+
 module ApplicationCable
+  # Set ups Action Cable connection for authenticated users
   class Connection < ActionCable::Connection::Base
+    identified_by :current_user
+
+    def connect
+      find_verified_user
+      @current_user = find_verified_user
+      logger.add_tags 'ActionCable', "CasUser id: #{@current_user.id}"
+    end
+
+    protected
+
+      def find_verified_user
+        verified_user = CasUser.find_by(cas_directory_id: cookies.signed[:cas_user])
+
+        return verified_user if verified_user
+
+        reject_unauthorized_connection
+      end
   end
 end

--- a/app/channels/export_jobs_channel.rb
+++ b/app/channels/export_jobs_channel.rb
@@ -21,6 +21,7 @@ class ExportJobsChannel < ApplicationCable::Channel
     export_job = ExportJob.find(job_id)
     return if export_job.nil?
 
+    Rails.logger.debug("Performing ExportJobStatusUpdatedJob ExportJob #{job_id}")
     ExportJobStatusUpdatedJob.perform_now(export_job)
   end
 

--- a/app/channels/import_jobs_channel.rb
+++ b/app/channels/import_jobs_channel.rb
@@ -22,6 +22,7 @@ class ImportJobsChannel < ApplicationCable::Channel
     import_job = ImportJob.find(job_id)
     return if import_job.nil?
 
+    Rails.logger.debug("Performing ImportJobStatusUpdatedJob ImportJob #{job_id}")
     ImportJobStatusUpdatedJob.perform_now(import_job)
   end
 

--- a/app/channels/publish_jobs_channel.rb
+++ b/app/channels/publish_jobs_channel.rb
@@ -14,6 +14,7 @@ class PublishJobsChannel < ApplicationCable::Channel
     publish_job = PublishJob.find(job_id)
     return if publish_job.nil?
 
+    Rails.logger.debug("Performing PublishJobStatusUpdatedJob PublishJob #{job_id}")
     PublishJobStatusUpdatedJob.perform_now(publish_job)
   end
 

--- a/app/channels/publish_jobs_channel.rb
+++ b/app/channels/publish_jobs_channel.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# PublishJobs Channel for Intercting with Action Cable
+class PublishJobsChannel < ApplicationCable::Channel
+  def subscribed
+    publish_job = PublishJob.find(params[:id])
+    username = current_user.cas_directory_id
+    Rails.logger.debug("Received subscription for PublishJob #{publish_job.id} from user #{username}")
+    stream_for publish_job if authorized_to_stream publish_job
+  end
+
+  def publish_job_status_check(data)
+    job_id = data['jobId']
+    publish_job = PublishJob.find(job_id)
+    return if publish_job.nil?
+
+    PublishJobStatusUpdatedJob.perform_now(publish_job)
+  end
+
+  private
+
+    def username
+      current_user.cas_directory_id
+    end
+
+    # confirm that the current user should be able to subscribe to this publish job
+    def authorized_to_stream(publish_job)
+      if current_user.admin? || publish_job.cas_user == current_user
+        Rails.logger.debug("Streaming Publish Job #{publish_job.id} for user #{username}")
+        true
+      else
+        Rails.logger.warning("User #{username} does not have permission to view PublishJob #{publish_job.id}")
+        false
+      end
+    end
+end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -12,6 +12,8 @@ import './add_rails_ujs'
 
 import './resource'
 
+import "./channels"
+
 // Load in React components
 import components from "./components/**/*.jsx"
 
@@ -25,5 +27,3 @@ const ReactRailsUJS = require("react_ujs")
 ReactRailsUJS.getConstructor = (name) => {
   return componentsContext[name]
 }
-
-import "./channels"

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -25,3 +25,5 @@ const ReactRailsUJS = require("react_ujs")
 ReactRailsUJS.getConstructor = (name) => {
   return componentsContext[name]
 }
+
+import "./channels"

--- a/app/javascript/channels/consumer.js
+++ b/app/javascript/channels/consumer.js
@@ -1,0 +1,8 @@
+// Action Cable provides the framework to deal with WebSockets in Rails.
+// You can generate new channels where WebSocket features live using the `bin/rails generate channel` command.
+
+import { createConsumer } from "@rails/actioncable"
+
+export default createConsumer()
+
+const consumer = createConsumer

--- a/app/javascript/channels/export_jobs_channel.js
+++ b/app/javascript/channels/export_jobs_channel.js
@@ -1,0 +1,30 @@
+import consumer from "./consumer"
+
+$(document).ready(function() {
+  document.querySelectorAll('.export-job[data-subscribe="true"]').forEach(function(exportJobRow) {
+    const {exportJobId} = exportJobRow.dataset;
+    consumer.subscriptions.create({ channel: "ExportJobsChannel", id: exportJobId }, {
+      connected() {
+        // Called when the subscription is ready for use on the server
+        console.log('Subscription confirmed for ExportJob ' + exportJobId);
+        this.perform('export_job_status_check', {jobId: exportJobId});
+      },
+
+      disconnected() {
+        console.log('Disconnected from ExportJob ' + exportJobId);
+      },
+
+      received(data) {
+        // Called when there's incoming data on the websocket for this channel
+        console.log('Received message for ExportJob ' + exportJobId)
+        // Update the display for the export job
+        const {job, statusWidget} = data;
+        console.log('ExportJob ' + exportJobId + ' state: ' + job.state + '; progress: ' + job.progress);
+        let oldWidget = $('[data-job-id="' + job.id + '"]');
+        if (oldWidget && statusWidget) {
+          oldWidget.replaceWith(statusWidget)
+        }
+      },
+    });
+  });
+});

--- a/app/javascript/channels/import_jobs_channel.js
+++ b/app/javascript/channels/import_jobs_channel.js
@@ -1,0 +1,35 @@
+import consumer from "./consumer"
+
+$(document).ready(function() {
+  // subscribe to all relevant import jobs on this page
+  document.querySelectorAll('.import-job[data-subscribe="true"]').forEach(function(importJobRow) {
+    const {importJobId} = importJobRow.dataset;
+    consumer.subscriptions.create({channel: 'ImportJobsChannel', id: importJobId}, {
+      connected: function() {
+        console.log('Subscription confirmed for ImportJob ' + importJobId);
+        this.perform('import_job_status_check', {jobId: importJobId});
+      },
+
+      received: function (data) {
+        console.log('Received message for ImportJob ' + importJobId)
+        // Update the status widget for the job in the received message
+        const {job, statusWidget} = data;
+        const {binaries_count, item_count} = job;
+        console.log('ImportJob ' + importJobId + ' state: ' + job.state + '; progress: ' + job.progress);
+        let oldWidget = $('[data-job-id="' + job.id + '"]');
+        if (oldWidget && statusWidget) {
+          oldWidget.replaceWith(statusWidget)
+        }
+        // update count columns
+        let td = document.querySelector('[data-job-id="' + job.id + '"]');
+        td.parentElement.querySelector('.binaries-count').innerHTML = binaries_count;
+        td.parentElement.querySelector('.item-count').innerHTML = item_count;
+      },
+
+      disconnected: function() {
+        console.log('Disconnected from ImportJob ' + importJobId);
+      }
+    });
+    console.log('Subscribed to ImportJobsChannel, id: ' + importJobId);
+  });
+});

--- a/app/javascript/channels/index.js
+++ b/app/javascript/channels/index.js
@@ -1,3 +1,4 @@
 // Import all the channels to be used by Action Cable
 import "./export_jobs_channel"
 import "./import_jobs_channel"
+import "./publish_jobs_channel"

--- a/app/javascript/channels/index.js
+++ b/app/javascript/channels/index.js
@@ -1,0 +1,2 @@
+// Import all the channels to be used by Action Cable
+import "./export_jobs_channel"

--- a/app/javascript/channels/index.js
+++ b/app/javascript/channels/index.js
@@ -1,2 +1,3 @@
 // Import all the channels to be used by Action Cable
 import "./export_jobs_channel"
+import "./import_jobs_channel"

--- a/app/javascript/channels/publish_jobs_channel.js
+++ b/app/javascript/channels/publish_jobs_channel.js
@@ -1,0 +1,35 @@
+import consumer from "./consumer"
+
+$(document).ready(function() {
+  // subscribe to all relevant publish jobs on this page
+  document.querySelectorAll('.publish-job[data-subscribe="true"]').forEach(function(publishJobRow) {
+    const {publishJobId} = publishJobRow.dataset;
+    consumer.subscriptions.create({channel: 'PublishJobsChannel', id: publishJobId}, {
+      connected: function() {
+        console.log('Subscription confirmed for PublishJob ' + publishJobId);
+        this.perform('publish_job_status_check', {jobId: publishJobId});
+      },
+
+      received: function (data) {
+        console.log('Received message for PublishJob ' + publishJobId)
+        // Update the status widget for the job in the received message
+        const {job, statusWidget} = data;
+      //   const {binaries_count, item_count} = job;
+        console.log('PublishJob ' + publishJobId + ' state: ' + job.state + '; progress: ' + job.progress);
+        let oldWidget = $('[data-job-id="' + job.id + '"]');
+        if (oldWidget && statusWidget) {
+          oldWidget.replaceWith(statusWidget)
+        }
+        // update count columns
+        let td = document.querySelector('[data-job-id="' + job.id + '"]');
+      //   td.parentElement.querySelector('.binaries-count').innerHTML = binaries_count;
+      //   td.parentElement.querySelector('.item-count').innerHTML = item_count;
+      },
+
+      disconnected: function() {
+        console.log('Disconnected from PublishJob ' + publishJobId);
+      }
+    });
+    console.log('Subscribed to PublishJobsChannel, id: ' + publishJobId);
+  });
+});

--- a/app/jobs/export_job_status_updated_job.rb
+++ b/app/jobs/export_job_status_updated_job.rb
@@ -5,6 +5,10 @@ class ExportJobStatusUpdatedJob < ApplicationJob
   retry_on RuntimeError
 
   def perform(export_job)
+    Rails.logger.debug(
+      "Broadcasting ExportJob #{export_job.id} to ExportJobsChannel, " +
+      "status=#{export_job.state}, progress=#{export_job.progress_text}"
+    )
     ExportJobsChannel.broadcast_to(export_job, job: export_job, statusWidget: status_widget(export_job))
   end
 

--- a/app/jobs/import_job_status_updated_job.rb
+++ b/app/jobs/import_job_status_updated_job.rb
@@ -5,6 +5,10 @@ class ImportJobStatusUpdatedJob < ApplicationJob
   retry_on RuntimeError
 
   def perform(import_job)
+    Rails.logger.debug(
+      "Broadcasting ImportJob #{import_job.id} to ImportJobsChannel, " +
+      "status=#{import_job.state}, progress=#{import_job.progress_text}"
+    )
     ImportJobsChannel.broadcast_to(import_job, job: import_job, statusWidget: status_widget(import_job))
   end
 

--- a/app/jobs/publish_job_status_updated_job.rb
+++ b/app/jobs/publish_job_status_updated_job.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Job for broadcasting publish job status over Action Cable to clients
+class PublishJobStatusUpdatedJob < ApplicationJob
+  retry_on RuntimeError
+
+  def perform(publish_job)
+    PublishJobsChannel.broadcast_to(publish_job, job: publish_job, statusWidget: status_widget(publish_job))
+  end
+
+  private
+
+    def status_widget(publish_job)
+      ActionController::Renderer.for(PublishJobsController).render(
+        partial: 'publish_job_status',
+        locals: { publish_job: publish_job }
+      )
+    end
+end

--- a/app/jobs/publish_job_status_updated_job.rb
+++ b/app/jobs/publish_job_status_updated_job.rb
@@ -5,6 +5,10 @@ class PublishJobStatusUpdatedJob < ApplicationJob
   retry_on RuntimeError
 
   def perform(publish_job)
+    Rails.logger.debug(
+      "Broadcasting PublishJob #{publish_job.id} to PublishJobsChannel, " +
+      "status=#{publish_job.state}, progress=#{publish_job.progress_text}"
+    )
     PublishJobsChannel.broadcast_to(publish_job, job: publish_job, statusWidget: status_widget(publish_job))
   end
 

--- a/app/views/import_jobs/_import_job_status.erb
+++ b/app/views/import_jobs/_import_job_status.erb
@@ -2,7 +2,7 @@
   <%= link_to status_text(import_job), import_job_path(import_job), class: "import_job_status_#{import_job.state}" %>
   <% if import_job.stalled? %>(may be stalled)<% end %>
   <% if import_job.validate_success? %>
-    <%= form_with model: import_job, method: :post, url: perform_import_import_jobs_path(import_job) do |form| %>
+    <%= form_with model: import_job, method: :post, local: false, url: perform_import_import_jobs_path(import_job) do |form| %>
       <%= form.submit 'Import', class: 'btn-xs btn-success' %>
     <% end %>
   <% elsif import_job.validate_failed? or import_job.validate_error? %>

--- a/app/views/publish_jobs/_publish_job_status.html.erb
+++ b/app/views/publish_jobs/_publish_job_status.html.erb
@@ -4,6 +4,6 @@
   <% if publish_job.publish_complete? %>
     (Job Succeeded)
   <% elsif publish_job.publish_incomplete? or publish_job.publish_error? %>
-    <%= link_to 'View Job', publish_job_url(publish_job), class: 'btn-xs btn-danger' %>
+    <%= link_to 'View Job', publish_job_path(publish_job), class: 'btn-xs btn-danger' %>
   <% end %>
 </td>

--- a/docs/ActionCable.md
+++ b/docs/ActionCable.md
@@ -10,20 +10,21 @@ See <https://guides.rubyonrails.org/v7.1/action_cable_overview.html> for
 an overview on Action Cable in Rails 7.1.
 
 ----
-**Note: Action Cable, Local Development Environment and Firefox**
+**Note:** Action Cable, Local Development Environment and Firefox
 
-Action Cable does not work correctly with Firefox in the local development
-environment, so dynamic status updates WILL NOT occur (it is necessary to
-refresh the browser page periodically to see the status updates).
+Action Cable may not work reliably with Firefox in the local development
+environment, so dynamic status updates MAY NOT occur (in which case
+it is necessary to refresh the browser page periodically to see the status
+updates).
 
-Dynamic status updates DO work in the local development environment when using
-Chrome or Safari.
+Dynamic status updates DO appear to work reliably in the local development
+environment when using Chrome or Safari.
 
 It is unclear why this is the case, but is possibly related to the use of
 "archelon-local", instead of "localhost" as the hostname in the local
 development environment, as a typical error seen in the browser console is:
 
-```
+```text
 Firefox can’t establish a connection to the server at ws://archelon-local:3000/cable.
 ```
 

--- a/docs/ActionCable.md
+++ b/docs/ActionCable.md
@@ -1,0 +1,95 @@
+# Action Cable
+
+## Introduction
+
+Archelon uses the Rails "Action Cable" functionality to provide dynamic updates
+to the GUI, in particular status updates for Export Jobs, Import Jobs, and
+Publish Jobs.
+
+See <https://guides.rubyonrails.org/v7.1/action_cable_overview.html> for
+an overview on Action Cable in Rails 7.1.
+
+----
+**Note: Action Cable, Local Development Environment and Firefox**
+
+Action Cable does not work correctly with Firefox in the local development
+environment, so dynamic status updates WILL NOT occur (it is necessary to
+refresh the browser page periodically to see the status updates).
+
+Dynamic status updates DO work in the local development environment when using
+Chrome or Safari.
+
+It is unclear why this is the case, but is possibly related to the use of
+"archelon-local", instead of "localhost" as the hostname in the local
+development environment, as a typical error seen in the browser console is:
+
+```
+Firefox can’t establish a connection to the server at ws://archelon-local:3000/cable.
+```
+
+It is not possible to use "localhost" as the hostname, due to DIT restrictions
+on the CAS server (the CAS server does not allow authentication from
+"localhost").
+
+----
+
+## Action Cable Server
+
+Action Cable runs "in app", so a separate stand-alone Action Cable server
+is not required.
+
+The application listens for WebSocket requests on the default "/cable"
+endpoint.
+
+## Channel Adapters
+
+By default, Archelon uses the `aync` adapter in all environments, including
+production.
+
+While the documentation indicates that the "async" adapter is only for
+development/testing (because it does not persist, doesn't scale, and may not be
+reliable), it is likely sufficient for our current use case of using it to
+process status updates.
+
+Previously the PostgreSQL adapter was used, but proved not be reliable, as it
+did not gracefully handle unexpected terminations of the database connection
+(see [LIBHYDRA-415](https://umd-dit.atlassian.net/browse/LIBHYDRA-415)).
+
+The Redis adapater has been considered in the past, but not implemented.
+
+## Action Cable Messages
+
+Action Cable messages provide status updates for export, import, and publish
+jobs, so in the following "jobs" refers to all three types.
+
+When running jobs, the status of the jobs is updated dynamically using the
+Rails "Action Cable" functionality. Action Cable enables the browser to receive
+messages from the server containing data about job status.
+Browser-side JavaScript is then used to update the relevant portion of the page,
+so that the status information is displayed to the user without having to
+perform a page reload.
+
+### Developer Information
+
+**Note:** The following is developer-level information about how the
+dynamic status updates is implemented. It is not necessary to understand this
+information to perform exports or imports through the GUI.
+
+#### Channel Streams
+
+For each job in a state other than "complete", the ActionCable client on the
+jobs' index page creates a subscription to that job. A subscription is only
+created if the authenticated user is either the creator of the job, or if they
+are an admin.
+
+#### Channel Data
+
+Status updates to the channels consist of a JSON object with the following
+attributes:
+
+* `job` - a JSON-serialized representation of the ImportJob or ExportJob object
+* `statusWidget` - HTML representing the status to display for the job
+
+The browser-side JavaScript uses the id in the "job" field to locate the
+appropriate DOM element using the "data-job-id" HTML attribute, and replaces
+the HTML of the element with the "statusWidget" content.

--- a/docs/Archelon2.0MigrationNotes.md
+++ b/docs/Archelon2.0MigrationNotes.md
@@ -88,6 +88,24 @@ the following files to fail:
 * test/controllers/cas_users_controller_test.rb
 * test/jobs/delete_old_exports_job_test.rb
 
+### JavaScript assets moved to app/javascript
+
+In Rails 6, JavaScript assets moved from "app/assets/javascripts" to
+"app/javascript".
+
+### esbuild and JavaScript
+
+The "esbuild" tool does not automatically pick up JavaScript files in the
+"app/javascript" directory. Instead, it uses "app/javascript/application.js"
+as the "entry point" file, incorporating all the files that it imports (and,
+transitively, all the files they import). This means that when adding a
+JavaScript file, it may be necessary to add an "import" statement in the
+"app/javascript/application.js" for the added file to be "reachable"
+for the build tool.
+
+To check whether "esbuild" can reach the file, examine the compiled JavaScript
+in the "app/assets/builds" directory.
+
 ### Blacklight::SearchHelper replaced by Blacklight::Searchable
 
 The “Blacklight::SearchHelper”
@@ -128,9 +146,9 @@ using the “older argument” style, a literal hash is required around the
 
 ### Form “data-remote: true”/”local:false”
 
-* https://stackoverflow.com/a/75410391
-* https://stackoverflow.com/a/45305004
-* https://github.com/rails/rails/issues/49499
+* <https://stackoverflow.com/a/75410391>
+* <https://stackoverflow.com/a/45305004>
+* <https://github.com/rails/rails/issues/49499>
 
 For forms expecting an AJAX response, add `local: false`, to the ERB tag. This
 causes the `data-remote:true` attribute to be added to the form. For example in
@@ -246,8 +264,6 @@ of the method.
 
 The database for tests is now in “storage/” instead of “db/”.
 
-
-
 ### foreman and dotenv
 
 Rails 7.1 uses the “foreman” gem to run the asset pipeline watchers and the
@@ -294,7 +310,7 @@ Needed to pin the “sass” package in “package.json” to v1.77.6, because i
 v1.77.7 a large number of deprecation warnings coming from Bootstrap were
 being printed to the console:
 
-```
+```text
 3:11:14 css.1  | DEPRECATION WARNING: Sass's behavior for declarations that appear after nested
 13:11:14 css.1  | rules will be changing to match the behavior specified by CSS in an upcoming
 13:11:14 css.1  | version. To keep the existing behavior, move the declaration above the nested

--- a/docs/RailsAssetPipeline.md
+++ b/docs/RailsAssetPipeline.md
@@ -5,6 +5,31 @@
 This document attempts to provide background and useful information to
 developers about the Rails asset pipeline in use by Archelon.
 
+## TL;DR
+
+### JavaScript
+
+JavaScript assets should be placed in the "app/javascript" directory.
+
+The "esbuild" tool is used to convert JavaScript assets into browser-usable
+files. JavaScript files are found by the tool using the
+"app/javascript/application.js" file as an "entry point". All JavaScript to
+be included in the build must be "reachable" via this file, either by direct
+import, or transitively by being imported by a file that is imported.
+
+This means that when adding a JavaScript file, it may be necessary to add an
+"import" for it in the "app/javascript/application.js" file, if it is not
+otherwise reachable.
+
+If uncertain whether "esbuild" is reaching a file, check the compiled
+JavaScript in the "app/assets/builds" directory.
+
+### CSS
+
+CSS handling is largely the same as in previous versions, with the
+"app/assets/stylesheets/application.scss" file acting as the entry point for
+CSS processing.
+
 ## Background
 
 The Rails-recommended default for the asset pipeline has changed significantly

--- a/lib/tasks/stomp.rake
+++ b/lib/tasks/stomp.rake
@@ -13,7 +13,7 @@ namespace :stomp do # rubocop:disable Metrics/BlockLength
 
     listener.subscribe(:job_status, 'client-individual') do |stomp_msg|
       message = PlastronMessage.new(stomp_msg)
-      puts "Updating job status for #{message.job_id}"
+      puts "Updating job status for #{message.job_id}, message headers='#{message.headers}', message body='#{message.body}'"
 
       begin
         # Wrapping in "with_connection" in case connection has timed out
@@ -33,7 +33,7 @@ namespace :stomp do # rubocop:disable Metrics/BlockLength
       message = PlastronMessage.new(stomp_msg)
       # ignore synchronous job progress messages
       unless message.job_id.start_with? 'SYNCHRONOUS'
-        puts "Updating job progress for #{message.job_id}"
+        puts "Updating job progress for #{message.job_id}, message headers='#{message.headers}', message body='#{message.body}''"
 
         begin
           # Wrapping in "with_connection" in case connection has timed out

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "dependencies": {
     "@github/auto-complete-element": "^3.6.2",
     "@popperjs/core": "^2.11.8",
+    "@rails/actioncable": "^7.2.0",
     "@rails/ujs": "^7.1.3-4",
     "autoprefixer": "^10.4.19",
     "blacklight-frontend": "^8.3.0",

--- a/test/channels/application_cable/connection_test.rb
+++ b/test/channels/application_cable/connection_test.rb
@@ -1,13 +1,33 @@
-require "test_helper"
+# frozen_string_literal: true
+
+require 'test_helper'
 
 module ApplicationCable
   class ConnectionTest < ActionCable::Connection::TestCase
-    # test "connects with cookies" do
-    #   cookies.signed[:user_id] = 42
-    #
-    #   connect
-    #
-    #   assert_equal connection.user_id, "42"
-    # end
+    test 'connection is created for valid users' do
+      cookies.signed[:cas_user] = 'test_user'
+
+      # Simulate a connection
+      connect
+
+      # Asserts that the connection identifier is correct
+      assert_equal 'test_user', connection.current_user.cas_directory_id
+    end
+
+    test 'connection is not created for nonexistent user' do
+      cookies.signed[:cas_user] = 'user_does_not_exist'
+
+      # Simulate a connection
+      assert_reject_connection do
+        connect
+      end
+    end
+
+    test 'does not connect without user' do
+      # Simulate a connection
+      assert_reject_connection do
+        connect
+      end
+    end
   end
 end

--- a/yarn.lock
+++ b/yarn.lock
@@ -394,6 +394,11 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.8.tgz#6b79032e760a0899cd4204710beede972a3a185f"
   integrity sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==
 
+"@rails/actioncable@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-7.2.0.tgz#dee66d21bc125a9819dc8080ce896eac78d8c63f"
+  integrity sha512-crcsPF3skrqJkFZLxesZoyUEt8ol25XtTuOAUMdLa5qQKWTZpL8eLVW71bDCwKDQLbV2z5sBZ/XGEC0i+ZZa+A==
+
 "@rails/ujs@^7.1.3-4":
   version "7.1.3-4"
   resolved "https://registry.yarnpkg.com/@rails/ujs/-/ujs-7.1.3-4.tgz#1dddea99d5c042e8513973ea709b2cb7e840dc2d"


### PR DESCRIPTION
Implemented dynamic status updates for import jobs, exports jobs, and
publish jobs using Rails Action Cable.

**Note:** In the local development environment dynamic updates do **not**
work with Firefox. They do work with Chrome and Safari.

https://umd-dit.atlassian.net/browse/LIBFCREPO-1523