### PR TITLE
LIBFCREPO-1551. Implemented OmniAuth "developer" strategy to bypass CAS

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,44 @@ this application is vulnerable to CVE-2015-9284, due to its use of the
 As configured, this application uses CAS for authentication. As the application
 does not use OAuth it is not vulnerable to CVE-2015-9284.
 
+## CAS Bypass to allow "localhost"
+
+In the local development environment, the Rails Action Cable functionality does
+not work in Firefox by default because the "archelon-local" hostname is used,
+instead of "localhost".
+
+To enable use of "localhost", the CAS login must be bypassed. To do this:
+
+1) Edit the "config/environments/development.rb" file and add "localhost" to
+   the list of "config.hosts", i.e.:
+
+   ```
+     config.hosts = [
+       "archelon-local",
+       "localhost"
+     ]
+   ```
+
+2) Run the application, setting the "ARCHELON_AUTH" environment variable
+   to "developer", i.e:
+
+   ```
+   $ ARCHELON_AUTH=developer bin/dev
+   ```
+
+3) In a web browser go to
+
+    <http://localhost:3000/>
+
+    Instead of a CAS login, a simple form with a "Uid" field will be displayed.
+    Enter the username of any user in LDAP, to be logged in as that user.
+
+This functionality uses the OmniAuth "[developer][omniauth_developer]" strategy,
+and is only available in the local development environment
+(`ENV["RAILS_ENV"] == "development"`) and when the `ARCHELON_AUTH` environment
+variable is set to "developer" (see the `use_developer_login` method in
+[app/helpers/cas_helper.rb](app/helpers/cas_helper.rb)).
+
 ## Action Cable
 
 The Rails "Action Cable" functionality is used to provide dynamic updates to
@@ -230,6 +268,7 @@ See the [LICENSE](LICENSE.md) file for license rights and limitations
 [delayed_job]: https://github.com/collectiveidea/delayed_job
 [delayed_job_active_record]: https://github.com/collectiveidea/delayed_job_active_record
 [fedora]: https://duraspace.org/fedora/
+[omniauth_developer]: https://github.com/omniauth/omniauth/blob/v1.9.2/lib/omniauth/strategies/developer.rb
 [plastron]: https://github.com/umd-lib/plastron
 [Solr]: https://github.com/umd-lib/umd-fcrepo-solr
 [stomp]: https://stomp.github.io/

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -2,6 +2,7 @@
 
 class SessionsController < ApplicationController
   skip_before_action :authenticate
+  skip_before_action :verify_authenticity_token, only: [:create] if CasHelper.use_developer_login
 
   def create # rubocop:disable Metrics/AbcSize
     @user = CasUser.find_or_create_from_auth_hash(request.env['omniauth.auth'])

--- a/app/helpers/cas_helper.rb
+++ b/app/helpers/cas_helper.rb
@@ -22,6 +22,11 @@ module CasHelper
     session[:cas_user]
   end
 
+  # Returns true if "developer" login bypass should be used
+  def self.use_developer_login
+    ENV["RAILS_ENV"] == "development" && ENV["ARCHELON_AUTH"] == 'developer'
+  end
+
   private
 
     # Returns true if entry is authorized, false otherwise.

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -4,7 +4,11 @@
 CAS_URL = "https://login.umd.edu/cas"
 
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :cas, url: CAS_URL
+  if CasHelper.use_developer_login
+    provider :developer, fields: [:uid], uid_field: :uid
+  else
+    provider :cas, url: CAS_URL
+  end
 end
 
 OmniAuth.config.logger = Rails.logger

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,10 +37,12 @@ Rails.application.routes.draw do
   get '/cas_users/:id/history' => 'cas_users#show_history'
   get 'public_keys' => 'public_keys#index'
 
-  get 'login', to: redirect('/auth/cas'), as: 'login'
+  get 'login', to: redirect('/auth/cas'), as: 'login' unless CasHelper.use_developer_login
+  get 'login', to: redirect('/auth/developer'), as: 'login' if CasHelper.use_developer_login
   get 'admin/user/login_as/:user_id', to: 'sessions#login_as', as: 'admin_user_login_as'
   get 'logout', to: 'sessions#destroy', as: 'logout'
   get 'auth/:provider/callback', to: 'sessions#create'
+  post 'auth/:provider/callback', to: 'sessions#create'
   get 'auth/failure', to: redirect('/')
 
   get 'react_components' => 'react_components#react_components'


### PR DESCRIPTION
Using CAS authentication for Archelon in the local development environment is problematic because DIT does not allow the “localhost” hostname to communicate with the CAS server.

To work around this, Archelon uses the “archelon-local” hostname in the local development environment.

This works for most Rails functionality, but appears to break Rails ActionCable functionality in Firefox, where the web browser can never subscribe to the ActionCable channels provided by the server.

This implementation uses the OmniAuth “developer” strategy (see <https://github.com/omniauth/omniauth/blob/v1.9.2/lib/omniauth/strategies/developer.rb>) which instead of going to CAS, presents a form with a single “Uid” field.

Note: Because Archelon uses the provided username to pull information from LDAP, only “active” LDAP users can be used (for example “blparker” for “Bria Parker” will not work, because she is presumably no longer in LDAP, while “lshiota” for Lisa Shiota does work).

The OmniAuth “developer” strategy is only available in the Rails “development” environment (`ENV["RAILS_ENV"] == "development"` and an `ARCHELON_AUTH` environment variable set to `developer`. This should make it impossible to accidentally trigger the authorization method in production.

In order to use the "localhost" hostname, the “config.hosts” environment variable in “config/environments/development.rb” must be changed to:

```
config.hosts = [
    "archelon-local",
    "localhost"
  ]
```

While possible to include both hostname all the time, it seemed like that might prove confusing.

https://umd-dit.atlassian.net/browse/LIBFCREPO-1551