### PR TITLE
LIBFCREPO-1522: Selected Item Functionality 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ test/reports
 # Ignore simplecov output
 coverage
 # End UMD Customization
+
+# Ignore third-party dependencies
+/vendor/bundle

--- a/Gemfile
+++ b/Gemfile
@@ -66,6 +66,7 @@ gem 'faker', '~> 3.4.1'
 gem 'net-http', '~> 0.4.1'
 # End UMD Blacklight 8 Fix
 
+gem 'turbo-rails'
 gem 'json-ld', '~> 3.3.1'
 
 gem 'http', '~> 5.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -382,6 +382,9 @@ GEM
     thor (1.3.1)
     tilt (2.4.0)
     timeout (0.4.1)
+    turbo-rails (2.0.11)
+      actionpack (>= 6.0.0)
+      railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     uri (0.13.0)
@@ -448,6 +451,7 @@ DEPENDENCIES
   simplecov-rcov
   sqlite3 (~> 1.4)
   stomp
+  turbo-rails
   tzinfo-data
   web-console
   webmock (~> 3.23.0)

--- a/app/components/blacklight/response/pagination_component.html.erb
+++ b/app/components/blacklight/response/pagination_component.html.erb
@@ -1,0 +1,31 @@
+<%= content_tag :section, class: 'paginate-section',  **html_attr do %>
+  <%= pagination %>
+
+  <% # UMD Customization %>
+  <% if helpers.current_or_guest_user %>
+    <% if params[:controller] == "catalog" %>
+        <br>
+        <%
+            numFound = @response["response"]["numFound"]
+            document_ids = @response.documents.map { |doc| doc[:id] }
+
+            page = helpers.search_state.page
+            per_page = helpers.search_state.per_page
+
+            page_results_params = { ids: document_ids, page: page, per_page: per_page }
+            all_results_params = { numFound: numFound, page: page, per_page: per_page }
+        %>
+        <%=
+            link_to t('blacklight.bookmarks.add_page_results.button'),
+            select_results_bookmarks_path(page_results_params),
+            class: 'btn btn-danger btn-sm'
+        %>
+        <%=
+            link_to t('blacklight.bookmarks.add_all_results.button'),
+            select_results_bookmarks_path(all_results_params),
+            class: 'btn btn-danger btn-sm'
+        %>
+    <% end %>
+  <% end %>
+  <% # End UMD Customization %>
+<% end %>

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -7,5 +7,74 @@ class BookmarksController < CatalogController
   blacklight_config.add_show_tools_partial(:export, path: :new_export_job_url, modal: false)
   blacklight_config.add_show_tools_partial(:publish_job, path: :new_publish_job_url, modal: false, label: 'Publish')
   blacklight_config.add_show_tools_partial(:unpublish_job, path: :new_unpublish_job_url, modal: false, label: 'Unpublish')
+
+  def create
+    if current_user.bookmarks.count >= max_limit
+      if request.xhr?
+        render(json: "Max selection limit reached: #{max_limit}", status: :forbidden)
+      else
+        flash[:error] = "Max selection limit reached: #{max_limit}"
+        redirect_back fallback_location: bookmarks_path
+      end
+
+      return
+    end
+    super
+  end
+
+  def select_results # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+    if current_user.bookmarks.count >= max_limit
+      return redirect_back_to_catalog(params, search_params)
+    end
+
+    # Adding only the ids on the page
+    if params.has_key? :ids
+      add_selected(params[:ids])
+      redirect_back_to_catalog(params, current_search_session.query_params)
+    else
+      # Retrieving all ids from the search
+      (@response, _) = search_service.search_results do |builder|
+        builder.rows = params[:numFound].to_i
+        builder
+      end
+
+      document_ids = @response.documents.map(&:id)
+
+      add_selected(document_ids)
+
+      redirect_back_to_catalog(params, current_search_session.query_params)
+    end
+  end
+
+  private
+
+    def add_selected (document_ids)
+      selected_ids = current_user.bookmarks.map(&:document_id)
+      missing_ids = document_ids.reject { |doc_id| selected_ids.include?(doc_id) }
+      select_ids = missing_ids.take(max_limit - current_user.bookmarks.count)
+
+      if select_ids.length.zero?
+        flash[:notice] = I18n.t(:already_selected)
+      else
+        select_ids.each do |id|
+          current_user.bookmarks.create(document_id: id, document_type: blacklight_config.document_model.to_s)
+        end
+
+        count = select_ids.length
+        flash[:notice] = I18n.t(:items_selected, selected_count: count, items: count == 1 ? 'item' : 'items')
+      end
+    end
+
+    def redirect_back_to_catalog(params, search_params)
+      search_params[:per_page] = params[:per_page]
+      search_params[:page] = params[:page]
+      search_params.delete(:rows)
+
+      redirect_to search_catalog_path(search_params)
+    end
+
+    def max_limit
+      helpers.max_bookmarks_selection_limit
+    end
   # End UMD Customization
 end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -27,3 +27,4 @@ const ReactRailsUJS = require("react_ujs")
 ReactRailsUJS.getConstructor = (name) => {
   return componentsContext[name]
 }
+import "@hotwired/turbo-rails"

--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<%= content_tag :html, class: 'no-js', **html_tag_attributes do %>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+    <% # UMD Customization %>
+    <meta name="turbo-prefetch" content="false">
+    <% # End UMD Customization %>
+
+    <title><%= render_page_title %></title>
+    <script>
+      document.querySelector('html').classList.remove('no-js');
+    </script>
+    <%= opensearch_description_tag application_name, opensearch_catalog_url(format: 'xml') %>
+    <%= favicon_link_tag %>
+    <%= stylesheet_link_tag "application", media: "all", "data-turbo-track": "reload"  %>
+    <% if defined? Importmap %>
+      <%= javascript_importmap_tags %>
+    <% elsif defined? Propshaft %>
+      <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
+    <% else %>
+      <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
+      <%= javascript_include_tag "blacklight/blacklight", type: 'module' %>
+      <script type="module">
+        import githubAutoCompleteElement from 'https://cdn.skypack.dev/@github/auto-complete-element';
+      </script>
+    <% end %>
+
+    <%= csrf_meta_tags %>
+    <%= content_for(:head) %>
+  </head>
+  <body class="<%= render_body_class %>">
+    <nav id="skip-link" role="navigation" aria-label="<%= t('blacklight.skip_links.label') %>">
+      <%= link_to t('blacklight.skip_links.search_field'), '#search_field', class: 'element-invisible element-focusable rounded-bottom py-2 px-3', data: { turbolinks: 'false' } %>
+      <%= link_to t('blacklight.skip_links.main_content'), '#main-container', class: 'element-invisible element-focusable rounded-bottom py-2 px-3', data: { turbolinks: 'false' } %>
+      <%= content_for(:skip_links) %>
+    </nav>
+    <%= render partial: 'shared/header_navbar' %>
+
+    <main id="main-container" class="<%= container_classes %>" role="main" aria-label="<%= t('blacklight.main.aria.main_container') %>">
+      <%= content_for(:container_header) %>
+
+      <%= render partial: 'shared/flash_msg', layout: 'shared/flash_messages' %>
+
+      <div class="row">
+        <%= content_for?(:content) ? yield(:content) : yield %>
+      </div>
+    </main>
+
+    <%= render partial: 'shared/footer' %>
+    <%= render partial: 'shared/modal' %>
+  </body>
+<% end %>

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -9,9 +9,9 @@ en:
       page_title: Selected Items - Archelon
       title: Selected Items
       no_bookmarks: You have not selected any items
-      addall:
+      add_page_results:
         button: Select all on page
-      addallresults:
+      add_all_results:
         button: Select all search results
       add:
         button: Select

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -1,3 +1,49 @@
 en:
   blacklight:
-    application_name: 'Archelon'
+    application_name: Archelon
+
+    header_links:
+      bookmarks: Selected Items
+
+    bookmarks:
+      page_title: Selected Items - Archelon
+      title: Selected Items
+      no_bookmarks: You have not selected any items
+      addall:
+        button: Select all on page
+      addallresults:
+        button: Select all search results
+      add:
+        button: Select
+        success:
+          one: Successfully selected item.
+          other: Successfully selected items.
+        failure:  Sorry, there was a problem saving the selected items.
+      remove:
+        button: Unselect
+        success: Successfully removed selected item.
+        failure: Sorry, there was a problem removing the selected items.
+        action_confirm: Remove the selected items?
+      clear:
+        action_title: Clear selected items
+        action_confirm: Clear your selected items?
+        success: Cleared your selected items.
+        failure: Sorry, there was a problem clearing your selected items.
+      need_login: Please log in to manage and view your selected items.
+      list_title: Your Selected Items
+      delete: Remove
+
+    back_to_bookmarks: Back to Selected Items
+
+    search:
+      title: "%{constraints} - %{application_name} Search"
+      bookmarks:
+        present: Selected
+        absent: Select
+        inprogress: Saving...
+      facets:
+        title: Limit your search
+      facets-workflow:
+        title: Limit to
+      filters:
+        none: Browse

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,9 +30,18 @@
 en:
   hello: "Hello world"
   solr_is_down: 'Unable to connect to Solr index. Search functionality is unavailable at this time.'
+  active_mq_is_down: 'Unable to connect to ActiveMQ. Import/export functionality is unavailable at this time.'
+  needs_selected_items: 'To create a export job, you must select items first.'
+  already_selected: 'All exportable items from this search are already selected.'
+  items_selected: 'Added %{selected_count} exportable %{items} from this search to your selected items list.'
+  max_limit: 'Maximum overall selection limit is %{limit}.'
+  selected_items_changed: 'Selected items has changed. Please review.'
   import_already_performed: 'Import has completed. Cannot reimport or validate'
   cannot_import_invalid_file: 'Cannot import a file with validation errors.'
+  export_job_no_mime_types_selected: 'Please select at least one MIME type when exporting binaries'
   resource_update_successful: 'Update successful'
+  resource_update_failed: 'Update failed'
+  resource_update_no_change: 'Please make a change before submitting.'
   resource_update_timeout_error: 'Timeout error. Fedora has taken too long to respond. Please report this error and check back in a few minutes as your changes may have been saved.'
 
   activerecord:
@@ -103,6 +112,7 @@ en:
             metadata_file:
               required: 'is required'
     models:
+      download_url: Download URL
       export_job: Export Job
       import_job: Import Job
   mime_types:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
 
     collection do
       delete 'clear'
+      get 'select_results'
     end
   end
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "dependencies": {
     "@github/auto-complete-element": "^3.6.2",
+    "@hotwired/turbo-rails": "^8.0.12",
     "@popperjs/core": "^2.11.8",
     "@rails/actioncable": "^7.2.0",
     "@rails/ujs": "^7.1.3-4",

--- a/test/controllers/bookmarks_controller_test.rb
+++ b/test/controllers/bookmarks_controller_test.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class BookmarksControllerTest < ActionController::TestCase
+  setup do
+    @cas_user = cas_users(:one)
+    mock_cas_login(@cas_user.cas_directory_id)
+    @cas_user.bookmarks.create(document_id: 'http://fcrepo-test/123', document_type: SolrDocument)
+  end
+
+  test 'should not create second bookmark if max bookmark limit reached' do
+    @controller.stub(:max_limit, 1) do
+      put :update, xhr: true, params: { id: 'http://fcrepo-test/new', format: :js }
+      assert_response :forbidden
+    end
+  end
+
+  test 'should create second bookmark if within max bookmark limit' do
+    @controller.stub(:max_limit, 2) do
+      put :update, xhr: true, params: { id: 'http://fcrepo-test/new', format: :js }
+      assert_response :success
+    end
+  end
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -317,6 +317,19 @@
   resolved "https://registry.yarnpkg.com/@github/combobox-nav/-/combobox-nav-2.3.1.tgz#76da4c47f1e33af56392c5c9cf661a28d5b4168e"
   integrity sha512-gwxPzLw8XKecy1nP63i9lOBritS3bWmxl02UX6G0TwMQZbMem1BCS1tEZgYd3mkrkiDrUMWaX+DbFCuDFo3K+A==
 
+"@hotwired/turbo-rails@^8.0.12":
+  version "8.0.12"
+  resolved "https://registry.yarnpkg.com/@hotwired/turbo-rails/-/turbo-rails-8.0.12.tgz#6f1a2661122c0a2bf717f3bc68b5106638798c89"
+  integrity sha512-ZXwu9ez+Gd4RQNeHIitqOQgi/LyqY8J4JqsUN0nnYiZDBRq7IreeFdMbz29VdJpIsmYqwooE4cFzPU7QvJkQkA==
+  dependencies:
+    "@hotwired/turbo" "^8.0.12"
+    "@rails/actioncable" "^7.0"
+
+"@hotwired/turbo@^8.0.12":
+  version "8.0.12"
+  resolved "https://registry.yarnpkg.com/@hotwired/turbo/-/turbo-8.0.12.tgz#50aa8345d7f62402680c6d2d9814660761837001"
+  integrity sha512-l3BiQRkD7qrnQv6ms6sqPLczvwbQpXt5iAVwjDvX0iumrz6yEonQkNAzNjeDX25/OJMFDTxpHjkJZHGpM9ikWw==
+
 "@jest/schemas@^29.6.3":
   version "29.6.3"
   resolved "https://registry.yarnpkg.com/@jest/schemas/-/schemas-29.6.3.tgz#430b5ce8a4e0044a7e3819663305a7b3091c8e03"
@@ -393,6 +406,11 @@
   version "2.11.8"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.8.tgz#6b79032e760a0899cd4204710beede972a3a185f"
   integrity sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==
+
+"@rails/actioncable@^7.0":
+  version "7.2.201"
+  resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-7.2.201.tgz#bfb3da01b3e2462f5a18f372c52dedd7de76037f"
+  integrity sha512-wsTdWoZ5EfG5k3t7ORdyQF0ZmDEgN4aVPCanHAiNEwCROqibSZMXXmCbH7IDJUVri4FOeAVwwbPINI7HVHPKBw==
 
 "@rails/actioncable@^7.2.0":
   version "7.2.0"


### PR DESCRIPTION
In Comparison with Archelon 1 there's less features that need to be modified:
- We no longer need to override the default javascript that blacklight provides to select all documents on a page
- The bookmarks controller no longer needs two different methods for updating bookmarks
- With the introduction of View Components in Rails 7, the button functionality could be added with the pagination_component instead of being within it's own partial

The pre-fetch functionality from turbo did need to be disabled because of it creating bizarre behavior on the buttons, where it would trigger the request without the user hovering, from discussion with David Steelman this has been disabled on other applications, so this should be fine

The bookmarks_controller_test.rb also was added back

https://umd-dit.atlassian.net/browse/LIBFCREPO-1522