### PR TITLE
LIBFCREPO-1608. Re-enable error message display for download URL and import job forms.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,8 @@ class ApplicationController < ActionController::Base
   # UMD Customization
   include CasHelper
 
+  add_flash_types :error
+
   rescue_from ActiveRecord::RecordNotFound, with: :not_found
 
   rescue_from CanCan::AccessDenied do
@@ -28,6 +30,10 @@ class ApplicationController < ActionController::Base
 
   def forbidden
     render file: Rails.root.join('public', '403.html'), status: :forbidden, layout: false
+  end
+
+  def bad_request
+    render file: Rails.root.join('public', '500.html'), status: :bad_request, layout: false
   end
 
   def impersonating?

--- a/app/javascript/resource.js
+++ b/app/javascript/resource.js
@@ -2,9 +2,6 @@
 $(document).ready(function() {
 
   const errorDiv = document.querySelector("#error_explanation");
-  if (errorDiv) {
-    errorDiv.innerHTML = "";
-  }
 
   const resourceFormSubmit = document.querySelector("#resource_form_submit");
 

--- a/app/views/catalog/_show_sidebar.html.erb
+++ b/app/views/catalog/_show_sidebar.html.erb
@@ -8,7 +8,7 @@
     <div class="card-body">
       <ul>
         <li><%= link_to 'Download', @document.id, target: '_blank' %></li>
-        <li><%= generate_download_url_link(@document) %></li>
+        <li><%= link_to 'Generate Download URL', new_download_url_path(document_url: @document.id) %></li>
       </ul>
     </div>
   </div>

--- a/app/views/download_urls/index.html.erb
+++ b/app/views/download_urls/index.html.erb
@@ -45,8 +45,7 @@
         <td><%= link_to 'Show', download_url, class: 'btn btn-primary' %></td>
         <td>
           <% if download_url.enabled? %>
-            <%= link_to 'Disable', disable_download_url_path(token: download_url.token),
-                            method: :put, data: { confirm: 'Are you sure?' }, class: 'btn btn-danger' %>
+            <%= button_to 'Disable', download_url, method: :put, params: { state: 'disable' }, data: { confirm: 'Are you sure?' }, class: 'btn btn-danger' %>
           <% end %>
         </td>
       </tr>

--- a/app/views/download_urls/new.html.erb
+++ b/app/views/download_urls/new.html.erb
@@ -1,6 +1,6 @@
 <h1>Generate Download URL</h1>
 
-<%= form_for(@download_url, url: create_download_url_path(document_url: @download_url.url)) do |f| %>
+<%= form_for(@download_url, url: download_urls_path(document_url: @download_url.url), data: { turbo: false }) do |f| %>
   <%= render partial: "shared/error_messages", locals: {object: @download_url} %>
 
   <%= f.label :url, 'Fedora URL' %>

--- a/app/views/download_urls/show.html.erb
+++ b/app/views/download_urls/show.html.erb
@@ -1,63 +1,62 @@
 <%= render partial: "retrieve_url", locals: {object: @download_url} %>
 
 <p>
-  <strong>Token:</strong>
-  <%= @download_url.token %>
+    <strong>Token:</strong>
+    <%= @download_url.token %>
 </p>
 
 <p>
-  <strong>Fedora URL:</strong>
-  <%= @download_url.url %>
+    <strong>Fedora URL:</strong>
+    <%= @download_url.url %>
 </p>
 
 <p>
-  <strong>Title:</strong>
-  <%= @download_url.title %>
+    <strong>Title:</strong>
+    <%= @download_url.title %>
 </p>
 
 <p>
-  <strong>Notes:</strong>
-  <%= @download_url.notes %>
+    <strong>Notes:</strong>
+    <%= @download_url.notes %>
 </p>
 
 <p>
-  <strong>Mime type:</strong>
-  <%= @download_url.mime_type %>
+    <strong>Mime type:</strong>
+    <%= @download_url.mime_type %>
 </p>
 
 <p>
-  <strong>Creator:</strong>
-  <%= @download_url.creator %>
+    <strong>Creator:</strong>
+    <%= @download_url.creator %>
 </p>
 
 <p>
-  <strong>Enabled:</strong>
-  <%= @download_url.enabled %>
+    <strong>Enabled:</strong>
+    <%= @download_url.enabled %>
 </p>
 
 <p>
-  <strong>Request ip:</strong>
-  <%= @download_url.request_ip %>
+    <strong>Request ip:</strong>
+    <%= @download_url.request_ip %>
 </p>
 
 <p>
-  <strong>Request user agent:</strong>
-  <%= @download_url.request_user_agent %>
+    <strong>Request user agent:</strong>
+    <%= @download_url.request_user_agent %>
 </p>
 
 <p>
-  <strong>Accessed at:</strong>
-  <%= @download_url.accessed_at %>
+    <strong>Accessed at:</strong>
+    <%= @download_url.accessed_at %>
 </p>
 
 <p>
-  <strong>Download completed at:</strong>
-  <%= @download_url.download_completed_at %>
+    <strong>Download completed at:</strong>
+    <%= @download_url.download_completed_at %>
 </p>
 
 <% if @download_url.enabled? %>
-  <%= link_to 'Disable', disable_download_url_path(token: @download_url.token),
-              method: :put, class: 'btn btn-danger', data: { confirm: 'Are you sure?' } %>
+  <%= button_to 'Disable', @download_url, method: :put, params: { state: 'disable' }, data: { confirm: 'Are you sure?' }, class: 'btn btn-danger', form: { style: 'display:inline' } %>
 <% end %>
 
 <%= link_to 'List Download URLs', download_urls_path, class: 'btn btn-primary' %>

--- a/app/views/import_jobs/_form.html.erb
+++ b/app/views/import_jobs/_form.html.erb
@@ -1,15 +1,5 @@
-<%= form_with(model: import_job, local: true) do |form| %>
-  <% if import_job.errors.any? %>
-    <div id="error_explanation">
-      <h2><%= pluralize(import_job.errors.count, "error") %> prohibited this job from being saved:</h2>
-
-      <ul>
-        <% import_job.errors.full_messages.each do |message| %>
-          <li><%= message %></li>
-        <% end %>
-      </ul>
-    </div>
-  <% end %>
+<%= form_with(model: import_job, data: {turbo: false}) do |form| %>
+  <%= render partial: "shared/error_messages", locals: {object: import_job} %>
 
   <div class="form-group">
     <div>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,10 +1,8 @@
 <% if object.errors.any? %>
   <div id="error_explanation">
-    <div class="alert alert-danger alert-dismissable" role="alert">
-      <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-        <span aria-hidden="true">&times;</span>
-      </button>
-      The form contains <%= pluralize(object.errors.count, "error") %>
+    <div class="alert alert-danger alert-dismissible" role="alert">
+      <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+      <p>The form contains <%= pluralize(object.errors.count, "error") %></p>
       <ul>
       <% object.errors.full_messages.each do |message| %>
         <li><%= message %></li>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -74,7 +74,8 @@ Rails.application.configure do
 
   # UMD Customization
   config.hosts = [
-    "archelon-local"
+    "archelon-local",
+    "localhost",
   ]
 
   config.active_job.queue_adapter = :delayed_job

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,16 +79,9 @@ Rails.application.routes.draw do
   end
 
   # Download URLs
-  resources :download_urls, only: %i[index show]
-  get '/download_urls/generate/:document_url', controller: 'download_urls',
-      action: 'generate_download_url', as: 'generate_download_url', constraints: { document_url: /.*/ }
-  post '/download_urls/create', controller: 'download_urls',
-       action: 'create_download_url', as: 'create_download_url'
-  get '/download_urls/show/:token', controller: 'download_urls',
-      action: 'show_download_url', as: 'show_download_url'
-  put '/download_urls/disable/:token', controller: 'download_urls',
-      action: 'disable', as: 'disable_download_url'
+  resources :download_urls
 
+  # Retrieve using download URLs
   get '/retrieve/:token', controller: 'retrieve', action: 'retrieve',
       as: 'retrieve'
   get '/retrieve/do/:token', controller: 'retrieve', action: 'do_retrieve',

--- a/test/controllers/download_urls_controller_test.rb
+++ b/test/controllers/download_urls_controller_test.rb
@@ -18,7 +18,7 @@ class DownloadUrlsControllerTest < ActionController::TestCase
   test 'should add creator on create' do
     stub_find_solr_document do
       assert_difference('DownloadUrl.count') do
-        post :create_download_url, params: {
+        post :create, params: {
           download_url: {
             accessed_at: @download_url.accessed_at,
             download_completed_at: @download_url.download_completed_at,
@@ -41,7 +41,7 @@ class DownloadUrlsControllerTest < ActionController::TestCase
       assert_difference('DownloadUrl.count') do
         impersonate_as_user(user_one) do
           assert_equal session[:cas_user], user_one.cas_directory_id
-          post :create_download_url, params: {
+          post :create, params: {
             download_url: {
               accessed_at: @download_url.accessed_at,
               download_completed_at: @download_url.download_completed_at,
@@ -66,7 +66,7 @@ class DownloadUrlsControllerTest < ActionController::TestCase
     creator_to_try = 'one'
     stub_find_solr_document do
       assert_difference('DownloadUrl.count') do
-        post :create_download_url, params: {
+        post :create, params: {
           download_url: {
             accessed_at: @download_url.accessed_at,
             download_completed_at: @download_url.download_completed_at,
@@ -87,7 +87,7 @@ class DownloadUrlsControllerTest < ActionController::TestCase
   test 'should require a note on create' do
     stub_find_solr_document do
       assert_no_difference('DownloadUrl.count') do
-        post :create_download_url, params: {
+        post :create, params: {
           download_url: {
             accessed_at: @download_url.accessed_at,
             download_completed_at: @download_url.download_completed_at,
@@ -112,14 +112,14 @@ class DownloadUrlsControllerTest < ActionController::TestCase
 
   test 'generate_download_url should respond with 404 if document cannot be found' do
     @controller.stub(:find_solr_document, nil) do
-      get :generate_download_url, params: { document_url: 'document does not exist' }
+      get :new, params: { document_url: 'document does not exist' }
       assert_response :not_found
     end
   end
 
   test 'create_download_url should respond with 404 if document cannot be found' do
     @controller.stub(:find_solr_document, nil) do
-      get :create_download_url, params: { document_url: 'document does not exist' }
+      post :create, params: { download_url: { document_url: 'document does not exist' } }
       assert_response :not_found
     end
   end
@@ -127,7 +127,7 @@ class DownloadUrlsControllerTest < ActionController::TestCase
   test 'show_download_url should assign the retrieve url' do
     # Assign a dummy RETRIEVE_BASE_URL so test can run without a .env file
     ENV['RETRIEVE_BASE_URL'] = 'https://example.com/'
-    get :show_download_url, params: { token: @download_url.token }
+    get :show, params: { id: @download_url.id }
     retrieve_base_url = ENV['RETRIEVE_BASE_URL']
     assert_not assigns(:download_url).nil?
     assert_equal retrieve_base_url + @download_url.token, assigns(:download_url).retrieve_url
@@ -136,7 +136,7 @@ class DownloadUrlsControllerTest < ActionController::TestCase
   test 'disable should disable an enabled download_url' do
     assert @download_url.enabled?
 
-    put :disable, params: { token: @download_url.token }
+    put :update, params: { state: 'disable', id: @download_url.id }
 
     @download_url.reload
     assert_not @download_url.enabled?

--- a/test/controllers/static_pages_controller_test.rb
+++ b/test/controllers/static_pages_controller_test.rb
@@ -9,9 +9,10 @@ class StaticPagesControllerTest < ActionController::TestCase
   end
 
   test 'should get about' do
-    stub_request(:get, 'http://localhost:8983/solr/fedora4')
-      .to_return(status: 200, body: '', headers: {})
-    get :about
-    assert_response :success
+    mock_env('SOLR_URL' => 'http://localhost:8983/solr/fedora4') do
+      stub_request(:get, ENV['SOLR_URL']).to_return(status: 200, body: '', headers: {})
+      get :about
+      assert_response :success
+    end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -181,4 +181,16 @@ def with_constant(constant_name, value)
   end
 end
 
+# mock the environment during testing
+# https://stackoverflow.com/a/76036999
+def mock_env(partial_env_hash)
+  old = ENV.to_hash
+  ENV.update partial_env_hash
+  begin
+    yield
+  ensure
+    ENV.replace old
+  end
+end
+
 # End UMD Customization


### PR DESCRIPTION
* Don't clear out the errorDiv on page load
* Rework download urls forms to operate as expected
  - disabled turbo
  - use the normal resource routing for download URLs
  - fixed tests
* Disable turbo on the import jobs form
  - use the shared/error_messages partial to display errors

https://umd-dit.atlassian.net/browse/LIBFCREPO-1608