### PR TITLE
LIBFCREPO-1505. Added "active" column to cas_user model.

### DIFF
--- a/app/assets/stylesheets/_umd_classes.scss
+++ b/app/assets/stylesheets/_umd_classes.scss
@@ -27,6 +27,10 @@
   background:#eee;
 }
 
+.umd-table td {
+  vertical-align: middle;
+}
+
 .publish-controls {
   display: inline;
 }

--- a/app/helpers/cas_helper.rb
+++ b/app/helpers/cas_helper.rb
@@ -31,6 +31,6 @@ module CasHelper
 
     # Returns true if entry is authorized, false otherwise.
     def allow_access
-      !current_cas_user.nil? && !current_cas_user.unauthorized?
+      !current_cas_user.nil? && !current_cas_user.unauthorized? && current_cas_user.active?
     end
 end

--- a/app/views/cas_users/index.html.erb
+++ b/app/views/cas_users/index.html.erb
@@ -1,33 +1,52 @@
 <h1>Users</h1>
 
-<div class="umd-table">
-  <table class="table">
-    <thead>
-      <tr>
-        <th>Directory ID</th>
-        <th>Name</th>
-        <th>Groups</th>
-        <th>Type</th>
-        <th colspan="3"></th>
-        <th colspan="2"></th>
-      </tr>
-    </thead>
+<form method="get" id="inactive_button">
+    <label><input type="checkbox" name="show_inactive" value="true" onchange="document.getElementById('inactive_button').submit()" <% if @show_inactive %>checked<% end %> /> Show inactive users</label>
+</form>
 
-    <tbody>
-      <% @cas_users.each do |cas_user| %>
-        <tr>
-          <td><%= link_to cas_user.cas_directory_id, cas_user %></td>
-          <td><%= cas_user.name %></td>
-          <td><%= cas_user.groups.map(&:name).sort.join(', ') %></td>
-          <td><%= cas_user.user_type %></td>
-          <td><%= link_to 'Destroy', cas_user, method: :delete, data: { confirm: 'Please remove Archelon Grouper roles of the user to ensure access is restricted. Confirm delete?' } %></td>
-          <td>
-            <% if can_login_as?(cas_user) %>
-              <%= link_to 'Sign In As', admin_user_login_as_path(cas_user.id) %>
+<div class="umd-table">
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Directory ID</th>
+                <th>Name</th>
+                <th>Groups</th>
+                <th>Type</th>
+                <th>Active?</th>
+                <th colspan="2"></th>
+            </tr>
+        </thead>
+
+        <tbody>
+            <% @cas_users.each do |cas_user| %>
+            <% if cas_user.active? || @show_inactive %>
+            <tr>
+                <td><%= link_to cas_user.cas_directory_id, cas_user %></td>
+                <td><%= cas_user.name %></td>
+                <td><%= cas_user.groups.map(&:name).sort.join(', ') %></td>
+                <td><%= cas_user.user_type %></td>
+                <td><%= cas_user.active? %></td>
+                <td>
+                  <% if current_cas_user != cas_user && can?(:manage, cas_user) %>
+                    <% if cas_user.active? %>
+                    <%= button_to 'Deactivate',
+                        cas_user_active_state_path(cas_user.id),
+                        params: {active: false, show_inactive: @show_inactive}, class: 'btn btn-danger', form: {data: {turbo: false}} %>
+                    <% else %>
+                    <%= button_to 'Activate',
+                        cas_user_active_state_path(cas_user.id),
+                        params: {active: true, show_inactive: @show_inactive}, class: 'btn btn-success', form: {data: {turbo: false}} %>
+                    <% end %>
+                  <% end %>
+                </td>
+                <td>
+                    <% if can_login_as?(cas_user) %>
+                    <%= link_to 'Sign In As', admin_user_login_as_path(cas_user.id) %>
+                    <% end %>
+                </td>
+            </tr>
             <% end %>
-          </td>
-        </tr>
-      <% end %>
-    </tbody>
-  </table>
+            <% end %>
+        </tbody>
+    </table>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,7 @@ Rails.application.routes.draw do
 
   resources :cas_users
   get '/cas_users/:id/history' => 'cas_users#show_history'
+  post '/cas_users/:id/active' => 'cas_users#active_state', as: 'cas_user_active_state'
   get 'public_keys' => 'public_keys#index'
 
   get 'login', to: redirect('/auth/cas'), as: 'login' unless CasHelper.use_developer_login

--- a/db/migrate/20250324141226_add_active_to_cas_user.rb
+++ b/db/migrate/20250324141226_add_active_to_cas_user.rb
@@ -1,0 +1,5 @@
+class AddActiveToCasUser < ActiveRecord::Migration[7.1]
+  def change
+    add_column :cas_users, :active, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_03_21_140555) do
+ActiveRecord::Schema[7.1].define(version: 2025_03_24_141226) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -57,6 +57,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_03_21_140555) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.string "user_type"
+    t.boolean "active", default: true
     t.index ["cas_directory_id"], name: "index_cas_users_on_cas_directory_id", unique: true
   end
 

--- a/test/controllers/cas_users_controller_test.rb
+++ b/test/controllers/cas_users_controller_test.rb
@@ -19,21 +19,31 @@ class CasUsersControllerTest < ActionController::TestCase
     assert_response :success
   end
 
-  test 'should destroy cas_user' do
-    skip("TODO: Address foreign key constraints -- see LIBFCREPO-1505")
-    assert_difference('CasUser.count', -1) do
-      delete :destroy, params: { id: @cas_user }
+  test 'should not destroy cas_user with jobs' do
+    assert_difference('CasUser.count', 0) do
+      delete :destroy, params: { id: cas_users(:one) }
     end
 
     assert_redirected_to cas_users_path
   end
 
-  test 'non-admin users should not have access to index, new, create, edit, update,destroy' do
+  test 'should destroy jobless cas_user' do
+    assert_difference('CasUser.count', -1) do
+      delete :destroy, params: { id: cas_users(:jobless_user) }
+    end
+
+    assert_redirected_to cas_users_path
+  end
+
+  test 'non-admin users should not have access to index, new, create, edit, update, destroy' do
     run_as_user(cas_users(:one)) do
       get :index
       assert_response :forbidden
 
       delete :destroy, params: { id: @cas_user }
+      assert_response :forbidden
+
+      post :active_state, params: { id: @cas_user, active: false }
       assert_response :forbidden
     end
   end

--- a/test/fixtures/cas_users.yml
+++ b/test/fixtures/cas_users.yml
@@ -59,3 +59,8 @@ key_user2:
   cas_directory_id: key_user2
   name: Key User (id_two)
   user_type: user
+
+jobless_user:
+  cas_directory_id: jobless_user
+  name: User (No jobs)
+  user_type: user


### PR DESCRIPTION
* if a user is inactive, they cannot successfully log in
* by default, hide inactive users from the manage users list, but provide a toggle switch to view them
* users cannot deactivate themselves
* only users with permissions to manage users (i.e., admins) can (de)activate other users

https://umd-dit.atlassian.net/browse/LIBFCREPO-1505