### PR TITLE
LIBFCREPO-1526. Restore Jenkins continuous integration

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,0 +1,40 @@
+# Dockerfile for use by the continuous integration server (ci), in order to
+# build and test the application.
+#
+# This Dockerfile provides the appropriate environment for building and testing
+# the application. It should _not_ be used for creating Docker images for use
+# in production.
+
+ARG RUBY_VERSION=3.2.4
+
+FROM registry.docker.com/library/ruby:$RUBY_VERSION-slim
+
+# Install packages needed to build gems and node modules
+RUN apt-get update -qq && \
+    apt-get install --no-install-recommends -y build-essential curl git libvips node-gyp pkg-config python-is-python3 && \
+    apt-get install --no-install-recommends -y libpq-dev && \
+    apt-get install -y libsqlite3-dev && \
+    apt-get clean
+
+ARG BUNDLER_VERSION=2.4.19
+ARG NODE_VERSION=18.19.0
+ARG YARN_VERSION=1.22.22
+
+ENV PATH=/usr/local/node/bin:$PATH
+RUN curl -sL https://github.com/nodenv/node-build/archive/master.tar.gz | tar xz -C /tmp/ && \
+    /tmp/node-build-master/bin/node-build "${NODE_VERSION}" /usr/local/node && \
+    npm install -g yarn@$YARN_VERSION && \
+    rm -rf /tmp/node-build-master
+
+# Copy in the Gemfile and Gemfile.lock, and install the gems
+# This makes builds where the Gemfile/Gemfile.lock file hasn't
+# changed faster by having the correct gems already downloaded
+# and cached.
+COPY Gemfile* /tmp/
+
+# Run bundler to install the gems
+WORKDIR /tmp
+RUN gem install bundler:$BUNDLER_VERSION
+RUN bundle install --without production
+
+WORKDIR /

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,181 @@
+pipeline {
+  // Jenkins configuration dependencies
+  //
+  //   Global Tool Configuration:
+  //     Git
+  //
+  // This configuration utilizes the following Jenkins plugins:
+  //
+  //   * Warnings Next Generation
+  //   * Email Extension Plugin
+  //
+  // This configuration also expects the following environment variables
+  // to be set (typically in /apps/ci/config/env:
+  //
+  // JENKINS_EMAIL_SUBJECT_PREFIX
+  //     The Email subject prefix identifying the server.
+  //     Typically "[Jenkins - <HOSTNAME>]" where <HOSTNAME>
+  //     is the name of the server, i.e. "[Jenkins - cidev]"
+  //
+  // JENKINS_DEFAULT_EMAIL_RECIPIENTS
+  //     A comma-separated list of email addresses that should
+  //    be the default recipients of Jenkins emails.
+
+  agent {
+    dockerfile {
+      filename 'Dockerfile.ci'
+      // Pass JENKINS_EMAIL_SUBJECT_PREFIX and JENKINS_DEFAULT_EMAIL_RECIPIENTS
+      // into container as "env" arguments, so they are available inside the
+      // Docker container
+      args '-u root --env JENKINS_DEFAULT_EMAIL_RECIPIENTS=$JENKINS_DEFAULT_EMAIL_RECIPIENTS --env JENKINS_EMAIL_SUBJECT_PREFIX=$JENKINS_EMAIL_SUBJECT_PREFIX'
+    }
+  }
+
+  options {
+    buildDiscarder(
+      logRotator(
+        artifactDaysToKeepStr: '',
+        artifactNumToKeepStr: '',
+        numToKeepStr: '20'))
+  }
+
+  environment {
+    DEFAULT_RECIPIENTS = "${ \
+      sh(returnStdout: true, \
+         script: 'echo $JENKINS_DEFAULT_EMAIL_RECIPIENTS').trim() \
+    }"
+
+    EMAIL_SUBJECT_PREFIX = "${ \
+      sh(returnStdout: true, script: 'echo $JENKINS_EMAIL_SUBJECT_PREFIX').trim() \
+    }"
+
+    EMAIL_SUBJECT = "$EMAIL_SUBJECT_PREFIX - " +
+                    '$PROJECT_NAME - ' +
+                    'GIT_BRANCH_PLACEHOLDER - ' +
+                    '$BUILD_STATUS! - ' +
+                    "Build # $BUILD_NUMBER"
+
+    EMAIL_CONTENT =
+        '''$PROJECT_NAME - GIT_BRANCH_PLACEHOLDER - $BUILD_STATUS! - Build # $BUILD_NUMBER:
+           |
+           |Check console output at $BUILD_URL to view the results.
+           |
+           |There are ${ANALYSIS_ISSUES_COUNT} static analysis issues in this build.
+           |
+           |There were ${TEST_COUNTS,var="skip"} skipped tests.'''.stripMargin()
+  }
+
+  stages {
+    stage('initialize') {
+      steps {
+        script {
+          // Retrieve the actual Git branch being built for use in email.
+          //
+          // For pull requests, the actual Git branch will be in the
+          // CHANGE_BRANCH environment variable.
+          //
+          // For actual branch builds, the CHANGE_BRANCH variable won't exist
+          // (and an exception will be thrown) but the branch name will be
+          // part of the PROJECT_NAME variable, so it is not needed.
+
+          ACTUAL_GIT_BRANCH = ''
+
+          try {
+            ACTUAL_GIT_BRANCH = CHANGE_BRANCH + ' - '
+          } catch (groovy.lang.MissingPropertyException mpe) {
+            // Do nothing. A branch (as opposed to a pull request) is being
+            // built
+          }
+
+          // Replace the "GIT_BRANCH_PLACEHOLDER" in email variables
+          EMAIL_SUBJECT = EMAIL_SUBJECT.replaceAll('GIT_BRANCH_PLACEHOLDER - ', ACTUAL_GIT_BRANCH )
+          EMAIL_CONTENT = EMAIL_CONTENT.replaceAll('GIT_BRANCH_PLACEHOLDER - ', ACTUAL_GIT_BRANCH )
+        }
+      }
+    }
+
+    stage('build') {
+      steps {
+        sh '''
+          yarn
+          ruby -v
+        '''
+      }
+    }
+
+    stage('test') {
+      steps {
+        sh '''
+          # Disable Spring, as it should not be needed, and may interfere with tests
+          export DISABLE_SPRING=true
+
+          # Configure MiniTest to use JUnit-style reporter
+          export MINITEST_REPORTER=JUnitReporter
+
+          bundle exec rails db:reset
+
+          # Run the tests (not running test:system, because there are no
+          # system tests.
+          bundle exec rails test
+        '''
+      }
+      post {
+        always {
+          junit '**/test/reports/*.xml'
+        }
+      }
+    }
+
+    stage('static-analysis') {
+      steps {
+        sh '''
+        # Run RuboCop
+        # Send output to standard out for "Record compiler warnings and static analysis results"
+        # post-build action
+        #
+        # Using "|| true" so that build will be considered successful, even if there are Rubocop
+        # violation.
+        bundle exec rubocop -D --format clang || true
+      '''
+      }
+      post {
+        always {
+          // Collect Rubocop reports
+          recordIssues(tools: [ruboCop(reportEncoding: 'UTF-8')], qualityGates: [[threshold: 1, type: 'TOTAL', criticality: 'UNSTABLE']])
+
+          // Collect coverage reports
+          publishHTML([
+                        allowMissing: false,
+                        alwaysLinkToLastBuild: false,
+                        keepAll: true,
+                        reportDir: 'coverage/rcov',
+                        reportFiles: 'index.html',
+                        reportName: "RCov Report"
+                      ])
+        }
+      }
+    }
+
+    stage('clean-workspace') {
+      steps {
+        // Change permissions of the workspace directory to world-writeable
+        // so Jenkins can delete it. This is needed, because files may be
+        // written to the directory from the Docker container as the "root"
+        // user, which Jenkins would not otherwise be able to clean up.
+        sh '''
+          chmod --recursive 777 $WORKSPACE
+        '''
+
+        cleanWs()
+      }
+    }
+  }
+
+  post {
+    always {
+      emailext to: "$DEFAULT_RECIPIENTS",
+               subject: "$EMAIL_SUBJECT",
+               body: "$EMAIL_CONTENT"
+    }
+  }
+}


### PR DESCRIPTION
Re-added “Dockerfile.ci” and “Jenkinsfile” from legacy Archelon.

The “Dockerfile.ci” file was updated for the updated Ruby, Node, Yarn, and Bundler versions used in Archelon 2.0, and to more closely resemble the “Dockerfile”.

The “Jenkinsfile” was largely unchanged, with the only modification being changing the command to run the tests from

```
bundle exec rails test:system test
```

to

```
bundle exec rails test
```

because there are currently no system-level tests. Without this change, the non-system tests would not be run.

https://umd-dit.atlassian.net/browse/LIBFCREPO-1526