### PR TITLE
LIBFCREPO-1660. Added "Administrative" card with "View in Fedora" link

### DIFF
--- a/app/views/catalog/_show_sidebar.html.erb
+++ b/app/views/catalog/_show_sidebar.html.erb
@@ -62,4 +62,12 @@
     </ul>
   </div>
 <% end %>
+
+<div class="card">
+  <div class="card-header">Administrative</div>
+    <ul class="nav">
+      <li><%= view_in_fedora_link(@document) %></li>
+    </ul>
+  </div>
+</div>
 <%# End UMD Customization %>


### PR DESCRIPTION
Restored an "Administrative" card to the item detail page, that contains a "View in Fedora" link, similar to the functionality that existed in pre-2.0 Archelon.

https://umd-dit.atlassian.net/browse/LIBFCREPO-1660