### PR TITLE
LIBFCREPO-1655. Modified Publish Jobs table to use "display_title".

### DIFF
--- a/app/components/archelon_document_component.rb
+++ b/app/components/archelon_document_component.rb
@@ -163,10 +163,7 @@ class ArchelonDocumentComponent < Blacklight::Component
         document[:file__title__txt]
 
       elsif !document[:object__title__display].nil?
-        titles = document[:object__title__display].map do |title|
-          title.starts_with?('[@') ? title.split(']')[1] : title
-        end
-        titles.join(' | ')
+        document.display_titles
 
       end
       # if none of the cases match, title should then default to using the id

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -73,6 +73,16 @@ class SolrDocument
     "#{fetch('object__terms_of_use__label__txt')}: #{terms_text}"
   end
 
+  # Concatenates titles for display, stripping out any language tags
+  def display_titles
+    return '' unless has? 'object__title__display'
+
+    titles = fetch(:object__title__display, []).map do |title|
+      title.starts_with?('[@') ? title.split(']')[1] : title
+    end
+    titles.join(' | ')
+  end
+
   private
 
     def format_with_language_tag(value)

--- a/app/views/publish_jobs/show.html.erb
+++ b/app/views/publish_jobs/show.html.erb
@@ -39,7 +39,7 @@
           <% if doc._source.exclude? "object__title__display" %>
             <td>"Title" not found</td>
           <% else %>
-            <td><%= doc._source["object__title__display"][0] %> </td>
+            <td><%= doc.display_titles %> </td>
           <% end %>
 
           <% if doc._source.exclude? "resource_type__facet" %>

--- a/test/models/solr_document_test.rb
+++ b/test/models/solr_document_test.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class SolrDocumentTest < ActiveSupport::TestCase
+  test 'display_titles returns empty string when no object__title__display' do
+    solr_doc = SolrDocument.new(
+      id: 'http://www.example.com'
+    )
+    assert_equal '', solr_doc.display_titles
+  end
+
+  test 'display_titles returns concatenated title without language tags' do
+    test_cases = [
+      { test_value: [], expected: '' },
+      { test_value: [''], expected: '' },
+      { test_value: ['Test Title'], expected: 'Test Title' },
+      { test_value: ['Test Title', '[@ja]Japanese Title'], expected: 'Test Title | Japanese Title' }
+    ]
+
+    test_cases.each do |test_case|
+      test_case => { test_value:, expected: }
+      solr_doc = SolrDocument.new(
+        id: 'http://www.example.com',
+        object__title__display: test_value
+      )
+
+      assert_equal expected, solr_doc.display_titles, "'#{test_value} did not return '#{expected}'"
+    end
+  end
+end


### PR DESCRIPTION
Updated the table of items on the "Publishing Job" detail page to
incorporated the Solr indexer changes made in LIBFCREPO-1588.

The "Access Level" column was removed from the table because it is
still being determined how best to integrate the access level into the
collection and item Solr entries.

https://umd-dit.atlassian.net/browse/LIBFCREPO-1655