### PR TITLE
LIBFCREPO-1663. Solr configuration.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -40,29 +40,20 @@ class CatalogController < ApplicationController # rubocop:disable Metrics/ClassL
     # config.raw_endpoint.enabled = false
 
     ## Default parameters to send to solr for all search-like requests. See also SearchBuilder#processed_parameters
-    config.default_solr_params = {
-      rows: 10
-    }
+    # config.default_solr_params = {}
 
-    config.fetch_many_document_params = {
-      fl: '*'
-    }
+    # config.fetch_many_document_params = {}
 
     # solr path which will be added to solr base url before the other solr params.
     # UMD Customization
-    config.solr_path = 'search'
+    config.solr_path = 'select'
     config.document_solr_path = 'select'
 
     # Default parameters to send on single-document requests to Solr. These settings are the Blacklight defaults (see
     # SearchHelper#solr_doc_params) or parameters included in the Blacklight-jetty document requestHandler.
-    config.default_document_solr_params = {
-      qt: 'select',
-      fl: '*,[child],object__first:[value v=""]',
-      rows: 1,
-      q: '{!term f=id v=$id}'
-    }
+    # config.default_document_solr_params = {}
     # End UMD Customization
-    # config.json_solr_path = 'advanced'
+    config.json_solr_path = nil
 
     # items to show per page, each number in the array represent another option to choose from.
     # config.per_page = [10,20,50,100]
@@ -339,8 +330,8 @@ class CatalogController < ApplicationController # rubocop:disable Metrics/ClassL
     config.spell_max = 5
 
     # Configuration for autocomplete suggester
-    config.autocomplete_enabled = true
-    config.autocomplete_path = 'suggest'
+    # config.autocomplete_enabled = true
+    # config.autocomplete_path = 'suggest'
     # if the name of the solr.SuggestComponent provided in your solrconfig.xml is not the
     # default 'mySuggester', uncomment and provide it below
     # config.autocomplete_suggester = 'mySuggester'

--- a/docs/Solr.md
+++ b/docs/Solr.md
@@ -1,0 +1,106 @@
+# Solr Configuration
+
+## Core
+
+Set the base URL of the core in the `SOLR_URL` environment variable.
+
+For example: `http://fcrepo-solr:8983/solr/fcrepo`
+
+### Schema and Fields
+
+This application assumes that the Solr field names follow the naming
+patterns used by [Solrizer] when building a Solr document. Since some of
+these naming patterns rely on Solr's dynamic field capabilities, there
+is not currently an exhaustive list of all possible fields. However,
+here is Solrizer, umd-fcrepo-solr, and Plastron documentation that
+should help explain the field name conventions:
+
+* [Content Model Indexer]
+* [Other Indexer Modules]
+* [Facet Fields]
+* [fcrepo Core Configuration]
+* [Item Content Model]
+
+## Endpoints
+
+* Search endpoint: `select`
+* Document endpoint: `select`
+* JSON query endpoint: _Disabled_
+
+This application uses the same endpoint for both search and document
+retrieval in order to simplify the Solr configuration. The JSON query
+endpoint is currently disabled (i.e., set to `nil`).
+
+### Parameters
+
+All default parameters for searches should be implemented in the Solr
+configuration as part of the `/select` request handler:
+
+```xml
+<requestHandler name="/select" class="solr.SearchHandler">
+  <lst name="defaults">
+    <str name="echoParams">explicit</str>
+    <!-- search all fields by default -->
+    <str name="q">*:*</str>
+    <!-- default to 10 results per page -->
+    <int name="rows">10</int>
+    <!-- include child documents as nested fields by default -->
+    <str name="fl">*,[child]</str>
+    <!-- exclude child documents from being top-level results -->
+    <str name="fq">!_nest_path_:*</str>
+    <!-- default to facet minimum of 1 -->
+    <str name="facet.mincount">1</str>
+  </lst>
+</requestHandler>
+```
+
+Since this configuration does not itself enable faceting, the Blacklight
+configuration for this application includes a call to `add_facet_fields_to_solr_request!` to ensure that faceting is enabled.
+
+## Search Fields
+
+This implementation replaces the custom functionality implemented in
+Archelon 1.x that allowed searching identifiers by wrapping your query
+in double quotes. It relies on Blacklight's built-in "search fields"
+concept, where you can define multiple combinations of Solr query
+parameters that the user can select from a dropdown menu next to the
+main search input field.
+
+Note the use of `edismax` as the query parser type (`defType`). This
+allows users to more naturally construct their search queries. For more
+information, see Solr's documentation about the [dismax] and [edismax]
+query parsers.
+
+### Text/Keywords
+
+* **Key:** `text`
+* **Label:** Text/Keywords
+* **Parameters:**
+
+  | Key       | Value     |
+  |-----------|-----------|
+  | `df`      | `text`    |
+  | `defType` | `edismax` |
+  | `q.alt`   | `*:*`     |
+
+### Identifier
+
+* **Key:** `identifier`
+* **Label:** Identifier
+* **Parameters:**
+
+  | Key       | Value        |
+  |-----------|--------------|
+  | `df`      | `identifier` |
+  | `defType` | `edismax`    |
+  | `q.alt`   | `*:*`        |
+
+
+[Solrizer]: https://github.com/umd-lib/solrizer
+[Content Model Indexer]: https://umd-lib.github.io/solrizer/solrizer/indexers/content_model.html
+[Other Indexer Modules]: https://umd-lib.github.io/solrizer/solrizer/indexers.html
+[Facet Fields]: https://umd-lib.github.io/solrizer/solrizer/faceters.html
+[fcrepo Core Configuration]: https://github.com/umd-lib/umd-fcrepo-solr/tree/main/fcrepo/core/conf
+[Item Content Model]: https://github.com/umd-lib/plastron/blob/4.5.1/plastron-models/src/plastron/models/umd.py#L31
+[dismax]: https://solr.apache.org/guide/solr/latest/query-guide/dismax-query-parser.html
+[edismax]: https://solr.apache.org/guide/solr/latest/query-guide/edismax-query-parser.html


### PR DESCRIPTION
* Use "select" as the query handler for search and single document retrieval.
  - disabled the json_solr_path "advanced" search pending further research
  - removed some redundant parameter settings (most are taken care of by the solrconfig.xml "select" request handler)
  - disabled autocomplete
* Use Blacklight's built-in "search_field" to switch between text and identifier search.
  - Simplified the handling of identifier queries since we are using the "edismax" query parser, which can handle search terms with ":" without getting confused that it is a fielded search term.
    - removed private fix_query_param method that is no longer needed
    - modified private identifier_search? method to check if the "search_field" parameter is "identifier" for the current request
    - added private methods single_result? and first_result to check whether a response has a single result, and to return that result document, respectively
* Added documentation about Solr configuration