### PR TITLE
LIBFCREPO-1677. Modified SolrDocument for Archelon-based "Members" URLs

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -4,6 +4,7 @@
 class SolrDocument
   include Blacklight::Solr::Document
   include ActionView::Helpers::TagHelper
+  include Rails.application.routes.url_helpers
 
   # self.unique_key = 'id'
 
@@ -61,7 +62,7 @@ class SolrDocument
     paired_uris = uris.zip(labels)
 
     paired_uris.map do |uri, label|
-      add_anchor_tag(uri, label)
+      add_anchor_tag(solr_document_path(uri), label)
     end
   end
 

--- a/test/models/solr_document_test.rb
+++ b/test/models/solr_document_test.rb
@@ -28,4 +28,36 @@ class SolrDocumentTest < ActiveSupport::TestCase
       assert_equal expected, solr_doc.display_titles, "'#{test_value} did not return '#{expected}'"
     end
   end
+
+  test 'members_anchor returns Archelon-based relative URLs' do
+    test_cases = [
+      # test_value: [page_label_sequence__txts, page_uri_sequence__uris]
+      # expected: [solr_document_path(test_value[1])]
+      { test_value: [nil, nil], expected: nil },
+      {
+        test_value: [['Page 1'], ['http://fcrepo.test.example/page1']],
+        expected: ['<a href="/catalog/http:%2F%2Ffcrepo.test.example%2Fpage1">Page 1</a>']
+      },
+      {
+        test_value: [['Page 1', 'Page 2'], ['http://fcrepo.test.example/page1', 'http://fcrepo.test.example/page2']],
+        expected: [
+          '<a href="/catalog/http:%2F%2Ffcrepo.test.example%2Fpage1">Page 1</a>',
+          '<a href="/catalog/http:%2F%2Ffcrepo.test.example%2Fpage2">Page 2</a>'
+        ]
+      }
+    ]
+
+    test_cases.each do |test_case|
+      test_case => { test_value:, expected: }
+
+      solr_params = { id: 'http://www.example.com' }
+      solr_params[:page_label_sequence__txts] = test_value[0] if test_value[0]
+      solr_params[:page_uri_sequence__uris] = test_value[1] if test_value[1]
+      solr_doc = SolrDocument.new(
+        **solr_params
+      )
+
+      assert_equal expected, solr_doc.members_anchor, "'#{test_value} did not return '#{expected}'"
+    end
+  end
 end


### PR DESCRIPTION
Modified the "members_anchor" in "solr_document.rb" to return URLS that link to the Archelon-based pages for the "Members" of the document, instead of to the fcrepo-based pages.

This provides consistency with the "Select Page(s) for More Options" panel in the right sidebar, which also provides link to the pages in Archelon, instead of in fcrepo.

https://umd-dit.atlassian.net/browse/LIBFCREPO-1677