### PR TITLE
LIBFCREPO-1676. Added "ArchelonBacklinkComponent" view component

### DIFF
--- a/app/components/archelon_backlink_component.erb
+++ b/app/components/archelon_backlink_component.erb
@@ -1,0 +1,8 @@
+<%= render(@layout.new(field: @field)) do |component| %>
+  <% component.with_label do %>
+    <%= label %>
+  <% end %>
+  <% component.with_value do %>
+    <%= link_to(@backlink_text, @backlink_url) %>
+  <% end %>
+<% end %>

--- a/app/components/archelon_backlink_component.rb
+++ b/app/components/archelon_backlink_component.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+# Component for displaying an Archelon-based "backlink" to the parent/container
+# of a Solr document, i.e., a link back to the container in which the current
+# item is contained.
+#
+# Given a Solr document, extracts the specified field from the document (the
+# value is assumed to an fcrepo URL), then queries Solr, retrieving the
+# Solr document to backlink to.
+#
+# The component then does the following:
+#
+#   1) The fcrepo URL is converted into a Archelon-based URL for the same item.
+#
+#   2) Using the the provided "backlink_text_field" or
+#      "backlink_text_accessor" field (see below), generates human-readable
+#      text to display with the link.
+#
+# This component adds the following fields to the field configuration:
+#
+# * backlink_text_field - the field in the retrieved Solr document to use
+#   as the human-readable text for the link.
+#
+# * backlink_text_accessor - the SolrDocument method to call on the retrieved
+#   Solr document to generate the human-readable text for the link.
+#
+# Typically, only one of these fields is provided. If both are provided, the
+# "backlink_text_accessor" field will take precedence.
+#
+# If neither field is provided, the link will be returned AS-IS, with the
+# human-readable text being the value of the Solr field.
+#
+# Note: This component makes a Solr query for each instance where it is used
+# on a page.
+class ArchelonBacklinkComponent < Blacklight::MetadataFieldComponent
+  def before_render
+    backlink_document_id = @field.field_config.key
+    backlink_document = controller.search_service.fetch(@field.document[backlink_document_id])
+
+    @backlink_text, @backlink_url = generate_backlink(@field, backlink_document)
+  end
+
+  # Generates an Archelon-based backlink based on the given field configuration
+  # and Solr document
+  #
+  # Returns a two-part array [<backlink title>, <backlink URL>], representing
+  # the human-readable link text, and URL.
+  def generate_backlink(field, backlink_document)
+    if field.field_config.key?(:backlink_text_accessor)
+      backlink_from_accessor(field, backlink_document)
+    elsif @field.field_config.key?(:backlink_text_field)
+      backlink_from_field(field, backlink_document)
+    else
+      default_backlink(field)
+    end
+  end
+
+  private
+
+    # Create backlink from "backlink_text_accessor" field configuration
+    #
+    # Returns a two-part array [<backlink title>, <backlink URL>], representing
+    # the human-readable link text, and URL.
+    def backlink_from_accessor(field, backlink_document)
+      backlink_text_accessor = field.field_config[:backlink_text_accessor]
+      backlink_text = backlink_document.send(backlink_text_accessor)
+      backlink_url = solr_document_url(field.render)
+
+      [backlink_text, backlink_url]
+    end
+
+    # Create backlink from "backlink_text_accessor" field configuration
+    #
+    # Returns a two-part array [<backlink title>, <backlink URL>], representing
+    # the human-readable link text, and URL.
+    def backlink_from_field(field, backlink_document)
+      backlink_text_field = field.field_config[:backlink_text_field]
+      backlink_text = backlink_document[backlink_text_field]
+      backlink_url = solr_document_url(field.render)
+
+      [backlink_text, backlink_url]
+    end
+
+    # Default - convert link to Archelon-based link with link as text
+    # Note: This is "fallback" behavior and likely not ideal. Consider
+    # specifying a "backlink_text_field" or "backlink_text_accessor"
+    # to get more human-friendly link text.
+    #
+    # Returns a two-part array [<backlink title>, <backlink URL>], representing
+    # the human-readable link text, and URL.
+    def default_backlink(field)
+      backlink_text = solr_document_url(field.render)
+      backlink_url = solr_document_url(field.render)
+
+      [backlink_text, backlink_url]
+    end
+end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -239,13 +239,13 @@ class CatalogController < ApplicationController # rubocop:disable Metrics/ClassL
 
     # Page Level Fields
     config.add_show_field 'page__title__txt', label: 'Page'
-    config.add_show_field 'page__member_of__uri', label: 'Member Of'
+    config.add_show_field 'page__member_of__uri', label: 'Member Of', backlink_text_accessor: 'display_titles', component: ArchelonBacklinkComponent
     config.add_show_field 'page__has_file__uris', label: 'Files', component: ListMetadataComponent
     config.add_show_field 'page__rdf_type__curies', label: 'RDF Types', component: ListMetadataComponent
 
     # File Level Fields
     config.add_show_field 'file__title__txt', label: 'Title'
-    config.add_show_field 'file__file_of__uri', label: 'File Of'
+    config.add_show_field 'file__file_of__uri', label: 'File Of', backlink_text_field: 'page__title__txt', component: ArchelonBacklinkComponent
     config.add_show_field 'file__size__int', label: 'Size'
     config.add_show_field 'file__mime_type__txt', label: 'Mime Type'
     config.add_show_field 'file__checksum__uri', label: 'Digest'


### PR DESCRIPTION
Created an “ArchelonBacklinkComponent” view component using the]
following files:

* app/components/archelon_backlink_component.rb
* app/components/archelon_backlink_component.erb

The “ArchelonBacklinkComponent” view component takes the fcrepo-based
URI in the configured field and queries Solr for the Solr document with
that URI (the URI is assumed to represent the “container” of the item).
The retrieved Solr document is then processed to create a “backlink” to
the container’s Archelon page:

* The fcrepo URI is used to generate a URL to the Archelon page for the
  container (using the “solr_document_url”/”solr_document_path” URL
  helpers).

* The human-readable text for the link is generated using the mechanism
  specified in the field configuration (which is typically the title of
  the container’s page).

This implementation includes two possible ways for specifying how to
generate the human-readable link test:

* “backlink_text_accessor” - Specifies the method to call on the
  “SolrDocument” class (for example, the “display_titles” method).

* “backlink_text_field” - the Solr field in the retrieved Solr document
  (for example the “page__title__txt” field).

Both of mechanisms are used in configuring the
“ArchelonBacklinkComponent” view component in the
“app/controllers/catalog_controller.rb” on the following fields:

* Page detail page - “page__member_of__uri” Solr field - Uses the
  “backlink_text_accessor” field to specify that the “display_titles”
  in the SolrDocument class be used to generate the human-readable link
  text.

* File detail page - “page__title__txt” Solr field - Uses the
  “backlink_text_field” to specify that the value of the
  “page__title__txt” in the retrieved Solr document should be used for
  the human-readable link text.

Note that each use of the “ArchelonBacklinkComponent” view component on
a particular page triggers a Solr query – in the existing
implementation, only one instance is used on each page.

The “app/components/archelon_backlink_component.erb” file contains the
ERB template for displaying the field label and link (modeled on the
“app/components/blacklight/metadata_field_component.html.erb” in the
“projectblacklight/blacklight” GitHub repository).

https://umd-dit.atlassian.net/browse/LIBFCREPO-1676