### PR TITLE
LIBFCREPO-1534. Overriding stock "clear bookmarks" template to remove turbo attributes.

### DIFF
--- a/app/views/bookmarks/_clear_bookmarks_widget.html.erb
+++ b/app/views/bookmarks/_clear_bookmarks_widget.html.erb
@@ -1,0 +1,9 @@
+  <%# Overriding the stock template to remove the turbo attributes, which were causing
+  the confirmation dialog box to appear twice. This is likely due to our continued use
+  of UJS. %>
+  <%= link_to t('blacklight.bookmarks.clear.action_title'), clear_bookmarks_path,
+      method: :delete, # for rails-UJS
+      data: {
+        confirm: t('blacklight.bookmarks.clear.action_confirm'), # for rails-UJS
+      },
+      class: 'clear-bookmarks btn btn-danger' %>


### PR DESCRIPTION
The turbo attributes, in conjunction with the old UJS attributes, were causing the confirmation dialog box to appear twice.

https://umd-dit.atlassian.net/browse/LIBFCREPO-1534