### PR TITLE
LIBFCREPO-1682. Added full text search to the existing text metadata search.

### DIFF
--- a/app/assets/stylesheets/_umd_classes.scss
+++ b/app/assets/stylesheets/_umd_classes.scss
@@ -34,3 +34,7 @@
 .publish-controls {
   display: inline;
 }
+
+.hl {
+  background-color: rgba(255, 255, 0, .25);
+}

--- a/app/components/extracted_text_metadata_component.html.erb
+++ b/app/components/extracted_text_metadata_component.html.erb
@@ -1,0 +1,8 @@
+<%= render(@layout.new(field: @field)) do |component| %>
+  <% component.with_label do %>
+    <%= label %>
+  <% end %>
+  <% component.with_value do %>
+    <%= @field.values.join(' [...] ').html_safe %>
+  <% end %>
+<% end %>

--- a/app/components/extracted_text_metadata_component.rb
+++ b/app/components/extracted_text_metadata_component.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+# Component to display multivalued metadata fields
+class ExtractedTextMetadataComponent < Blacklight::MetadataFieldComponent
+end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -94,6 +94,13 @@ class SolrDocument
     strip_language_tags(:object__title__display).join(' | ')
   end
 
+  # Get the extracted text snippets from the highlighting results and strips out
+  # the page and bounding box tags
+  def extracted_text
+    text_values = response.dig('highlighting', id, 'extracted_text__dps_txt') || []
+    text_values.map { |value| value.gsub(/\|n=\d+&xywh=\d+,\d+,\d+,\d+/, '') }
+  end
+
   private
 
     def extract_language_tags(field_name)

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Represents a single document returned from Solr
-class SolrDocument
+class SolrDocument # rubocop:disable Metrics/ClassLength
   include Blacklight::Solr::Document
   include ActionView::Helpers::TagHelper
   include Rails.application.routes.url_helpers

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -40,11 +40,14 @@ class SolrDocument # rubocop:disable Metrics/ClassLength
   end
 
   def archival_collection_links
-    handle_link = vocab_term_with_same_as(:object__archival_collection,
-                                          anchor_label: 'View Collection in Archival Collection Database')
+    return unless has? 'object__archival_collection'
 
-    archelon_search_link = ActionController::Base.helpers.link_to('View Collection in Archelon',
-                                                                  search_catalog_path('f[archival_collection__facet][]' => fetch('object__archival_collection__label__txt'))) # rubocop:disable Layout/LineLength
+    handle_link = vocab_term_with_same_as(
+      :object__archival_collection,
+      anchor_label: 'View Collection in Archival Collection Database'
+    )
+    path = search_catalog_path('f[archival_collection__facet][]' => fetch('object__archival_collection__label__txt'))
+    archelon_search_link = ActionController::Base.helpers.link_to('View Collection in Archelon', path)
 
     [handle_link, archelon_search_link]
   end


### PR DESCRIPTION
- changed label from "Text/Keywords" to "Text & Metadata"
- changed identifier search label to "Identifier Lookup"
- in addition to the "q" query parameter, try getting the current query from the session, so it can be passed on to the IIIF manifest server for generating the hit highlight annotations

https://umd-dit.atlassian.net/browse/LIBFCREPO-1682