### PR TITLE
LIBFCREPO-1691. Remove `IIIF_MANIFESTS_URL_TEMPLATE`.

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -25,7 +25,6 @@ REPO_EXTERNAL_URL=http://fcrepo-local:8080/fcrepo/rest/
 
 # --- config/environments/*.rb
 IIIF_VIEWER_URL_TEMPLATE=http://localhost:8888/viewer/1.3.0/mirador.html?manifest={+manifest}{&q}
-IIIF_MANIFESTS_URL_TEMPLATE=http://localhost:3001/manifests/{+manifest_id}/manifest.json
 
 # Base URL for retrieving files via download urls.
 # This should include the entire URL except for the token

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,6 @@ RUN bundle exec bootsnap precompile app/ lib/
 RUN SECRET_KEY_BASE_DUMMY=1 \
     ARCHELON_DATABASE_ADAPTER=postgresql \
     IIIF_VIEWER_URL_TEMPLATE=x \
-    IIIF_MANIFESTS_URL_TEMPLATE=x \
     ./bin/rails assets:precompile
 # End UMD Customization
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,7 +16,7 @@ module ApplicationHelper
   end
 
   def repo_path(url)
-    url.slice(REPO_EXTERNAL_URL.size, url.size)
+    url.sub(REPO_EXTERNAL_URL, '')
   end
 
   def fcrepo_url
@@ -46,16 +46,8 @@ module ApplicationHelper
     end
   end
 
-  def iiif_id(repo_uri)
-    "fcrepo:#{repo_path(repo_uri).tr('/', ':')}"
-  end
-
-  def iiif_manifest_url(repo_uri)
-    IIIF_MANIFESTS_URL_TEMPLATE.expand(manifest_id: iiif_id(repo_uri)).to_s
-  end
-
-  def iiif_viewer_url(repo_uri, query)
-    IIIF_VIEWER_URL_TEMPLATE.expand(manifest: iiif_manifest_url(repo_uri), q: query).to_s
+  def iiif_viewer_url(manifest_uri, query)
+    IIIF_VIEWER_URL_TEMPLATE.expand(manifest: manifest_uri, q: query).to_s
   end
 
   def link_to_edit(resource)

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -15,6 +15,10 @@ class SolrDocument # rubocop:disable Metrics/ClassLength
   # Recommendation: Use field names from Dublin Core
   use_extension(Blacklight::Document::DublinCore)
 
+  def iiif_manifest_uri
+    fetch('iiif_manifest__uri')
+  end
+
   def creator_language_badge
     return unless has? 'object__creator'
 

--- a/app/views/catalog/_show_main_content.html.erb
+++ b/app/views/catalog/_show_main_content.html.erb
@@ -24,7 +24,7 @@
       <% end %>
     </div>
     <div class="image-viewer intrinsic-container ratio-4x3">
-      <iframe src="<%= iiif_viewer_url(@document.id, @current_query) %>" allowfullscreen></iframe>
+      <iframe src="<%= iiif_viewer_url(@document.iiif_manifest_uri, @current_query) %>" allowfullscreen></iframe>
     </div>
   <% end %>
   <%# End UMD Customization %>

--- a/config/initializers/iiif.rb
+++ b/config/initializers/iiif.rb
@@ -1,4 +1,3 @@
 require 'addressable/template'
 
 IIIF_VIEWER_URL_TEMPLATE = Addressable::Template.new(ENV['IIIF_VIEWER_URL_TEMPLATE'])
-IIIF_MANIFESTS_URL_TEMPLATE = Addressable::Template.new(ENV['IIIF_MANIFESTS_URL_TEMPLATE'])


### PR DESCRIPTION
Instead of calculating the IIIF manifest URI in Archelon, use the value indexed in Solr.

https://umd-dit.atlassian.net/browse/LIBFCREPO-1691