### PR TITLE
LIBFCREPO-1697. Restore Archival Collection to details page.

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -44,7 +44,7 @@ class SolrDocument # rubocop:disable Metrics/ClassLength
   end
 
   def archival_collection_links
-    return unless has? 'object__archival_collection'
+    return unless has? 'object__archival_collection__uri'
 
     handle_link = vocab_term_with_same_as(
       :object__archival_collection,


### PR DESCRIPTION
Correct the field check by the guard clause of the `archival_collection_links` accessor.

https://umd-dit.atlassian.net/browse/LIBFCREPO-1697