### PR TITLE
LIBFCREPO-1695: Add Subject Facet and hyperlink it in item details page

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -136,6 +136,7 @@ class CatalogController < ApplicationController # rubocop:disable Metrics/ClassL
     config.add_facet_field 'admin_set__facet', label: 'Administrative Set', limit: 10, sort: 'index'
     config.add_facet_field 'archival_collection__facet', label: 'Archival Collection', limit: 10
     config.add_facet_field 'creator__facet', label: 'Creator', limit: 10
+    config.add_facet_field 'subject__facet', label: 'Subject', limit: 10
     config.add_facet_field 'resource_type__facet', label: 'Resource Type', limit: 10
     config.add_facet_field 'rdf_type__facet', label: 'RDF Type', limit: 10
     config.add_facet_field 'visibility__facet', label: 'Visibility'
@@ -223,7 +224,7 @@ class CatalogController < ApplicationController # rubocop:disable Metrics/ClassL
     config.add_show_field 'publisher__facet', label: 'Publisher', component: ListMetadataComponent
     config.add_show_field 'location__facet', label: 'Location', component: ListMetadataComponent
     # not sure what to do for extent
-    config.add_show_field 'subject__facet', label: 'Subject', component: ListMetadataComponent
+    config.add_show_field 'subject__facet', label: 'Subject', accessor: :subject_facet_links, component: ListMetadataComponent
     config.add_show_field 'language__facet', label: 'Language', component: ListMetadataComponent
     config.add_show_field 'object__terms_of_use__value__txt', label: 'Terms of Use', accessor: :terms_of_use
     # not sure what to do for collection information

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -56,6 +56,17 @@ class SolrDocument # rubocop:disable Metrics/ClassLength
     [handle_link, archelon_search_link]
   end
 
+  def subject_facet_links
+    return unless has? 'subject__facet'
+
+    subjects = fetch('subject__facet')
+
+    subjects.map do |subject|
+      path = search_catalog_path('f[subject__facet][]' => subject)
+      ActionController::Base.helpers.link_to(subject, path)
+    end
+  end
+
   def format_anchor
     vocab_term_with_same_as :object__format
   end


### PR DESCRIPTION
Adding a facet for subjects, and adding an accessor to hyperlink the subject in the item details page.

https://umd-dit.atlassian.net/browse/LIBFCREPO-1695