### PR TITLE
LIBFCREPO-1803. Switch description to use the `object__description__display` field.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -236,17 +236,17 @@ class CatalogController < ApplicationController # rubocop:disable Metrics/ClassL
     # UMD Customization
 
     # Item Level Fields
-    config.add_show_field 'object__title__display', label: 'Title', accessor: :title, component: ListMetadataComponent
-    config.add_show_field 'object__alternate_title__display', label: 'Alternate Title', accessor: :alternate_title, component: ListMetadataComponent
+    config.add_show_field 'object__title__display', label: 'Title', accessor: :language_tagged_values, component: ListMetadataComponent
+    config.add_show_field 'object__alternate_title__display', label: 'Alternate Title', accessor: :language_tagged_values, component: ListMetadataComponent
     config.add_show_field 'object__volume__txt', label: 'Volume'
     config.add_show_field 'object__issue__txt', label: 'Issue'
     config.add_show_field 'object__edition__txt', label: 'Edition'
     config.add_show_field 'object__identifier__ids', label: 'Identifier', component: ListMetadataComponent
     config.add_show_field 'object__accession_number__id', label: 'Accession Number'
     config.add_show_field 'handle__id', label: 'Handle', accessor: :handle_anchor
-    config.add_show_field 'object__creator', label: 'Creator', accessor: :creator, component: ListMetadataComponent
-    config.add_show_field 'object__contributor', label: 'Contributor', accessor: :contributor, component: ListMetadataComponent
-    config.add_show_field 'object__audience', label: 'Audience', accessor: :audience, component: ListMetadataComponent
+    config.add_show_field 'object__creator', label: 'Creator', accessor: :agent_names, component: ListMetadataComponent
+    config.add_show_field 'object__contributor', label: 'Contributor', accessor: :agent_names, component: ListMetadataComponent
+    config.add_show_field 'object__audience', label: 'Audience', accessor: :agent_names, component: ListMetadataComponent
     config.add_show_field 'publisher__facet', label: 'Publisher', component: ListMetadataComponent
     config.add_show_field 'object__date__edtf', label: 'Date'
     config.add_show_field 'object__description__txt', label: 'Description'
@@ -261,8 +261,8 @@ class CatalogController < ApplicationController # rubocop:disable Metrics/ClassL
 
     # pair with object__rights__label__txt
     config.add_show_field 'object__rights__uri', label: 'Rights Statement', accessor: :rights_anchor
-    config.add_show_field 'object__rights_holder', label: 'Rights Holder', accessor: :rights_holder, component: ListMetadataComponent
-    config.add_show_field 'object__copyright_notice__display', label: 'Copyright Notice', accessor: :copyright_notice, component: ListMetadataComponent
+    config.add_show_field 'object__rights_holder', label: 'Rights Holder', accessor: :agent_names, component: ListMetadataComponent
+    config.add_show_field 'object__copyright_notice__display', label: 'Copyright Notice', accessor: :language_tagged_values, component: ListMetadataComponent
 
     config.add_show_field 'object__terms_of_use__value__txt', label: 'Terms of Use', accessor: :terms_of_use
     config.add_show_field 'location__facet', label: 'Location', component: ListMetadataComponent

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -249,7 +249,7 @@ class CatalogController < ApplicationController # rubocop:disable Metrics/ClassL
     config.add_show_field 'object__audience', label: 'Audience', accessor: :agent_names, component: ListMetadataComponent
     config.add_show_field 'publisher__facet', label: 'Publisher', component: ListMetadataComponent
     config.add_show_field 'object__date__edtf', label: 'Date'
-    config.add_show_field 'object__description__txt', label: 'Description'
+    config.add_show_field 'object__description__display', label: 'Description', accessor: :language_tagged_values, component: ListMetadataComponent
 
     # pair with object__archival_collection__label__txt
     # pair with object__archival_collection__same_as__uris

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -31,34 +31,6 @@ class SolrDocument # rubocop:disable Metrics/ClassLength
     fetch('iiif_manifest__uri')
   end
 
-  def creator
-    agent_names :object__creator
-  end
-
-  def audience
-    agent_names :object__audience
-  end
-
-  def title
-    language_tagged_values :object__title__display
-  end
-
-  def alternate_title
-    language_tagged_values :object__alternate_title__display
-  end
-
-  def contributor
-    agent_names :object__contributor
-  end
-
-  def rights_holder
-    agent_names :object__rights_holder
-  end
-
-  def copyright_notice
-    language_tagged_values :object__copyright_notice__display
-  end
-
   def archival_collection_links
     return unless has? 'object__archival_collection__uri'
 
@@ -156,13 +128,24 @@ class SolrDocument # rubocop:disable Metrics/ClassLength
     fetch('is_published')
   end
 
-  private
+  # Can be used as an accessor in the Catalog Controller
+  def language_tagged_values(field_name)
+    return unless has? field_name
 
-    def language_tagged_values(field_name)
-      return unless has? field_name
+    Array(fetch(field_name)).map { |v| format_with_language_tag(v) }
+  end
 
-      Array(fetch(field_name)).map { |v| format_with_language_tag(v) }
+  # Can be used as an accessor in the Catalog Controller
+  def agent_names(field_name)
+    return unless has? field_name
+
+    Array(fetch(field_name)).map do |agent|
+      tagged_names = agent[:agent__label__display].map { |name| format_with_language_tag(name) }
+      safe_join(tagged_names, ' | ')
     end
+  end
+
+  private
 
     def extract_language_tags(field_name)
       return [] unless has? field_name
@@ -187,15 +170,6 @@ class SolrDocument # rubocop:disable Metrics/ClassLength
       return parsed_value[:value] if parsed_value[:lang].nil?
 
       safe_join([parsed_value[:value], tag.span(parsed_value[:lang], class: %w[badge text-bg-secondary])], "\xa0")
-    end
-
-    def agent_names(field_name)
-      return unless has? field_name
-
-      Array(fetch(field_name)).map do |agent|
-        tagged_names = agent[:agent__label__display].map { |name| format_with_language_tag(name) }
-        safe_join(tagged_names, ' | ')
-      end
     end
 
     def add_anchor_tag(uri, label)


### PR DESCRIPTION
- use the `language_tagged_values` accessor and ListMetadataComponent to display all values with their (optional) language tag
- removed some custom accessors from the SolrDocument class, since the accessor method gets passed the field name, we can directly call the `language_tagged_values` and `agent_names` methods of the SolrDocument from the CatalogController
- made `language_tagged_values` and `agent_names` public methods

https://umd-dit.atlassian.net/browse/LIBFCREPO-1803