### PR TITLE
LIBFCREPO-1808. Enabled relevancy sorting.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -393,7 +393,7 @@ class CatalogController < ApplicationController # rubocop:disable Metrics/ClassL
     # except in the relevancy case). Add the sort: option to configure a
     # custom Blacklight url parameter value separate from the Solr sort fields.
     # UMD Customization
-    # config.add_sort_field 'relevance', sort: 'score desc, pub_date_si desc, title_si asc', label: 'relevance'
+    config.add_sort_field 'relevance', sort: 'score desc', label: 'Relevance'
     # config.add_sort_field 'year-desc', sort: 'pub_date_si desc, title_si asc', label: 'year'
     # config.add_sort_field 'author', sort: 'author_si asc, title_si asc', label: 'author'
     # config.add_sort_field 'title_si asc, pub_date_si desc', label: 'title'


### PR DESCRIPTION
Uses the Solr defaults with no explicit tuning.

https://umd-dit.atlassian.net/browse/LIBFCREPO-1808