### PR TITLE
LIBFCREPO-1805. Date range search.

### DIFF
--- a/app/components/blacklight/search_bar_component.html.erb
+++ b/app/components/blacklight/search_bar_component.html.erb
@@ -1,0 +1,54 @@
+<search>
+  <%= form_with url: @url, local: true, method: @method, class: @classes.join(' '), scope: @prefix, role: 'search', **@form_options do |f| %>
+    <%= render Blacklight::HiddenSearchStateComponent.new(params: @params.reject{ |param| param =~ /(begin|end)_date/ }) %>
+    <% if search_fields.length > 1 %>
+      <%= f.label :search_field, scoped_t('search_field.label'), class: 'sr-only visually-hidden' %>
+    <% end %>
+    <% before_input_groups.each do |input_group| %>
+      <%= input_group %>
+    <% end %>
+    <div class="input-group">
+      <%= prepend %>
+
+      <% if search_fields.length > 1 %>
+        <%= f.select(:search_field,
+                    options_for_select(search_fields, h(@search_field)),
+                    {},
+                    title: scoped_t('search_field.title'),
+                    class: "custom-select form-select search-field") %>
+      <% elsif search_fields.length == 1 %>
+        <%= f.hidden_field :search_field, value: search_fields.first.last %>
+      <% end %>
+
+      <%= f.label @query_param, scoped_t('search.label'), class: 'sr-only visually-hidden' %>
+      <% if autocomplete_path.present? %>
+        <auto-complete src="<%= autocomplete_path %>" for="autocomplete-popup" class="search-autocomplete-wrapper">
+          <%= f.search_field @query_param, value: @q, placeholder: scoped_t('search.placeholder'), class: "search-q q form-control rounded-#{search_fields.length > 1 ? '0' : 'left'}", autofocus: @autofocus, aria: { label: scoped_t('search.label'), autocomplete: 'list', controls: 'autocomplete-popup' }  %>
+          <ul id="autocomplete-popup" role="listbox" aria-label="<%= scoped_t('search.label') %>" hidden></ul>
+        </auto-complete>
+      <% else %>
+        <%= f.search_field @query_param, value: @q, placeholder: scoped_t('search.placeholder'), class: "search-q q form-control rounded-#{search_fields.length > 1 ? '0' : 'left'}", autofocus: @autofocus, aria: { label: scoped_t('search.label') }  %>
+      <% end %>
+
+      <%= append %>
+      <%= search_button || render(Blacklight::SearchButtonComponent.new(id: "#{@prefix}search", text: scoped_t('submit'))) %>
+    </div>
+    <div style="margin: .5em;">
+      <label>
+        From date:
+        <%= f.search_field 'begin_date',
+          class: "search-field", size: "12", placeholder: "YYYY[-MM[-DD]]",
+          pattern: '\d\d\d\d(-\d\d(-\d\d)?)?|\*', value: @params[:begin_date] %>
+      </label>
+      <label>
+        until: <%= f.search_field 'end_date',
+          class: "search-field", size: "12", placeholder: "YYYY[-MM[-DD]]",
+          pattern: '\d\d\d\d(-\d\d(-\d\d)?)?|\*', value: @params[:end_date] %>
+      </label>
+    </div>
+  <% end %>
+
+  <% if advanced_search_enabled? %>
+    <%= link_to t('blacklight.advanced_search.more_options'), @advanced_search_url, class: 'advanced_search btn btn-secondary'%>
+  <% end %>
+</search>

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -123,6 +123,7 @@ class CatalogController < ApplicationController # rubocop:disable Metrics/ClassL
     # config.show.document_component = MyApp::DocumentComponent
     # config.show.sidebar_component = MyApp::SidebarComponent
 
+    config.search_state_fields += %i[begin_date end_date]
     # solr fields that will be treated as facets by the blacklight application
     #   The ordering of the field names is the order of the display
     #

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -235,6 +235,12 @@ class CatalogController < ApplicationController # rubocop:disable Metrics/ClassL
     # config.add_show_field 'isbn_ssim', label: 'ISBN'
 
     # UMD Customization
+    config.date_fields = {
+      range: :object__date__dt,
+      precision: :object__date__dt_precision__int,
+      range_size: :object__date__dt_range_size__int
+    }
+    config.date_qualifier_fields = %i[object__dt_is_approximate object__dt_is_uncertain object__dt_is_uncertain_and_approximate]
 
     # Item Level Fields
     config.add_show_field 'object__title__display', label: 'Title', accessor: :language_tagged_values, component: ListMetadataComponent

--- a/app/models/date_range_query.rb
+++ b/app/models/date_range_query.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# date range query
+class DateRangeQuery
+  def initialize(begin_date, end_date)
+    @begin_date = begin_date
+    @end_date = end_date
+  end
+
+  def query
+    @query ||=
+      if @begin_date.present? && @end_date.present?
+        "[#{@begin_date} TO #{@end_date}]"
+      elsif @begin_date.present?
+        @begin_date
+      elsif @end_date.present?
+        "[* TO #{@end_date}]"
+      end
+  end
+
+  def fq(field_name, operation = 'Intersects')
+    "{!field f=#{field_name} op=#{operation}}#{query}"
+  end
+end

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -9,19 +9,18 @@ class SearchBuilder < Blacklight::SearchBuilder
   def build_date_range_query(solr_parameters)
     return unless blacklight_params[:begin_date].present? || blacklight_params[:end_date].present?
 
-    query = build_date_query(*blacklight_params.slice(:begin_date, :end_date).values)
-    solr_parameters[:fq] += ["object__date__dt:#{query}"]
+    %i[fq bq bf].each { |key| solr_parameters[key] ||= [] }
+    field = blacklight_config.date_fields[:range].to_s
+    date_range_query = DateRangeQuery.new(*blacklight_params.slice(:begin_date, :end_date).values)
+    solr_parameters[:fq] << date_range_query.fq(field)
+    # boost dates/date ranges that fall completely within the queried range
+    solr_parameters[:bq] << date_range_query.fq(field, :Within)
+    # also boost dates/date ranges...
+    # ...with higher precision
+    solr_parameters[:bf] << blacklight_config.date_fields[:precision].to_s
+    # ...with a smaller range
+    solr_parameters[:bf] << "div(1,#{blacklight_config.date_fields[:range_size]})"
+    # ...without qualifiers
+    blacklight_config.date_qualifier_fields.each { |f| solr_parameters[:bf] << "not(#{f})" }
   end
-
-  private
-
-    def build_date_query(begin_date, end_date)
-      if begin_date.present? && end_date.present?
-        "[#{begin_date} TO #{end_date}]"
-      elsif begin_date.present?
-        begin_date
-      elsif end_date.present?
-        "[* TO #{end_date}]"
-      end
-    end
 end

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -6,7 +6,7 @@ class SearchBuilder < Blacklight::SearchBuilder
 
   self.default_processor_chain += %i[build_date_range_query]
 
-  def build_date_range_query(solr_parameters)
+  def build_date_range_query(solr_parameters) # rubocop:disable Metrics/AbcSize
     return unless blacklight_params[:begin_date].present? || blacklight_params[:end_date].present?
 
     %i[fq bq bf].each { |key| solr_parameters[key] ||= [] }

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -4,11 +4,24 @@
 class SearchBuilder < Blacklight::SearchBuilder
   include Blacklight::Solr::SearchBuilderBehavior
 
-  ##
-  # @example Adding a new step to the processor chain
-  #   self.default_processor_chain += [:add_custom_data_to_query]
-  #
-  #   def add_custom_data_to_query(solr_parameters)
-  #     solr_parameters[:custom] = blacklight_params[:user_value]
-  #   end
+  self.default_processor_chain += %i[build_date_range_query]
+
+  def build_date_range_query(solr_parameters)
+    return unless blacklight_params[:begin_date].present? || blacklight_params[:end_date].present?
+
+    query = build_date_query(*blacklight_params.slice(:begin_date, :end_date).values)
+    solr_parameters[:fq] += ["object__date__dt:#{query}"]
+  end
+
+  private
+
+    def build_date_query(begin_date, end_date)
+      if begin_date.present? && end_date.present?
+        "[#{begin_date} TO #{end_date}]"
+      elsif begin_date.present?
+        begin_date
+      elsif end_date.present?
+        "[* TO #{end_date}]"
+      end
+    end
 end


### PR DESCRIPTION
- Added a date range filter section to the main search form.
  - controller accepts `begin_date` and `end_date` query parameters
  - based on the request parameters, generate a filter query for a date or date range
- Boost an object in the results ordering if any of the following apply:
  - object's date/date range is wholly contained by the search range
  - object has a higher date precision
  - object's date range is smaller
  - object's date is not qualified (approximate, uncertain, or uncertain and approximate)

https://umd-dit.atlassian.net/browse/LIBFCREPO-1805