### PR TITLE
LIBFCREPO-1825: Set limit for facets arbitrarily large

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -138,8 +138,8 @@ class CatalogController < ApplicationController # rubocop:disable Metrics/ClassL
     # UMD Customization
     config.add_facet_field 'presentation_set__facet', label: 'Presentation Set', limit: 10, sort: 'index'
     config.add_facet_field 'publication_title__facet', label: 'Publication Title', if: :show_dependent_facet?
-    config.add_facet_field 'archival_collection__facet', label: 'Archival Collection', component: FilterFacetComponent
-    config.add_facet_field 'creator__facet', label: 'Creator', component: FilterFacetComponent
+    config.add_facet_field 'archival_collection__facet', label: 'Archival Collection', component: FilterFacetComponent, limit: 10_000
+    config.add_facet_field 'creator__facet', label: 'Creator', component: FilterFacetComponent, limit: 10_000
     config.add_facet_field 'resource_type__facet', label: 'Resource Type', limit: 10
     config.add_facet_field 'subject__facet', label: 'Subject', limit: 10
     config.add_facet_field 'rights__facet', label: 'Rights Statement', limit: 10


### PR DESCRIPTION
To include all of the facets for the archival collections and creators Setting it to -1 uses Solr's defalut of 100, which isn't sufficient

https://umd-dit.atlassian.net/browse/LIBFCREPO-1825