### PR TITLE
LIBFCREPO-1834. Enforce exact matching in the EDTF date search.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -355,7 +355,7 @@ class CatalogController < ApplicationController # rubocop:disable Metrics/ClassL
 
     config.add_search_field('edtf_date') do |field|
       field.label = 'EDTF Date'
-      field.solr_parameters = { df: 'object__date__edtf' }
+      field.solr_local_parameters = { type: 'term', f: 'object__date__edtf' }
     end
 
     # Now we see how to over-ride Solr request handler defaults, in this


### PR DESCRIPTION
- use a the term query parser to enforce exact matching when searching the EDTF date field

https://umd-dit.atlassian.net/browse/LIBFCREPO-1834