### PR TITLE
LIBFCREPO-1838. Fix Import Jobs "Adminstrative Set" dropdown

### DIFF
--- a/app/services/admin_sets_service.rb
+++ b/app/services/admin_sets_service.rb
@@ -24,7 +24,7 @@ class AdminSetsService
       solr_doc = SolrDocument.new(doc)
       {
         uri: solr_doc['id'],
-        display_title: solr_doc.display_titles
+        display_title: solr_doc['adminset__title__txt']
       }
     end
     admin_sets.sort_by { |c| c[:display_title] }

--- a/test/fixtures/files/services/admin_sets_service/solr_response_multiple_collections.json
+++ b/test/fixtures/files/services/admin_sets_service/solr_response_multiple_collections.json
@@ -15,7 +15,7 @@
       {
         "id": "https://fcrepo-test.lib.umd.edu/fcrepo/rest/pcdm/9d/05/57/c2/9d0557c2-825f-4e33-8a52-a6d70145878e",
         "content_model_name__str": "AdminSet",
-        "object__rdf_type__curies": [
+        "adminset__rdf_type__curies": [
           "pcdm:Collection",
           "fedora:Container",
           "fedora:Resource",
@@ -23,7 +23,7 @@
           "ldp:RDFSource",
           "ldp:Container"
         ],
-        "object__rdf_type__uris": [
+        "adminset__rdf_type__uris": [
           "http://pcdm.org/models#Collection",
           "http://fedora.info/definitions/v4/repository#Container",
           "http://fedora.info/definitions/v4/repository#Resource",
@@ -31,16 +31,16 @@
           "http://www.w3.org/ns/ldp#RDFSource",
           "http://www.w3.org/ns/ldp#Container"
         ],
-        "object__title__display": [
+        "adminset__title__display": [
           "UMD Student Newspapers"
         ],
-        "object__title__txt": "UMD Student Newspapers",
+        "adminset__title__txt": "UMD Student Newspapers",
         "_version_": 1839812340769357800
       },
       {
         "id": "https://fcrepo-test.lib.umd.edu/fcrepo/rest/pcdm/9c/33/f7/f3/9c33f7f3-e275-4248-9c46-36666b28d704",
         "content_model_name__str": "AdminSet",
-        "object__rdf_type__curies": [
+        "adminset__rdf_type__curies": [
           "pcdm:Collection",
           "fedora:Container",
           "umdaccess:Public",
@@ -49,7 +49,7 @@
           "ldp:RDFSource",
           "ldp:Container"
         ],
-        "object__rdf_type__uris": [
+        "adminset__rdf_type__uris": [
           "http://pcdm.org/models#Collection",
           "http://fedora.info/definitions/v4/repository#Container",
           "http://vocab.lib.umd.edu/access#Public",
@@ -58,56 +58,56 @@
           "http://www.w3.org/ns/ldp#RDFSource",
           "http://www.w3.org/ns/ldp#Container"
         ],
-        "object__title__display": [
+        "adminset__title__display": [
           "Prange Posters and Wall Newspapers Collection"
         ],
-        "object__title__txt": "Prange Posters and Wall Newspapers Collection",
+        "adminset__title__txt": "Prange Posters and Wall Newspapers Collection",
         "_version_": 1839812413799530500
       },
       {
         "id": "https://fcrepo-test.lib.umd.edu/fcrepo/rest/pcdm/7b/ee/90/4f/7bee904f-ce36-4e16-8ece-a7cae1ab5be9",
         "content_model_name__str": "AdminSet",
-        "object__rdf_type__curies": [
+        "adminset__rdf_type__curies": [
           "pcdm:Collection",
           "fedora:Container",
           "fedora:Resource",
           "ldp:RDFSource",
           "ldp:Container"
         ],
-        "object__rdf_type__uris": [
+        "adminset__rdf_type__uris": [
           "http://pcdm.org/models#Collection",
           "http://fedora.info/definitions/v4/repository#Container",
           "http://fedora.info/definitions/v4/repository#Resource",
           "http://www.w3.org/ns/ldp#RDFSource",
           "http://www.w3.org/ns/ldp#Container"
         ],
-        "object__title__display": [
+        "adminset__title__display": [
           "The Katherine Anne Porter Correspondence Collection"
         ],
-        "object__title__txt": "The Katherine Anne Porter Correspondence Collection",
+        "adminset__title__txt": "The Katherine Anne Porter Correspondence Collection",
         "_version_": 1839812376161943600
       },
       {
         "id": "https://fcrepo-test.lib.umd.edu/fcrepo/rest/pcdm/4a/21/d7/58/4a21d758-7ec2-42ee-9444-8e36c09cb5c4",
         "content_model_name__str": "AdminSet",
-        "object__rdf_type__curies": [
+        "adminset__rdf_type__curies": [
           "pcdm:Collection",
           "fedora:Container",
           "fedora:Resource",
           "ldp:RDFSource",
           "ldp:Container"
         ],
-        "object__rdf_type__uris": [
+        "adminset__rdf_type__uris": [
           "http://pcdm.org/models#Collection",
           "http://fedora.info/definitions/v4/repository#Container",
           "http://fedora.info/definitions/v4/repository#Resource",
           "http://www.w3.org/ns/ldp#RDFSource",
           "http://www.w3.org/ns/ldp#Container"
         ],
-        "object__title__display": [
+        "adminset__title__display": [
           "Plant Patents Image Database"
         ],
-        "object__title__txt": "Plant Patents Image Database",
+        "adminset__title__txt": "Plant Patents Image Database",
         "_version_": 1839812389368758300
       }
     ]

--- a/test/fixtures/files/services/admin_sets_service/solr_response_one_collection.json
+++ b/test/fixtures/files/services/admin_sets_service/solr_response_one_collection.json
@@ -15,7 +15,7 @@
       {
         "id": "https://fcrepo-test.lib.umd.edu/fcrepo/rest/pcdm/9d/05/57/c2/9d0557c2-825f-4e33-8a52-a6d70145878e",
         "content_model_name__str": "AdminSet",
-        "object__rdf_type__curies": [
+        "adminset__rdf_type__curies": [
           "pcdm:Collection",
           "fedora:Container",
           "fedora:Resource",
@@ -23,7 +23,7 @@
           "ldp:RDFSource",
           "ldp:Container"
         ],
-        "object__rdf_type__uris": [
+        "adminset__rdf_type__uris": [
           "http://pcdm.org/models#Collection",
           "http://fedora.info/definitions/v4/repository#Container",
           "http://fedora.info/definitions/v4/repository#Resource",
@@ -31,10 +31,10 @@
           "http://www.w3.org/ns/ldp#RDFSource",
           "http://www.w3.org/ns/ldp#Container"
         ],
-        "object__title__display": [
+        "adminset__title__display": [
           "UMD Student Newspapers"
         ],
-        "object__title__txt": "UMD Student Newspapers",
+        "adminset__title__txt": "UMD Student Newspapers",
         "_version_": 1839812340769357800
       }
     ]


### PR DESCRIPTION
Fixed an issue with creating a new import job, where the "Administrative Set" would not be populated with any entries.

This issue is caused by the change made in LIBFCREPO-1881 (specifically the change in https://github.com/umd-lib/solrizer/blob/4ee738baaaa96a12894487909ecea07ecd307824/src/solrizer/indexers/content_model.py#L129), where the display title for Admin Sets in Solr was changed from "object__title__txt" to  "adminset__title_txt".

After discussions with Peter Eichman, it was decided to keep the Solrizer change so as to:

> avoid confusion in the future, as only so-called "top-level objects"
> (Item, Issue, and the legacy Poster and Letter content models)
> will be referred to as "object__" in the Solr index

The following changes were made to Archelon:

* Updated the “self.process_solr_response” method in “app/services/admin_sets_service.rb” to use the Solr `adminset__title__txt` attribute as the display title for the admin sets.

* Renamed the following attributes:
   * object__rdf_type__curies → adminset__rdf_type__curies
   * object__rdf_type__uris → adminset__rdf_type__uris
   * object__title__display → adminset__title__display
   * object__title__txt → adminset__title__txt

in the following test fixture files:

* test/fixtures/files/services/admin_sets_service/solr_response_one_collection.json
* test/fixtures/files/services/admin_sets_service/solr_response_multiple_collections.json

https://umd-dit.atlassian.net/browse/LIBFCREPO-1838