### PR TITLE
LIBFCREPO-1844. Convert DateRangeQuery to use keyword arguments.

### DIFF
--- a/app/models/date_range_query.rb
+++ b/app/models/date_range_query.rb
@@ -2,7 +2,7 @@
 
 # date range query
 class DateRangeQuery
-  def initialize(begin_date, end_date)
+  def initialize(begin_date: nil, end_date: nil)
     @begin_date = begin_date
     @end_date = end_date
   end

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -11,7 +11,7 @@ class SearchBuilder < Blacklight::SearchBuilder
 
     %i[fq bq bf].each { |key| solr_parameters[key] ||= [] }
     field = blacklight_config.date_fields[:range].to_s
-    date_range_query = DateRangeQuery.new(*blacklight_params.slice(:begin_date, :end_date).values)
+    date_range_query = DateRangeQuery.new(**blacklight_params.symbolize_keys.slice(:begin_date, :end_date))
     solr_parameters[:fq] << date_range_query.fq(field)
     # boost dates/date ranges that fall completely within the queried range
     solr_parameters[:bq] << date_range_query.fq(field, :Within)


### PR DESCRIPTION
- ensures that the values for begin_date and end_date get passed in the proper order

https://umd-dit.atlassian.net/browse/LIBFCREPO-1844